### PR TITLE
Add cancel-on-disconnect across H1/H2/H3

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,7 @@ solution.
 - [Log every request](guides/log-requests.md)
 - [Propagate request IDs](guides/propagate-request-ids.md)
 - [Catch handler errors](guides/handler-errors.md)
+- [Cancel work when the client disconnects](guides/cancel-on-disconnect.md)
 - [Generate OpenAPI docs and validate requests](guides/openapi-and-validation.md)
 - [Serve MCP tools](guides/serve-mcp-tools.md)
 - [Serve WebTransport](guides/serve-webtransport.md)

--- a/docs/features.md
+++ b/docs/features.md
@@ -3,6 +3,24 @@
 Tracked work that is not yet scheduled. Upstream items link to the
 sibling library that owns the change.
 
+## Framework-gap backlog (from the audit)
+
+Modern web/AI framework gaps, in priority order. Step 1 is done.
+
+1. Cancel on client disconnect. DONE: `livery_req:on_disconnect/2`
+   plus the `{livery_disconnect, _, _}` message, delivered across
+   H1/H2/H3 by the per-stream translator (which monitors the
+   connection). See `docs/guides/cancel-on-disconnect.md`.
+2. CORS middleware.
+3. Response compression (gzip/br/zstd) with Accept-Encoding.
+4. Multipart / form-data body parsing (uploads, multimodal).
+5. Concurrency limit / load-shedding middleware (admission control).
+6. Security-headers middleware (HSTS/CSP/etc).
+7. Rate limiting / throttling.
+8. HTTP caching primitives (ETag, conditional GET, Cache-Control).
+9. Static-directory serving with ETag/MIME.
+10. Health/readiness endpoints + Prometheus `/metrics`.
+
 ## Benchmarking: H3 needs an external client
 
 The in-VM bench harness understates H3. Findings (loopback, 14

--- a/docs/guides/cancel-on-disconnect.md
+++ b/docs/guides/cancel-on-disconnect.md
@@ -1,0 +1,80 @@
+# How to cancel work when the client disconnects
+
+## Problem
+
+A request triggers expensive work (an LLM inference, a long query).
+If the client disconnects mid-request, you want to stop that work
+instead of finishing it for nobody.
+
+## Solution
+
+Livery signals the request handler when the client resets the stream
+or closes the connection, across HTTP/1.1, HTTP/2, and HTTP/3. There
+are two ways to react, depending on how your handler is shaped.
+
+### Streaming handler in a receive loop
+
+A producer that streams tokens already loops on its data source. It
+also matches the disconnect message, and stops when `Emit` reports a
+failed send:
+
+```erlang
+chat(Req) ->
+    {ok, InferRef} = my_llm:start(prompt(Req)),   %% streams {token, InferRef, T}
+    livery_resp:sse(200, fun(Emit) -> stream(Emit, InferRef) end).
+
+stream(Emit, InferRef) ->
+    receive
+        {token, InferRef, T} ->
+            case Emit(#{data => T}) of
+                ok         -> stream(Emit, InferRef);
+                {error, _} -> my_llm:cancel(InferRef)   %% send failed: client gone
+            end;
+        {done, InferRef} ->
+            ok;
+        {livery_disconnect, _Ref, _Reason} ->            %% explicit disconnect
+            my_llm:cancel(InferRef)
+    end.
+```
+
+`{livery_disconnect, _, _}` is delivered to the handler's process; the
+`Emit` error return is a second backstop. Chunked, SSE, and NDJSON
+producers all propagate the send error now, so returning `{error, _}`
+from the producer also stops the terminal write.
+
+### Blocking handler
+
+A handler that blocks in a NIF cannot loop. Register a cancel
+callback; Livery runs it in a separate process the moment the client
+disconnects, so the NIF is signalled even though the handler is busy:
+
+```erlang
+complete(Req) ->
+    {ok, InferRef} = my_llm:new(),
+    ok = livery_req:on_disconnect(Req, fun() -> my_llm:cancel(InferRef) end),
+    livery_resp:json(200, my_llm:infer_blocking(InferRef, prompt(Req))).
+```
+
+`on_disconnect/2` returns immediately. The callback runs **at most
+once**, **only on a real disconnect** (never on normal completion),
+and on the test adapter it is a no-op (handler unit tests are
+unaffected).
+
+## Notes
+
+- Default is signal-only: Livery does not kill your handler. It runs
+  any cleanup it likes, then returns. A handler that ignores the
+  signal simply keeps running.
+- HTTP/1.1 is half-duplex. A disconnect is detected when the
+  connection closes (via the connection monitor) or when a send
+  fails; a paused streaming response that never sends again may not
+  notice until the connection drops. H2 and H3 multiplex, so a
+  reset/close is detected promptly.
+- `livery_req:disconnect_tag/0` returns the message tag
+  (`livery_disconnect`) for guard-style matching.
+
+## See also
+
+- Reference: `livery_req` (`on_disconnect/2`), `livery_resp`
+- Guide: [Return a streaming response](stream-chunked.md),
+  [Serve MCP tools](serve-mcp-tools.md)

--- a/include/livery.hrl
+++ b/include/livery.hrl
@@ -19,6 +19,8 @@
     adapter = undefined :: module() | undefined,
     stream = undefined :: term(),
     engine_pid = undefined :: pid() | undefined,
+    notifier_pid = undefined :: pid() | undefined,
+    disc_ref = undefined :: reference() | undefined,
     req_id = <<>> :: binary(),
     started_at = undefined :: integer() | undefined,
     meta = #{} :: map()
@@ -29,8 +31,8 @@
     headers = [] :: [{binary(), binary()}],
     body = {full, <<>>} ::
         {full, iodata()}
-        | {chunked, fun((term()) -> ok)}
-        | {sse, fun((term()) -> ok)}
+        | {chunked, fun((term()) -> ok | {error, term()})}
+        | {sse, fun((term()) -> ok | {error, term()})}
         | {file, file:name_all(), undefined | {non_neg_integer(), non_neg_integer() | eof}}
         | {upgrade, ws | wt, term()}
         | empty

--- a/rebar.config
+++ b/rebar.config
@@ -94,6 +94,9 @@
         {"docs/guides/log-requests.md", #{title => <<"Log every request">>}},
         {"docs/guides/propagate-request-ids.md", #{title => <<"Propagate request IDs">>}},
         {"docs/guides/handler-errors.md", #{title => <<"Catch handler errors">>}},
+        {"docs/guides/cancel-on-disconnect.md", #{
+            title => <<"Cancel on client disconnect">>
+        }},
         {"docs/guides/openapi-and-validation.md", #{title => <<"OpenAPI docs and validation">>}},
         {"docs/guides/serve-mcp-tools.md", #{title => <<"Serve MCP tools">>}},
         {"docs/guides/serve-webtransport.md", #{title => <<"Serve WebTransport">>}},
@@ -147,6 +150,7 @@
             <<"docs/guides/log-requests.md">>,
             <<"docs/guides/propagate-request-ids.md">>,
             <<"docs/guides/handler-errors.md">>,
+            <<"docs/guides/cancel-on-disconnect.md">>,
             <<"docs/guides/openapi-and-validation.md">>,
             <<"docs/guides/serve-mcp-tools.md">>,
             <<"docs/guides/serve-webtransport.md">>,
@@ -265,7 +269,9 @@
             {elvis_style, max_function_length, #{
                 ignore => [
                     livery,
+                    livery_h1,
                     livery_h2,
+                    livery_h3,
                     livery_mcp,
                     livery_openapi_validate,
                     livery_router
@@ -274,7 +280,9 @@
             {elvis_style, max_function_clause_length, #{
                 ignore => [
                     livery,
+                    livery_h1,
                     livery_h2,
+                    livery_h3,
                     livery_mcp,
                     livery_openapi_validate,
                     livery_router

--- a/src/livery.erl
+++ b/src/livery.erl
@@ -247,8 +247,7 @@ emit_body(Adapter, Stream, Status, Hs, {chunked, Producer}, Trailers) ->
             Emit = fun(Chunk) ->
                 Adapter:send_data(Stream, Chunk, #{end_stream => false})
             end,
-            _ = Producer(Emit),
-            close_stream(Adapter, Stream, Trailers);
+            finish_stream(Adapter, Stream, Producer(Emit), Trailers);
         Other ->
             Other
     end;
@@ -262,8 +261,7 @@ emit_body(Adapter, Stream, Status, Hs, {sse, Producer}, Trailers) ->
                     #{end_stream => false}
                 )
             end,
-            _ = Producer(Emit),
-            close_stream(Adapter, Stream, Trailers);
+            finish_stream(Adapter, Stream, Producer(Emit), Trailers);
         Other ->
             Other
     end;
@@ -340,6 +338,14 @@ emit_trailers(Adapter, Stream, Trailers) when is_list(Trailers) ->
     Adapter:send_trailers(Stream, Trailers);
 emit_trailers(Adapter, Stream, Fun) when is_function(Fun, 0) ->
     Adapter:send_trailers(Stream, Fun()).
+
+%% Close a chunked/SSE stream once its producer returns. A producer
+%% that reports a failed send (the client is gone) short-circuits the
+%% terminal write and surfaces the error.
+finish_stream(_Adapter, _Stream, {error, _} = Err, _Trailers) ->
+    Err;
+finish_stream(Adapter, Stream, _ProducerResult, Trailers) ->
+    close_stream(Adapter, Stream, Trailers).
 
 close_stream(Adapter, Stream, undefined) ->
     Adapter:send_data(Stream, <<>>, #{end_stream => true});

--- a/src/livery_disconnect.erl
+++ b/src/livery_disconnect.erl
@@ -1,0 +1,57 @@
+-module(livery_disconnect).
+-moduledoc """
+Internal helper for delivering a client-disconnect signal.
+
+Called by the per-stream translator in each adapter when the client
+resets the stream or closes the connection. It signals the request
+worker two ways: a `{livery_disconnect, Ref, Reason}` message (for a
+handler waiting in a `receive` loop) and a spawned run of each
+registered cancel callback (for a handler blocked in a NIF that would
+not see a mailbox message until it returns).
+
+Callbacks are always run in a fresh process via `spawn/1`, so a slow
+or crashing callback cannot block the translator or delay the worker's
+`'DOWN'` cleanup.
+""".
+
+-export([fire/4, fire_once/5, register/3]).
+
+-doc """
+Signal `WorkerPid` that the client for `Ref` disconnected with
+`Reason`, and spawn each registered cancel callback.
+""".
+-spec fire(pid(), reference(), term(), [fun(() -> term())]) -> ok.
+fire(WorkerPid, Ref, Reason, Callbacks) ->
+    WorkerPid ! {livery_disconnect, Ref, Reason},
+    lists:foreach(fun run/1, Callbacks),
+    ok.
+
+-doc """
+Fire on the first disconnect only. Returns the new `fired` flag
+(always `true`). A no-op when already fired, so a stream reset
+followed by a connection close fires once.
+""".
+-spec fire_once(boolean(), pid(), reference(), term(), [fun(() -> term())]) -> true.
+fire_once(true, _WorkerPid, _Ref, _Reason, _Callbacks) ->
+    true;
+fire_once(false, WorkerPid, Ref, Reason, Callbacks) ->
+    ok = fire(WorkerPid, Ref, Reason, Callbacks),
+    true.
+
+-doc """
+Register a cancel callback. If the disconnect already fired, run it
+immediately (spawned) and leave the list unchanged; otherwise prepend
+it for the eventual fire.
+""".
+-spec register(boolean(), fun(() -> term()), [fun(() -> term())]) ->
+    [fun(() -> term())].
+register(true, Fun, Callbacks) ->
+    ok = run(Fun),
+    Callbacks;
+register(false, Fun, Callbacks) ->
+    [Fun | Callbacks].
+
+-spec run(fun(() -> term())) -> ok.
+run(Fun) ->
+    _ = spawn(Fun),
+    ok.

--- a/src/livery_h1.erl
+++ b/src/livery_h1.erl
@@ -271,10 +271,17 @@ dispatch_request(Conn, StreamId, Method, Path, Headers, Stack, Handler) ->
     %% `{h1_stream, StreamId, _}' messages in this process's
     %% mailbox.
     BodyRef = make_ref(),
+    DiscRef = make_ref(),
     Reader = livery_body:new(BodyRef),
     {RawPath, RawQuery} = split_query(Path),
     Req = build_req(Conn, StreamId, Method, RawPath, Headers, Reader),
-    Req1 = Req#livery_req{raw_query = RawQuery},
+    %% The dispatch process (this one) runs the translator loop, so it
+    %% is the disconnect notifier the handler registers with.
+    Req1 = Req#livery_req{
+        raw_query = RawQuery,
+        notifier_pid = self(),
+        disc_ref = DiscRef
+    },
     {ok, WorkerPid} = livery_req_sup:start_request(#{
         adapter => ?MODULE,
         stream => {Conn, StreamId},
@@ -282,8 +289,13 @@ dispatch_request(Conn, StreamId, Method, Path, Headers, Stack, Handler) ->
         stack => Stack,
         handler => Handler
     }),
-    MRef = erlang:monitor(process, WorkerPid),
-    translate_until_done(StreamId, BodyRef, WorkerPid, MRef).
+    WMRef = erlang:monitor(process, WorkerPid),
+    %% Monitor the h1 connection process too, so a client disconnect
+    %% fires even when the handler is not reading the body or emitting.
+    CMRef = erlang:monitor(process, Conn),
+    translate_until_done(
+        StreamId, BodyRef, DiscRef, Conn, WorkerPid, WMRef, CMRef, [], false
+    ).
 
 -spec build_req(
     h1:connection(),
@@ -323,27 +335,46 @@ split_query(Path) ->
 -spec translate_until_done(
     h1:stream_id(),
     reference(),
+    reference(),
     pid(),
-    reference()
+    pid(),
+    reference(),
+    reference(),
+    [fun(() -> term())],
+    boolean()
 ) -> ok.
-translate_until_done(StreamId, BodyRef, WorkerPid, MRef) ->
+translate_until_done(StreamId, BodyRef, DiscRef, Conn, WorkerPid, WMRef, CMRef, Cbs, Fired) ->
+    Loop = fun(Cbs1, Fired1) ->
+        translate_until_done(
+            StreamId, BodyRef, DiscRef, Conn, WorkerPid, WMRef, CMRef, Cbs1, Fired1
+        )
+    end,
     receive
         {h1_stream, StreamId, {data, <<>>, true}} ->
             WorkerPid ! {livery_body, BodyRef, eof},
-            translate_until_done(StreamId, BodyRef, WorkerPid, MRef);
+            Loop(Cbs, Fired);
         {h1_stream, StreamId, {data, Chunk, true}} ->
             WorkerPid ! {livery_body, BodyRef, {data, Chunk}},
             WorkerPid ! {livery_body, BodyRef, eof},
-            translate_until_done(StreamId, BodyRef, WorkerPid, MRef);
+            Loop(Cbs, Fired);
         {h1_stream, StreamId, {data, Chunk, false}} ->
             WorkerPid ! {livery_body, BodyRef, {data, Chunk}},
-            translate_until_done(StreamId, BodyRef, WorkerPid, MRef);
+            Loop(Cbs, Fired);
         {h1_stream, StreamId, {trailers, Headers}} ->
             WorkerPid ! {livery_body, BodyRef, {trailers, Headers}},
-            translate_until_done(StreamId, BodyRef, WorkerPid, MRef);
+            Loop(Cbs, Fired);
         {h1_stream, StreamId, {stream_reset, Reason}} ->
             WorkerPid ! {livery_body, BodyRef, {reset, Reason}},
-            translate_until_done(StreamId, BodyRef, WorkerPid, MRef);
-        {'DOWN', MRef, process, WorkerPid, _Reason} ->
+            Loop(Cbs, livery_disconnect:fire_once(Fired, WorkerPid, DiscRef, Reason, Cbs));
+        {'DOWN', CMRef, process, Conn, Reason} ->
+            Loop(
+                Cbs,
+                livery_disconnect:fire_once(
+                    Fired, WorkerPid, DiscRef, {connection_closed, Reason}, Cbs
+                )
+            );
+        {livery_on_disconnect, DiscRef, Fun} ->
+            Loop(livery_disconnect:register(Fired, Fun, Cbs), Fired);
+        {'DOWN', WMRef, process, WorkerPid, _Reason} ->
             ok
     end.

--- a/src/livery_h2.erl
+++ b/src/livery_h2.erl
@@ -283,10 +283,21 @@ make_handler_fun(Stack, Handler) ->
 ) -> ok.
 dispatch_request(Conn, StreamId, Method, Path, Headers, Stack, Handler) ->
     BodyRef = make_ref(),
+    DiscRef = make_ref(),
     Reader = livery_body:new(BodyRef),
     {RawPath, RawQuery} = split_query(Path),
     Req = build_req(Conn, StreamId, Method, RawPath, Headers, Reader),
-    Req1 = Req#livery_req{raw_query = RawQuery},
+    %% The translator is the disconnect notifier. It is spawned before
+    %% the worker (so the req can carry its pid) and given the worker
+    %% pid afterwards via {worker, _}, breaking the dependency cycle.
+    Translator = spawn(fun() ->
+        translator_init(Conn, StreamId, BodyRef, DiscRef)
+    end),
+    Req1 = Req#livery_req{
+        raw_query = RawQuery,
+        notifier_pid = Translator,
+        disc_ref = DiscRef
+    },
     {ok, WorkerPid} = livery_req_sup:start_request(#{
         adapter => ?MODULE,
         stream => {Conn, StreamId},
@@ -294,16 +305,7 @@ dispatch_request(Conn, StreamId, Method, Path, Headers, Stack, Handler) ->
         stack => Stack,
         handler => Handler
     }),
-    %% h2 events for this stream go to a per-stream translator. The
-    %% translator forwards body/trailer events to the worker in the
-    %% livery_body protocol and exits on terminal events. It also
-    %% monitors the worker so it cleans up when the worker finishes,
-    %% including the WebSocket/WebTransport case where the worker
-    %% hands the stream off to another session and exits.
-    Translator = spawn(fun() ->
-        MRef = erlang:monitor(process, WorkerPid),
-        translate_loop(Conn, StreamId, BodyRef, WorkerPid, MRef)
-    end),
+    Translator ! {worker, WorkerPid},
     case
         h2:set_stream_handler(
             Conn,
@@ -374,35 +376,70 @@ connect_pseudo_headers(Req, Protocol) ->
 %% Translator: h2 messages -> livery_body protocol
 %%====================================================================
 
+%% Two-phase init: receive the worker pid, then monitor both the worker
+%% (for normal completion / handoff) and the connection (for client
+%% disconnect, which h2 does not fan out to stream handlers).
+-spec translator_init(h2:connection(), h2:stream_id(), reference(), reference()) ->
+    ok.
+translator_init(Conn, StreamId, BodyRef, DiscRef) ->
+    receive
+        {worker, WorkerPid} ->
+            WMRef = erlang:monitor(process, WorkerPid),
+            CMRef = erlang:monitor(process, Conn),
+            translate_loop(
+                Conn, StreamId, BodyRef, DiscRef, WorkerPid, WMRef, CMRef, [], false
+            )
+    end.
+
 -spec translate_loop(
     h2:connection(),
     h2:stream_id(),
     reference(),
+    reference(),
     pid(),
-    reference()
+    reference(),
+    reference(),
+    [fun(() -> term())],
+    boolean()
 ) -> ok.
-translate_loop(Conn, StreamId, BodyRef, WorkerPid, MRef) ->
+translate_loop(Conn, StreamId, BodyRef, DiscRef, WorkerPid, WMRef, CMRef, Cbs, Fired) ->
+    Loop = fun(Cbs1, Fired1) ->
+        translate_loop(
+            Conn, StreamId, BodyRef, DiscRef, WorkerPid, WMRef, CMRef, Cbs1, Fired1
+        )
+    end,
     receive
         {h2, Conn, {data, StreamId, <<>>, true}} ->
             WorkerPid ! {livery_body, BodyRef, eof},
-            translate_loop(Conn, StreamId, BodyRef, WorkerPid, MRef);
+            Loop(Cbs, Fired);
         {h2, Conn, {data, StreamId, Chunk, true}} ->
             WorkerPid ! {livery_body, BodyRef, {data, Chunk}},
             WorkerPid ! {livery_body, BodyRef, eof},
-            translate_loop(Conn, StreamId, BodyRef, WorkerPid, MRef);
+            Loop(Cbs, Fired);
         {h2, Conn, {data, StreamId, Chunk, false}} ->
             WorkerPid ! {livery_body, BodyRef, {data, Chunk}},
-            translate_loop(Conn, StreamId, BodyRef, WorkerPid, MRef);
+            Loop(Cbs, Fired);
         {h2, Conn, {trailers, StreamId, Trailers}} ->
             WorkerPid ! {livery_body, BodyRef, {trailers, Trailers}},
-            translate_loop(Conn, StreamId, BodyRef, WorkerPid, MRef);
+            Loop(Cbs, Fired);
         {h2, Conn, {stream_reset, StreamId, Reason}} ->
             WorkerPid ! {livery_body, BodyRef, {reset, Reason}},
-            translate_loop(Conn, StreamId, BodyRef, WorkerPid, MRef);
-        {'DOWN', MRef, process, WorkerPid, _Reason} ->
+            Loop(Cbs, livery_disconnect:fire_once(Fired, WorkerPid, DiscRef, Reason, Cbs));
+        {'DOWN', CMRef, process, Conn, Reason} ->
+            %% Connection closed: client disconnect. Fire, keep looping
+            %% (to serve late registrations) until the worker exits.
+            Loop(
+                Cbs,
+                livery_disconnect:fire_once(
+                    Fired, WorkerPid, DiscRef, {connection_closed, Reason}, Cbs
+                )
+            );
+        {livery_on_disconnect, DiscRef, Fun} ->
+            Loop(livery_disconnect:register(Fired, Fun, Cbs), Fired);
+        {'DOWN', WMRef, process, WorkerPid, _Reason} ->
             %% Worker finished (normal request done, or it handed the
             %% stream off to a ws/wt session). Stop translating.
             ok;
         {h2, Conn, _Other} ->
-            translate_loop(Conn, StreamId, BodyRef, WorkerPid, MRef)
+            Loop(Cbs, Fired)
     end.

--- a/src/livery_h3.erl
+++ b/src/livery_h3.erl
@@ -303,10 +303,20 @@ make_handler_fun(Stack, Handler) ->
 ) -> ok.
 dispatch_request(Conn, StreamId, Method, Path, Headers, Stack, Handler) ->
     BodyRef = make_ref(),
+    DiscRef = make_ref(),
     Reader = livery_body:new(BodyRef),
     {RawPath, RawQuery} = split_query(Path),
     Req = build_req(Conn, StreamId, Method, RawPath, Headers, Reader),
-    Req1 = Req#livery_req{raw_query = RawQuery},
+    %% Translator is the disconnect notifier; spawned before the worker
+    %% so the req carries its pid, and given the worker pid afterwards.
+    Translator = spawn(fun() ->
+        translator_init(Conn, StreamId, BodyRef, DiscRef)
+    end),
+    Req1 = Req#livery_req{
+        raw_query = RawQuery,
+        notifier_pid = Translator,
+        disc_ref = DiscRef
+    },
     {ok, WorkerPid} = livery_req_sup:start_request(#{
         adapter => ?MODULE,
         stream => {Conn, StreamId},
@@ -314,10 +324,7 @@ dispatch_request(Conn, StreamId, Method, Path, Headers, Stack, Handler) ->
         stack => Stack,
         handler => Handler
     }),
-    Translator = spawn(fun() ->
-        MRef = erlang:monitor(process, WorkerPid),
-        translate_loop(Conn, StreamId, BodyRef, WorkerPid, MRef)
-    end),
+    Translator ! {worker, WorkerPid},
     _ = quic_h3:set_stream_handler(
         Conn,
         StreamId,
@@ -357,33 +364,67 @@ split_query(Path) ->
 %% Translator: quic_h3 messages -> livery_body protocol
 %%====================================================================
 
+%% Two-phase init: receive the worker pid, then monitor the worker and
+%% the connection. quic_h3 routes a single-stream reset to the
+%% connection owner (not the stream handler), so the reliable client
+%% disconnect signal here is the connection 'DOWN'. A single-stream RST
+%% without a connection close is not observable in the current quic_h3.
+-spec translator_init(pid(), non_neg_integer(), reference(), reference()) -> ok.
+translator_init(Conn, StreamId, BodyRef, DiscRef) ->
+    receive
+        {worker, WorkerPid} ->
+            WMRef = erlang:monitor(process, WorkerPid),
+            CMRef = erlang:monitor(process, Conn),
+            translate_loop(
+                Conn, StreamId, BodyRef, DiscRef, WorkerPid, WMRef, CMRef, [], false
+            )
+    end.
+
 -spec translate_loop(
     pid(),
     non_neg_integer(),
     reference(),
+    reference(),
     pid(),
-    reference()
+    reference(),
+    reference(),
+    [fun(() -> term())],
+    boolean()
 ) -> ok.
-translate_loop(Conn, StreamId, BodyRef, WorkerPid, MRef) ->
+translate_loop(Conn, StreamId, BodyRef, DiscRef, WorkerPid, WMRef, CMRef, Cbs, Fired) ->
+    Loop = fun(Cbs1, Fired1) ->
+        translate_loop(
+            Conn, StreamId, BodyRef, DiscRef, WorkerPid, WMRef, CMRef, Cbs1, Fired1
+        )
+    end,
     receive
         {quic_h3, Conn, {data, StreamId, <<>>, true}} ->
             WorkerPid ! {livery_body, BodyRef, eof},
-            translate_loop(Conn, StreamId, BodyRef, WorkerPid, MRef);
+            Loop(Cbs, Fired);
         {quic_h3, Conn, {data, StreamId, Chunk, true}} ->
             WorkerPid ! {livery_body, BodyRef, {data, Chunk}},
             WorkerPid ! {livery_body, BodyRef, eof},
-            translate_loop(Conn, StreamId, BodyRef, WorkerPid, MRef);
+            Loop(Cbs, Fired);
         {quic_h3, Conn, {data, StreamId, Chunk, false}} ->
             WorkerPid ! {livery_body, BodyRef, {data, Chunk}},
-            translate_loop(Conn, StreamId, BodyRef, WorkerPid, MRef);
+            Loop(Cbs, Fired);
         {quic_h3, Conn, {trailers, StreamId, Trailers}} ->
             WorkerPid ! {livery_body, BodyRef, {trailers, Trailers}},
-            translate_loop(Conn, StreamId, BodyRef, WorkerPid, MRef);
+            Loop(Cbs, Fired);
         {quic_h3, Conn, {stream_reset, StreamId, Reason}} ->
             WorkerPid ! {livery_body, BodyRef, {reset, Reason}},
-            translate_loop(Conn, StreamId, BodyRef, WorkerPid, MRef);
-        {'DOWN', MRef, process, WorkerPid, _Reason} ->
+            Loop(Cbs, livery_disconnect:fire_once(Fired, WorkerPid, DiscRef, Reason, Cbs));
+        {'DOWN', CMRef, process, Conn, Reason} ->
+            Loop(
+                Cbs,
+                livery_disconnect:fire_once(
+                    Fired, WorkerPid, DiscRef, {connection_closed, Reason}, Cbs
+                )
+            );
+        {livery_on_disconnect, DiscRef, Fun} ->
+            Loop(livery_disconnect:register(Fired, Fun, Cbs), Fired);
+        {'DOWN', WMRef, process, WorkerPid, _Reason} ->
             ok;
         {quic_h3, Conn, _Other} ->
-            translate_loop(Conn, StreamId, BodyRef, WorkerPid, MRef)
+            Loop(Cbs, Fired)
     end.

--- a/src/livery_req.erl
+++ b/src/livery_req.erl
@@ -49,7 +49,10 @@ new value for the next stage using the setters.
     meta/3,
     set_meta/3,
 
-    set_req_id/2
+    set_req_id/2,
+
+    on_disconnect/2,
+    disconnect_tag/0
 ]).
 
 -export_type([req/0]).
@@ -83,6 +86,8 @@ set_field(body, V, R) -> R#livery_req{body = V};
 set_field(adapter, V, R) -> R#livery_req{adapter = V};
 set_field(stream, V, R) -> R#livery_req{stream = V};
 set_field(engine_pid, V, R) -> R#livery_req{engine_pid = V};
+set_field(notifier_pid, V, R) -> R#livery_req{notifier_pid = V};
+set_field(disc_ref, V, R) -> R#livery_req{disc_ref = V};
 set_field(req_id, V, R) -> R#livery_req{req_id = V};
 set_field(started_at, V, R) -> R#livery_req{started_at = V};
 set_field(meta, V, R) -> R#livery_req{meta = V};
@@ -264,6 +269,46 @@ set_meta(Key, Value, #livery_req{meta = M} = Req) ->
 -spec set_req_id(binary(), req()) -> req().
 set_req_id(Id, Req) when is_binary(Id) ->
     Req#livery_req{req_id = Id}.
+
+%%====================================================================
+%% Client disconnect
+%%====================================================================
+
+-doc """
+Register a cancel callback to run when the client disconnects.
+
+`Fun` is a 0-arity function (e.g. `fun() -> my_llm:cancel(Ref) end`).
+If the client resets the stream or closes the connection before the
+request finishes, `Fun` is run exactly once in a fresh process, even
+if the handler is blocked in a NIF. It never runs on normal
+completion. Returns `ok` immediately; a no-op on adapters without a
+real connection (e.g. the test adapter).
+
+A handler that runs its own `receive` loop can instead match the
+`{livery_disconnect, _Ref, _Reason}` message delivered to it; see
+`disconnect_tag/0`.
+""".
+-spec on_disconnect(req(), fun(() -> term())) -> ok.
+on_disconnect(#livery_req{notifier_pid = undefined}, _Fun) ->
+    ok;
+on_disconnect(#livery_req{notifier_pid = Pid, disc_ref = Ref}, Fun) when
+    is_pid(Pid), is_reference(Ref), is_function(Fun, 0)
+->
+    Pid ! {livery_on_disconnect, Ref, Fun},
+    ok;
+on_disconnect(#livery_req{}, _Fun) ->
+    ok.
+
+-doc """
+The tag of the disconnect message delivered to a request worker.
+
+A handler in a `receive` loop matches
+`{livery_disconnect, _Ref, _Reason}`. This helper returns the tag
+atom (`livery_disconnect`) for guard-style matching.
+""".
+-spec disconnect_tag() -> livery_disconnect.
+disconnect_tag() ->
+    livery_disconnect.
 
 %%====================================================================
 %% Helpers

--- a/src/livery_resp.erl
+++ b/src/livery_resp.erl
@@ -57,8 +57,8 @@ Response builders here are pure: they never touch sockets.
 -type header_value() :: binary().
 -type body() ::
     {full, iodata()}
-    | {chunked, fun((term()) -> ok)}
-    | {sse, fun((term()) -> ok)}
+    | {chunked, fun((term()) -> ok | {error, term()})}
+    | {sse, fun((term()) -> ok | {error, term()})}
     | {file, file:name_all(), undefined | {non_neg_integer(), non_neg_integer() | eof}}
     | {upgrade, ws | wt, term()}
     | empty
@@ -212,20 +212,20 @@ until it returns.
 -spec stream(
     100..599,
     [{header_name(), header_value()}],
-    fun((term()) -> ok)
+    fun((term()) -> ok | {error, term()})
 ) -> resp().
 stream(Status, Headers, Producer) when is_function(Producer, 1) ->
     new(Status, Headers, {chunked, Producer}).
 
 -doc "Server-Sent Events response.".
--spec sse(100..599, fun((term()) -> ok)) -> resp().
+-spec sse(100..599, fun((term()) -> ok | {error, term()})) -> resp().
 sse(Status, Producer) -> sse(Status, [], Producer).
 
 -doc "`sse/2` with extra headers.".
 -spec sse(
     100..599,
     [{header_name(), header_value()}],
-    fun((term()) -> ok)
+    fun((term()) -> ok | {error, term()})
 ) -> resp().
 sse(Status, ExtraHeaders, Producer) when is_function(Producer, 1) ->
     Hs0 = with_default(<<"content-type">>, <<"text/event-stream">>, ExtraHeaders),
@@ -249,14 +249,14 @@ end).
 
 For pre-encoded bytes, use `stream/3` directly.
 """.
--spec ndjson(100..599, fun((term()) -> ok)) -> resp().
+-spec ndjson(100..599, fun((term()) -> ok | {error, term()})) -> resp().
 ndjson(Status, Producer) -> ndjson(Status, [], Producer).
 
 -doc "`ndjson/2` with extra headers.".
 -spec ndjson(
     100..599,
     [{header_name(), header_value()}],
-    fun((term()) -> ok)
+    fun((term()) -> ok | {error, term()})
 ) -> resp().
 ndjson(Status, ExtraHeaders, Producer) when is_function(Producer, 1) ->
     Hs = with_default(
@@ -268,8 +268,7 @@ ndjson(Status, ExtraHeaders, Producer) when is_function(Producer, 1) ->
         Encode = fun(Term) ->
             Emit([json:encode(Term), <<"\n">>])
         end,
-        _ = Producer(Encode),
-        ok
+        Producer(Encode)
     end,
     new(Status, Hs, {chunked, Wrapped}).
 

--- a/test/livery_disconnect_tests.erl
+++ b/test/livery_disconnect_tests.erl
@@ -1,0 +1,139 @@
+-module(livery_disconnect_tests).
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%====================================================================
+%% livery_disconnect helper
+%%====================================================================
+
+fire_signals_worker_and_runs_callbacks_test() ->
+    Self = self(),
+    Ref = make_ref(),
+    ok = livery_disconnect:fire(Self, Ref, gone, [
+        fun() -> Self ! cb_a end,
+        fun() -> Self ! cb_b end
+    ]),
+    receive
+        {livery_disconnect, R, gone} -> ?assertEqual(Ref, R)
+    after 500 -> ?assert(false)
+    end,
+    ?assert(got(cb_a)),
+    ?assert(got(cb_b)).
+
+fire_once_fires_only_on_first_test() ->
+    Self = self(),
+    Ref = make_ref(),
+    %% Not yet fired -> fires, returns true.
+    ?assertEqual(true, livery_disconnect:fire_once(false, Self, Ref, r1, [])),
+    receive
+        {livery_disconnect, Ref, r1} -> ok
+    after 500 -> ?assert(false)
+    end,
+    %% Already fired -> no-op, returns true.
+    ?assertEqual(true, livery_disconnect:fire_once(true, Self, Ref, r2, [])),
+    ?assertEqual(false, got({livery_disconnect, Ref, r2})).
+
+register_before_fire_accumulates_test() ->
+    Fun = fun() -> ok end,
+    ?assertEqual([Fun], livery_disconnect:register(false, Fun, [])).
+
+register_after_fire_spawns_immediately_test() ->
+    Self = self(),
+    Cbs = [fun() -> already end],
+    %% Fired = true: run now, leave the list unchanged.
+    ?assertEqual(Cbs, livery_disconnect:register(true, fun() -> Self ! ran_now end, Cbs)),
+    ?assert(got(ran_now)).
+
+%%====================================================================
+%% livery_req:on_disconnect/2
+%%====================================================================
+
+on_disconnect_messages_notifier_test() ->
+    Self = self(),
+    Ref = make_ref(),
+    Req = livery_req:new(#{notifier_pid => Self, disc_ref => Ref}),
+    Fun = fun() -> ok end,
+    ok = livery_req:on_disconnect(Req, Fun),
+    receive
+        {livery_on_disconnect, R, F} ->
+            ?assertEqual(Ref, R),
+            ?assertEqual(Fun, F)
+    after 500 -> ?assert(false)
+    end.
+
+on_disconnect_noop_without_notifier_test() ->
+    Req = livery_req:new(#{}),
+    ?assertEqual(ok, livery_req:on_disconnect(Req, fun() -> self() ! nope end)),
+    ?assertEqual(false, got(nope)).
+
+disconnect_tag_test() ->
+    ?assertEqual(livery_disconnect, livery_req:disconnect_tag()).
+
+%%====================================================================
+%% Streaming producer error short-circuits the terminal close
+%%====================================================================
+
+chunked_producer_error_skips_close_test() ->
+    Cap = livery_test_adapter:run(
+        [],
+        fun(_R) ->
+            livery_resp:stream(200, [], fun(Emit) ->
+                Emit(<<"one">>),
+                {error, closed}
+            end)
+        end,
+        #{}
+    ),
+    ?assertEqual(<<"one">>, livery_test_adapter:body(Cap)),
+    ?assertNot(livery_test_adapter:end_stream(Cap)).
+
+chunked_producer_ok_closes_test() ->
+    Cap = livery_test_adapter:run(
+        [],
+        fun(_R) ->
+            livery_resp:stream(200, [], fun(Emit) ->
+                Emit(<<"one">>),
+                ok
+            end)
+        end,
+        #{}
+    ),
+    ?assert(livery_test_adapter:end_stream(Cap)).
+
+ndjson_producer_error_skips_close_test() ->
+    Cap = livery_test_adapter:run(
+        [],
+        fun(_R) ->
+            livery_resp:ndjson(200, fun(Emit) ->
+                Emit(#{<<"n">> => 1}),
+                {error, closed}
+            end)
+        end,
+        #{}
+    ),
+    ?assertEqual(<<"{\"n\":1}\n">>, livery_test_adapter:body(Cap)),
+    ?assertNot(livery_test_adapter:end_stream(Cap)).
+
+ndjson_producer_ok_closes_test() ->
+    Cap = livery_test_adapter:run(
+        [],
+        fun(_R) ->
+            livery_resp:ndjson(200, fun(Emit) ->
+                Emit(#{<<"n">> => 1}),
+                ok
+            end)
+        end,
+        #{}
+    ),
+    ?assert(livery_test_adapter:end_stream(Cap)).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+got(Msg) ->
+    receive
+        Msg -> true
+    after 200 -> false
+    end.

--- a/test/livery_h1_SUITE.erl
+++ b/test/livery_h1_SUITE.erl
@@ -24,7 +24,8 @@
     streaming_chunked_response/1,
     sse_response/1,
     echo_buffered_body/1,
-    error_500_on_crash/1
+    error_500_on_crash/1,
+    cancel_on_client_disconnect/1
 ]).
 
 %%====================================================================
@@ -40,7 +41,8 @@ all() ->
         streaming_chunked_response,
         sse_response,
         echo_buffered_body,
-        error_500_on_crash
+        error_500_on_crash,
+        cancel_on_client_disconnect
     ].
 
 init_per_suite(Config) ->
@@ -127,6 +129,29 @@ error_500_on_crash(Config) ->
     ?assertEqual(500, Status),
     ?assertEqual(<<"internal server error">>, Body).
 
+cancel_on_client_disconnect(Config) ->
+    %% Raw socket so we control the close. The handler registers an
+    %% on_disconnect callback and then reads the request body; HTTP/1.1
+    %% is half-duplex, so the disconnect is detected while the server
+    %% is reading the (incomplete) body. The client promises a large
+    %% body, sends a few bytes, then closes.
+    Port = ?config(port, Config),
+    {ok, Sock} = gen_tcp:connect(
+        "127.0.0.1", Port, [binary, {active, false}], 5000
+    ),
+    ok = gen_tcp:send(Sock, <<
+        "POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 1000\r\n\r\nhi"
+    >>),
+    receive
+        handler_ready -> ok
+    after 5000 -> ct:fail(handler_did_not_start)
+    end,
+    ok = gen_tcp:close(Sock),
+    receive
+        cancelled -> ok
+    after 5000 -> ct:fail(cancel_callback_not_run)
+    end.
+
 %%====================================================================
 %% Handlers
 %%====================================================================
@@ -168,7 +193,16 @@ handler_for(echo_buffered_body) ->
         livery_resp:text(200, Bytes)
     end;
 handler_for(error_500_on_crash) ->
-    fun(_R) -> error(boom) end.
+    fun(_R) -> error(boom) end;
+handler_for(cancel_on_client_disconnect) ->
+    Test = self(),
+    fun(R) ->
+        ok = livery_req:on_disconnect(R, fun() -> Test ! cancelled end),
+        Test ! handler_ready,
+        {stream, Reader} = livery_req:body(R),
+        _ = livery_body:read_all(Reader, 10000),
+        livery_resp:text(200, <<"done">>)
+    end.
 
 %%====================================================================
 %% HTTP helpers (hackney)

--- a/test/livery_h2_SUITE.erl
+++ b/test/livery_h2_SUITE.erl
@@ -24,7 +24,8 @@
     sse_response/1,
     echo_buffered_body/1,
     error_500_on_crash/1,
-    response_with_trailers/1
+    response_with_trailers/1,
+    cancel_on_connection_close/1
 ]).
 
 %%====================================================================
@@ -40,7 +41,8 @@ all() ->
         sse_response,
         echo_buffered_body,
         error_500_on_crash,
-        response_with_trailers
+        response_with_trailers,
+        cancel_on_connection_close
     ].
 
 init_per_suite(Config) ->
@@ -158,6 +160,37 @@ handler_for(response_with_trailers) ->
     fun(_R) ->
         Resp = livery_resp:text(200, <<"hello">>),
         livery_resp:with_trailers([{<<"x-checksum">>, <<"abc">>}], Resp)
+    end;
+handler_for(cancel_on_connection_close) ->
+    Test = self(),
+    fun(R) ->
+        ok = livery_req:on_disconnect(R, fun() -> Test ! cancelled end),
+        livery_resp:stream(200, [], fun(Emit) ->
+            Emit(<<"start">>),
+            Test ! handler_ready,
+            receive
+                {livery_disconnect, _, _} -> ok
+            after 10000 -> ok
+            end
+        end)
+    end.
+
+cancel_on_connection_close(Config) ->
+    Port = ?config(port, Config),
+    {ok, Conn} = h2:connect("127.0.0.1", Port, #{transport => tcp}),
+    {ok, _StreamId} = h2:request(Conn, <<"GET">>, <<"/">>, [
+        {<<"host">>, <<"127.0.0.1">>}
+    ]),
+    receive
+        handler_ready -> ok
+    after 5000 -> ct:fail(handler_did_not_start)
+    end,
+    %% Closing the client connection terminates the server-side h2
+    %% connection process, which the translator monitors -> fire.
+    h2:close(Conn),
+    receive
+        cancelled -> ok
+    after 5000 -> ct:fail(cancel_callback_not_run)
     end.
 
 %%====================================================================

--- a/test/livery_h3_SUITE.erl
+++ b/test/livery_h3_SUITE.erl
@@ -23,7 +23,8 @@
     sse_response/1,
     echo_buffered_body/1,
     error_500_on_crash/1,
-    response_with_trailers/1
+    response_with_trailers/1,
+    cancel_on_connection_close/1
 ]).
 
 %%====================================================================
@@ -39,7 +40,8 @@ all() ->
         sse_response,
         echo_buffered_body,
         error_500_on_crash,
-        response_with_trailers
+        response_with_trailers,
+        cancel_on_connection_close
     ].
 
 init_per_suite(Config) ->
@@ -161,6 +163,43 @@ handler_for(response_with_trailers) ->
     fun(_R) ->
         Resp = livery_resp:text(200, <<"hello">>),
         livery_resp:with_trailers([{<<"x-checksum">>, <<"abc">>}], Resp)
+    end;
+handler_for(cancel_on_connection_close) ->
+    Test = self(),
+    fun(R) ->
+        ok = livery_req:on_disconnect(R, fun() -> Test ! cancelled end),
+        livery_resp:stream(200, [], fun(Emit) ->
+            Emit(<<"start">>),
+            Test ! handler_ready,
+            receive
+                {livery_disconnect, _, _} -> ok
+            after 15000 -> ok
+            end
+        end)
+    end.
+
+cancel_on_connection_close(Config) ->
+    Port = ?config(port, Config),
+    {ok, Conn} = quic_h3:connect(
+        <<"localhost">>, Port, #{verify => verify_none, sync => true}
+    ),
+    Headers = [
+        {<<":method">>, <<"GET">>},
+        {<<":path">>, <<"/">>},
+        {<<":scheme">>, <<"https">>},
+        {<<":authority">>, <<"localhost">>}
+    ],
+    {ok, _StreamId} = quic_h3:request(Conn, Headers, #{end_stream => true}),
+    receive
+        handler_ready -> ok
+    after 10000 -> ct:fail(handler_did_not_start)
+    end,
+    %% Closing the QUIC connection terminates the server-side quic_h3
+    %% connection process, which the translator monitors -> fire.
+    catch quic_h3:close(Conn),
+    receive
+        cancelled -> ok
+    after 10000 -> ct:fail(cancel_callback_not_run)
     end.
 
 %%====================================================================


### PR DESCRIPTION
## Summary

- The per-stream translator now monitors the connection process on every adapter (H1/H2/H3). On a client stream reset or connection close it signals the request worker exactly once.
- New `livery_req:on_disconnect/2` registers a cancel callback that runs (spawned) on disconnect even when the handler is blocked in a NIF; `{livery_disconnect, Ref, Reason}` is also delivered for handlers in a receive loop. Signal-only by default (the worker is never killed); never fires on normal completion.
- Chunked/SSE/NDJSON producers may return `{error, _}` to short-circuit the terminal write when the client is gone; producer types widened accordingly.
- First item of the framework-gap audit backlog (the top AI-serving gap).

Guide: `docs/guides/cancel-on-disconnect.md`.