### PR TITLE
Add CORS and security-headers middleware

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -5,17 +5,21 @@ sibling library that owns the change.
 
 ## Framework-gap backlog (from the audit)
 
-Modern web/AI framework gaps, in priority order. Step 1 is done.
+Modern web/AI framework gaps, in priority order. Steps 1 and 2 are done.
 
 1. Cancel on client disconnect. DONE: `livery_req:on_disconnect/2`
    plus the `{livery_disconnect, _, _}` message, delivered across
    H1/H2/H3 by the per-stream translator (which monitors the
    connection). See `docs/guides/cancel-on-disconnect.md`.
-2. CORS middleware.
+2. CORS middleware. DONE: `livery_cors` (preflight short-circuit,
+   origin allowlist/predicate, credentials, expose, max-age, and
+   cache-correct `Vary`). See `docs/guides/enable-cors.md`.
 3. Response compression (gzip/br/zstd) with Accept-Encoding.
 4. Multipart / form-data body parsing (uploads, multimodal).
 5. Concurrency limit / load-shedding middleware (admission control).
-6. Security-headers middleware (HSTS/CSP/etc).
+6. Security-headers middleware (HSTS/CSP/etc). DONE:
+   `livery_security_headers` (nosniff, frame options, referrer policy,
+   HSTS on TLS, opt-in CSP). See `docs/guides/set-security-headers.md`.
 7. Rate limiting / throttling.
 8. HTTP caching primitives (ETag, conditional GET, Cache-Control).
 9. Static-directory serving with ETag/MIME.

--- a/docs/guides/enable-cors.md
+++ b/docs/guides/enable-cors.md
@@ -1,0 +1,68 @@
+# How to enable CORS
+
+## Problem
+
+A browser app on another origin needs to call your API, so the
+responses must carry Cross-Origin Resource Sharing headers and
+preflight `OPTIONS` requests must be answered.
+
+## Solution
+
+Add `livery_cors` to the stack. Every config key is optional; the
+default allows any origin:
+
+```erlang
+Stack = [
+    {livery_cors, #{
+        origins => [<<"https://app.example.com">>],
+        methods => [<<"GET">>, <<"POST">>],
+        headers => mirror,            %% echo Access-Control-Request-Headers
+        expose  => [<<"x-total-count">>],
+        credentials => true,
+        max_age => 600
+    }}
+    %% ... handler
+].
+```
+
+A preflight (`OPTIONS` carrying `Access-Control-Request-Method`) is
+answered directly with `204` and the `Access-Control-Allow-*` headers;
+the handler is never called. A normal request runs the handler, then
+the CORS response headers are added.
+
+## Origins
+
+```erlang
+origins => '*'                                  %% any origin (default)
+origins => [<<"https://a.test">>, <<"https://b.test">>]
+origins => fun(Origin) -> is_tenant_origin(Origin) end
+```
+
+When the origin is not allowed, no `Access-Control-Allow-Origin` is
+emitted and the browser blocks the response.
+
+## Credentials and the wildcard
+
+`Access-Control-Allow-Origin: *` is invalid with credentials. When
+`credentials => true`, `livery_cors` always echoes the request
+`Origin` instead of `*` and adds `Access-Control-Allow-Credentials:
+true`.
+
+## Caching is handled for you
+
+`livery_cors` sets `Vary` so shared caches stay correct:
+
+- `Vary: Origin` is added on every response (allowed, denied, and the
+  no-`Origin` passthrough) whenever the output depends on the request
+  origin, which is any config except the plain non-credentialed `'*'`.
+- Mirroring preflights also add `Vary: Access-Control-Request-Headers`.
+- A plain `origins => '*'` without credentials is origin-independent,
+  so no `Vary` is added.
+
+Existing `Vary` tokens are never duplicated.
+
+## See also
+
+- Reference: `livery_cors`, `livery_security_headers`
+- Recipe: [Set security headers](set-security-headers.md)
+- Recipe: [Write a custom middleware](custom-middleware.md)

--- a/docs/guides/set-security-headers.md
+++ b/docs/guides/set-security-headers.md
@@ -1,0 +1,70 @@
+# How to set security headers
+
+## Problem
+
+You want responses to carry baseline hardening headers
+(`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`,
+`Strict-Transport-Security`, optionally `Content-Security-Policy`).
+
+## Solution
+
+Add `livery_security_headers` to the stack. With no config it applies
+sensible defaults:
+
+```erlang
+Stack = [
+    {livery_security_headers, #{}}
+    %% ... handler
+].
+```
+
+Defaults emitted:
+
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY`
+- `Referrer-Policy: no-referrer`
+- `Strict-Transport-Security: max-age=31536000; includeSubDomains`
+  (HTTPS / TLS requests only)
+
+## HSTS only on secure requests
+
+`Strict-Transport-Security` is meaningless over plain HTTP, so it is
+emitted only when the request is secure (`scheme` is `https` or TLS
+info is present). Tune or disable it:
+
+```erlang
+{livery_security_headers, #{
+    hsts => #{max_age => 63072000, include_subdomains => true, preload => true}
+}}
+
+{livery_security_headers, #{hsts => false}}  %% never send HSTS
+```
+
+## Content-Security-Policy is opt-in
+
+A wrong CSP breaks pages, so there is no default. Set it explicitly:
+
+```erlang
+{livery_security_headers, #{csp => <<"default-src 'self'">>}}
+```
+
+## Overriding per header
+
+Any key set to a value replaces the default; set it to `false` to drop
+that header entirely:
+
+```erlang
+{livery_security_headers, #{
+    frame_options => <<"SAMEORIGIN">>,
+    referrer_policy => false
+}}
+```
+
+A header the handler already set on the response is preserved, so a
+handler can override any of these per response.
+
+## See also
+
+- Reference: `livery_security_headers`, `livery_cors`
+- Recipe: [Enable CORS](enable-cors.md)
+- Recipe: [Write a custom middleware](custom-middleware.md)

--- a/rebar.config
+++ b/rebar.config
@@ -97,6 +97,8 @@
         {"docs/guides/cancel-on-disconnect.md", #{
             title => <<"Cancel on client disconnect">>
         }},
+        {"docs/guides/enable-cors.md", #{title => <<"Enable CORS">>}},
+        {"docs/guides/set-security-headers.md", #{title => <<"Set security headers">>}},
         {"docs/guides/openapi-and-validation.md", #{title => <<"OpenAPI docs and validation">>}},
         {"docs/guides/serve-mcp-tools.md", #{title => <<"Serve MCP tools">>}},
         {"docs/guides/serve-webtransport.md", #{title => <<"Serve WebTransport">>}},
@@ -151,6 +153,8 @@
             <<"docs/guides/propagate-request-ids.md">>,
             <<"docs/guides/handler-errors.md">>,
             <<"docs/guides/cancel-on-disconnect.md">>,
+            <<"docs/guides/enable-cors.md">>,
+            <<"docs/guides/set-security-headers.md">>,
             <<"docs/guides/openapi-and-validation.md">>,
             <<"docs/guides/serve-mcp-tools.md">>,
             <<"docs/guides/serve-webtransport.md">>,
@@ -180,7 +184,9 @@
             livery_request_id,
             livery_body_limit,
             livery_timeout,
-            livery_access_log
+            livery_access_log,
+            livery_cors,
+            livery_security_headers
         ]},
         {<<"Authentication">>, [
             livery_auth,

--- a/src/livery_cors.erl
+++ b/src/livery_cors.erl
@@ -1,0 +1,255 @@
+-module(livery_cors).
+-moduledoc """
+CORS middleware.
+
+Adds Cross-Origin Resource Sharing headers and answers preflight
+`OPTIONS` requests. Configure it as a stack entry
+`{livery_cors, Config}` where every `Config` key is optional:
+
+- `origins` — `'*'` (default), a list of allowed origin binaries, or
+  a predicate `fun((binary()) -> boolean())`.
+- `methods` — allowed methods for preflight `Access-Control-Allow-Methods`
+  (default the common verb set).
+- `headers` — `mirror` (default, echo the request's
+  `Access-Control-Request-Headers`) or an explicit list of header names.
+- `expose` — header names for `Access-Control-Expose-Headers` (default `[]`).
+- `credentials` — `true` to send `Access-Control-Allow-Credentials`
+  (default `false`). With credentials the wildcard origin is never sent;
+  the request `Origin` is echoed instead.
+- `max_age` — seconds for `Access-Control-Max-Age` on preflights.
+
+`Vary` is set so shared caches stay correct: `Origin` is added on every
+branch whenever the emitted headers depend on the request origin (a
+list, a predicate, or credentialed wildcard), and
+`Access-Control-Request-Headers` is added on mirroring preflights. A
+plain non-credentialed `'*'` configuration is origin-independent and
+adds no `Vary`.
+""".
+-behaviour(livery_middleware).
+
+-export([call/3]).
+
+-doc "Apply CORS headers, answering preflight requests directly.".
+-spec call(livery_req:req(), livery_middleware:next(), map() | undefined) ->
+    livery_resp:resp().
+call(Req, Next, State) ->
+    Cfg = config(State),
+    case livery_req:header(<<"origin">>, Req) of
+        undefined ->
+            add_actual_vary(Cfg, Next(Req));
+        Origin ->
+            handle(Req, Next, Cfg, Origin)
+    end.
+
+%%====================================================================
+%% Request handling
+%%====================================================================
+
+-spec handle(livery_req:req(), livery_middleware:next(), map(), binary()) ->
+    livery_resp:resp().
+handle(Req, Next, Cfg, Origin) ->
+    case is_preflight(Req) of
+        true -> preflight(Req, Cfg, Origin);
+        false -> actual(Req, Next, Cfg, Origin)
+    end.
+
+-spec is_preflight(livery_req:req()) -> boolean().
+is_preflight(Req) ->
+    livery_req:method(Req) =:= <<"OPTIONS">> andalso
+        livery_req:has_header(<<"access-control-request-method">>, Req).
+
+-spec preflight(livery_req:req(), map(), binary()) -> livery_resp:resp().
+preflight(Req, Cfg, Origin) ->
+    Resp0 = livery_resp:empty(204),
+    Resp1 =
+        case allowed(Origin, maps:get(origins, Cfg)) of
+            true -> preflight_headers(Req, Cfg, Origin, Resp0);
+            false -> Resp0
+        end,
+    preflight_vary(Cfg, Resp1).
+
+-spec actual(livery_req:req(), livery_middleware:next(), map(), binary()) ->
+    livery_resp:resp().
+actual(Req, Next, Cfg, Origin) ->
+    Resp0 = Next(Req),
+    Resp1 =
+        case allowed(Origin, maps:get(origins, Cfg)) of
+            true -> actual_headers(Cfg, Origin, Resp0);
+            false -> Resp0
+        end,
+    add_actual_vary(Cfg, Resp1).
+
+%%====================================================================
+%% Header builders
+%%====================================================================
+
+-spec preflight_headers(livery_req:req(), map(), binary(), livery_resp:resp()) ->
+    livery_resp:resp().
+preflight_headers(Req, Cfg, Origin, Resp) ->
+    R1 = set_acao(Cfg, Origin, Resp),
+    R2 = livery_resp:with_header(
+        <<"access-control-allow-methods">>, join(maps:get(methods, Cfg)), R1
+    ),
+    R3 = set_allow_headers(Req, Cfg, R2),
+    R4 = set_max_age(Cfg, R3),
+    set_credentials(Cfg, R4).
+
+-spec actual_headers(map(), binary(), livery_resp:resp()) -> livery_resp:resp().
+actual_headers(Cfg, Origin, Resp) ->
+    R1 = set_acao(Cfg, Origin, Resp),
+    R2 = set_credentials(Cfg, R1),
+    set_expose(Cfg, R2).
+
+-spec set_acao(map(), binary(), livery_resp:resp()) -> livery_resp:resp().
+set_acao(Cfg, Origin, Resp) ->
+    Value =
+        case origin_dependent(Cfg) of
+            true -> Origin;
+            false -> <<"*">>
+        end,
+    livery_resp:with_header(<<"access-control-allow-origin">>, Value, Resp).
+
+-spec set_allow_headers(livery_req:req(), map(), livery_resp:resp()) ->
+    livery_resp:resp().
+set_allow_headers(Req, Cfg, Resp) ->
+    case maps:get(headers, Cfg) of
+        mirror ->
+            case livery_req:header(<<"access-control-request-headers">>, Req) of
+                undefined -> Resp;
+                Requested -> allow_headers(Requested, Resp)
+            end;
+        [] ->
+            Resp;
+        List when is_list(List) ->
+            allow_headers(join(List), Resp)
+    end.
+
+-spec allow_headers(binary(), livery_resp:resp()) -> livery_resp:resp().
+allow_headers(Value, Resp) ->
+    livery_resp:with_header(<<"access-control-allow-headers">>, Value, Resp).
+
+-spec set_max_age(map(), livery_resp:resp()) -> livery_resp:resp().
+set_max_age(Cfg, Resp) ->
+    case maps:get(max_age, Cfg) of
+        undefined ->
+            Resp;
+        Secs when is_integer(Secs), Secs >= 0 ->
+            livery_resp:with_header(
+                <<"access-control-max-age">>, integer_to_binary(Secs), Resp
+            )
+    end.
+
+-spec set_credentials(map(), livery_resp:resp()) -> livery_resp:resp().
+set_credentials(Cfg, Resp) ->
+    case maps:get(credentials, Cfg) of
+        true ->
+            livery_resp:with_header(
+                <<"access-control-allow-credentials">>, <<"true">>, Resp
+            );
+        false ->
+            Resp
+    end.
+
+-spec set_expose(map(), livery_resp:resp()) -> livery_resp:resp().
+set_expose(Cfg, Resp) ->
+    case maps:get(expose, Cfg) of
+        [] ->
+            Resp;
+        List when is_list(List) ->
+            livery_resp:with_header(
+                <<"access-control-expose-headers">>, join(List), Resp
+            )
+    end.
+
+%%====================================================================
+%% Vary (cache-correctness)
+%%====================================================================
+
+-spec add_actual_vary(map(), livery_resp:resp()) -> livery_resp:resp().
+add_actual_vary(Cfg, Resp) ->
+    case origin_dependent(Cfg) of
+        true -> append_vary(<<"Origin">>, Resp);
+        false -> Resp
+    end.
+
+-spec preflight_vary(map(), livery_resp:resp()) -> livery_resp:resp().
+preflight_vary(Cfg, Resp) ->
+    R1 = add_actual_vary(Cfg, Resp),
+    case maps:get(headers, Cfg) of
+        mirror -> append_vary(<<"Access-Control-Request-Headers">>, R1);
+        _ -> R1
+    end.
+
+-spec append_vary(binary(), livery_resp:resp()) -> livery_resp:resp().
+append_vary(Token, Resp) ->
+    case vary_present(Token, Resp) of
+        true -> Resp;
+        false -> livery_resp:append_header(<<"vary">>, Token, Resp)
+    end.
+
+-spec vary_present(binary(), livery_resp:resp()) -> boolean().
+vary_present(Token, Resp) ->
+    LToken = normalize_token(Token),
+    Existing = [V || {<<"vary">>, V} <- livery_resp:headers(Resp)],
+    lists:any(
+        fun(Value) -> lists:member(LToken, split_tokens(Value)) end, Existing
+    ).
+
+-spec split_tokens(binary()) -> [binary()].
+split_tokens(Value) ->
+    [normalize_token(P) || P <- binary:split(Value, <<",">>, [global])].
+
+-spec normalize_token(binary()) -> binary().
+normalize_token(Token) ->
+    iolist_to_binary(string:trim(string:lowercase(Token))).
+
+%%====================================================================
+%% Config and predicates
+%%====================================================================
+
+-spec config(map() | undefined) -> map().
+config(undefined) ->
+    config(#{});
+config(State) when is_map(State) ->
+    #{
+        origins => maps:get(origins, State, '*'),
+        methods => maps:get(methods, State, default_methods()),
+        headers => maps:get(headers, State, mirror),
+        expose => maps:get(expose, State, []),
+        credentials => maps:get(credentials, State, false),
+        max_age => maps:get(max_age, State, undefined)
+    }.
+
+-spec default_methods() -> [binary()].
+default_methods() ->
+    [
+        <<"GET">>,
+        <<"HEAD">>,
+        <<"PUT">>,
+        <<"PATCH">>,
+        <<"POST">>,
+        <<"DELETE">>,
+        <<"OPTIONS">>
+    ].
+
+-spec origin_dependent(map()) -> boolean().
+origin_dependent(#{origins := '*', credentials := false}) ->
+    false;
+origin_dependent(_Cfg) ->
+    true.
+
+-spec allowed(binary(), '*' | [binary()] | fun((binary()) -> boolean())) ->
+    boolean().
+allowed(_Origin, '*') ->
+    true;
+allowed(Origin, List) when is_list(List) ->
+    lists:member(Origin, List);
+allowed(Origin, Pred) when is_function(Pred, 1) ->
+    case Pred(Origin) of
+        true -> true;
+        _ -> false
+    end.
+
+-spec join([binary()]) -> binary().
+join(List) ->
+    iolist_to_binary(lists:join(<<", ">>, List)).

--- a/src/livery_security_headers.erl
+++ b/src/livery_security_headers.erl
@@ -1,0 +1,114 @@
+-module(livery_security_headers).
+-moduledoc """
+Security-headers middleware.
+
+Decorates responses with baseline hardening headers. Configure it as a
+stack entry `{livery_security_headers, Config}` where every `Config`
+key is optional and a value of `false` disables that header:
+
+- `content_type_options` — `true` (default) sends
+  `X-Content-Type-Options: nosniff`.
+- `frame_options` — header value, default `<<"DENY">>`.
+- `referrer_policy` — header value, default `<<"no-referrer">>`.
+- `csp` — `Content-Security-Policy` value, default `false` (off): a
+  wrong policy breaks apps, so it is opt-in.
+- `hsts` — `#{max_age => Secs, include_subdomains => boolean(),
+  preload => boolean()}` (defaults `31536000`, `true`, `false`), or
+  `false`. `Strict-Transport-Security` is only emitted on secure
+  (HTTPS / TLS) requests; on plain HTTP it is meaningless and skipped.
+
+Each header is set only when the handler did not already set it, so a
+handler can override any of them per response.
+""".
+-behaviour(livery_middleware).
+
+-export([call/3]).
+
+-doc "Add the configured security headers to the downstream response.".
+-spec call(livery_req:req(), livery_middleware:next(), map() | undefined) ->
+    livery_resp:resp().
+call(Req, Next, State) ->
+    Cfg = config(State),
+    Resp = Next(Req),
+    Steps = [
+        {<<"x-content-type-options">>, content_type_value(Cfg)},
+        {<<"x-frame-options">>, maps:get(frame_options, Cfg)},
+        {<<"referrer-policy">>, maps:get(referrer_policy, Cfg)},
+        {<<"content-security-policy">>, maps:get(csp, Cfg)},
+        {<<"strict-transport-security">>, hsts_value(Req, Cfg)}
+    ],
+    lists:foldl(
+        fun({Name, Value}, Acc) -> maybe_set(Name, Value, Acc) end, Resp, Steps
+    ).
+
+%%====================================================================
+%% Header application
+%%====================================================================
+
+-spec maybe_set(binary(), false | binary(), livery_resp:resp()) ->
+    livery_resp:resp().
+maybe_set(_Name, false, Resp) ->
+    Resp;
+maybe_set(Name, Value, Resp) when is_binary(Value) ->
+    case lists:keymember(Name, 1, livery_resp:headers(Resp)) of
+        true -> Resp;
+        false -> livery_resp:with_header(Name, Value, Resp)
+    end.
+
+-spec content_type_value(map()) -> false | binary().
+content_type_value(Cfg) ->
+    case maps:get(content_type_options, Cfg) of
+        true -> <<"nosniff">>;
+        false -> false
+    end.
+
+-spec hsts_value(livery_req:req(), map()) -> false | binary().
+hsts_value(Req, Cfg) ->
+    case maps:get(hsts, Cfg) of
+        false ->
+            false;
+        Opts when is_map(Opts) ->
+            case secure(Req) of
+                true -> build_hsts(Opts);
+                false -> false
+            end
+    end.
+
+-spec secure(livery_req:req()) -> boolean().
+secure(Req) ->
+    livery_req:scheme(Req) =:= <<"https">> orelse
+        livery_req:tls(Req) =/= undefined.
+
+-spec build_hsts(map()) -> binary().
+build_hsts(Opts) ->
+    Max = maps:get(max_age, Opts, 31536000),
+    Base = <<"max-age=", (integer_to_binary(Max))/binary>>,
+    WithSub =
+        case maps:get(include_subdomains, Opts, true) of
+            true -> <<Base/binary, "; includeSubDomains">>;
+            false -> Base
+        end,
+    case maps:get(preload, Opts, false) of
+        true -> <<WithSub/binary, "; preload">>;
+        false -> WithSub
+    end.
+
+%%====================================================================
+%% Config
+%%====================================================================
+
+-spec config(map() | undefined) -> map().
+config(undefined) ->
+    config(#{});
+config(State) when is_map(State) ->
+    #{
+        content_type_options => maps:get(content_type_options, State, true),
+        frame_options => maps:get(frame_options, State, <<"DENY">>),
+        referrer_policy => maps:get(referrer_policy, State, <<"no-referrer">>),
+        hsts => maps:get(hsts, State, default_hsts()),
+        csp => maps:get(csp, State, false)
+    }.
+
+-spec default_hsts() -> map().
+default_hsts() ->
+    #{max_age => 31536000, include_subdomains => true, preload => false}.

--- a/test/livery_builtin_middleware_tests.erl
+++ b/test/livery_builtin_middleware_tests.erl
@@ -230,3 +230,281 @@ request_id_in_access_log_test() ->
         logger:remove_handler(HandlerId),
         logger:set_primary_config(level, maps:get(level, Primary))
     end.
+
+%%====================================================================
+%% livery_cors
+%%====================================================================
+
+cors_preflight_returns_204_and_skips_handler_test() ->
+    Cap = livery_test_adapter:run(
+        [{livery_cors, #{origins => [<<"http://app.test">>]}}],
+        fun(_R) -> error(must_not_be_called) end,
+        #{
+            method => <<"OPTIONS">>,
+            headers => [
+                {<<"origin">>, <<"http://app.test">>},
+                {<<"access-control-request-method">>, <<"POST">>}
+            ]
+        }
+    ),
+    ?assertEqual(204, livery_test_adapter:status(Cap)),
+    ?assertEqual(
+        <<"http://app.test">>,
+        livery_test_adapter:header(<<"access-control-allow-origin">>, Cap)
+    ),
+    ?assert(
+        is_binary(
+            livery_test_adapter:header(<<"access-control-allow-methods">>, Cap)
+        )
+    ).
+
+cors_simple_allowed_origin_echoes_and_varies_test() ->
+    Cap = run_cors(
+        #{origins => [<<"http://app.test">>]},
+        #{headers => [{<<"origin">>, <<"http://app.test">>}]}
+    ),
+    ?assertEqual(
+        <<"http://app.test">>,
+        livery_test_adapter:header(<<"access-control-allow-origin">>, Cap)
+    ),
+    ?assert(has_vary(<<"origin">>, Cap)).
+
+cors_fun_origin_allowed_test() ->
+    Pred = fun(Origin) -> Origin =:= <<"http://ok.test">> end,
+    Cap = run_cors(
+        #{origins => Pred},
+        #{headers => [{<<"origin">>, <<"http://ok.test">>}]}
+    ),
+    ?assertEqual(
+        <<"http://ok.test">>,
+        livery_test_adapter:header(<<"access-control-allow-origin">>, Cap)
+    ),
+    ?assert(has_vary(<<"origin">>, Cap)).
+
+cors_wildcard_no_credentials_test() ->
+    Cap = run_cors(#{}, #{headers => [{<<"origin">>, <<"http://any.test">>}]}),
+    ?assertEqual(
+        <<"*">>,
+        livery_test_adapter:header(<<"access-control-allow-origin">>, Cap)
+    ),
+    ?assertEqual([], vary_tokens(Cap)).
+
+cors_wildcard_with_credentials_echoes_origin_test() ->
+    Cap = run_cors(
+        #{credentials => true},
+        #{headers => [{<<"origin">>, <<"http://any.test">>}]}
+    ),
+    ?assertEqual(
+        <<"http://any.test">>,
+        livery_test_adapter:header(<<"access-control-allow-origin">>, Cap)
+    ),
+    ?assertEqual(
+        <<"true">>,
+        livery_test_adapter:header(<<"access-control-allow-credentials">>, Cap)
+    ),
+    ?assert(has_vary(<<"origin">>, Cap)).
+
+cors_disallowed_origin_no_acao_but_varies_test() ->
+    Cap = run_cors(
+        #{origins => [<<"http://allowed.test">>]},
+        #{headers => [{<<"origin">>, <<"http://evil.test">>}]}
+    ),
+    ?assertEqual(
+        undefined,
+        livery_test_adapter:header(<<"access-control-allow-origin">>, Cap)
+    ),
+    ?assert(has_vary(<<"origin">>, Cap)).
+
+cors_no_origin_wildcard_byte_identical_test() ->
+    Cap = run_cors(#{}, #{}),
+    ?assertEqual(
+        undefined,
+        livery_test_adapter:header(<<"access-control-allow-origin">>, Cap)
+    ),
+    ?assertEqual([], vary_tokens(Cap)).
+
+cors_no_origin_dependent_config_adds_vary_test() ->
+    Cap = run_cors(#{origins => [<<"http://app.test">>]}, #{}),
+    ?assertEqual(
+        undefined,
+        livery_test_adapter:header(<<"access-control-allow-origin">>, Cap)
+    ),
+    ?assert(has_vary(<<"origin">>, Cap)).
+
+cors_mirror_preflight_echoes_and_varies_acrh_test() ->
+    Cap = livery_test_adapter:run(
+        [{livery_cors, #{origins => [<<"http://app.test">>]}}],
+        fun(_R) -> error(must_not_be_called) end,
+        #{
+            method => <<"OPTIONS">>,
+            headers => [
+                {<<"origin">>, <<"http://app.test">>},
+                {<<"access-control-request-method">>, <<"POST">>},
+                {<<"access-control-request-headers">>, <<"x-custom, authorization">>}
+            ]
+        }
+    ),
+    ?assertEqual(
+        <<"x-custom, authorization">>,
+        livery_test_adapter:header(<<"access-control-allow-headers">>, Cap)
+    ),
+    ?assert(has_vary(<<"origin">>, Cap)),
+    ?assert(has_vary(<<"access-control-request-headers">>, Cap)).
+
+cors_expose_headers_on_simple_response_test() ->
+    Cap = run_cors(
+        #{expose => [<<"x-total-count">>, <<"x-page">>]},
+        #{headers => [{<<"origin">>, <<"http://any.test">>}]}
+    ),
+    ?assertEqual(
+        <<"x-total-count, x-page">>,
+        livery_test_adapter:header(<<"access-control-expose-headers">>, Cap)
+    ).
+
+cors_does_not_duplicate_existing_vary_test() ->
+    Handler = fun(_R) ->
+        livery_resp:with_header(
+            <<"vary">>, <<"Origin">>, livery_resp:text(200, <<"ok">>)
+        )
+    end,
+    Cap = livery_test_adapter:run(
+        [{livery_cors, #{origins => [<<"http://app.test">>]}}],
+        Handler,
+        #{headers => [{<<"origin">>, <<"http://app.test">>}]}
+    ),
+    Varys = [V || {<<"vary">>, V} <- livery_test_adapter:headers(Cap)],
+    ?assertEqual(1, length(Varys)),
+    ?assert(has_vary(<<"origin">>, Cap)).
+
+%%====================================================================
+%% livery_security_headers
+%%====================================================================
+
+security_defaults_test() ->
+    Cap = run_sec(#{}, #{}),
+    ?assertEqual(
+        <<"nosniff">>,
+        livery_test_adapter:header(<<"x-content-type-options">>, Cap)
+    ),
+    ?assertEqual(
+        <<"DENY">>,
+        livery_test_adapter:header(<<"x-frame-options">>, Cap)
+    ),
+    ?assertEqual(
+        <<"no-referrer">>,
+        livery_test_adapter:header(<<"referrer-policy">>, Cap)
+    ).
+
+security_hsts_present_on_https_test() ->
+    Cap = run_sec(#{}, #{scheme => <<"https">>}),
+    ?assertEqual(
+        <<"max-age=31536000; includeSubDomains">>,
+        livery_test_adapter:header(<<"strict-transport-security">>, Cap)
+    ).
+
+security_hsts_absent_on_http_test() ->
+    Cap = run_sec(#{}, #{}),
+    ?assertEqual(
+        undefined,
+        livery_test_adapter:header(<<"strict-transport-security">>, Cap)
+    ).
+
+security_preserves_handler_header_test() ->
+    Handler = fun(_R) ->
+        livery_resp:with_header(
+            <<"x-frame-options">>, <<"SAMEORIGIN">>, livery_resp:text(200, <<"ok">>)
+        )
+    end,
+    Cap = livery_test_adapter:run(
+        [{livery_security_headers, #{}}], Handler, #{}
+    ),
+    ?assertEqual(
+        <<"SAMEORIGIN">>,
+        livery_test_adapter:header(<<"x-frame-options">>, Cap)
+    ).
+
+security_csp_present_when_configured_test() ->
+    Cap = run_sec(#{csp => <<"default-src 'self'">>}, #{}),
+    ?assertEqual(
+        <<"default-src 'self'">>,
+        livery_test_adapter:header(<<"content-security-policy">>, Cap)
+    ).
+
+security_csp_absent_by_default_test() ->
+    Cap = run_sec(#{}, #{}),
+    ?assertEqual(
+        undefined,
+        livery_test_adapter:header(<<"content-security-policy">>, Cap)
+    ).
+
+security_false_disables_header_test() ->
+    Cap = run_sec(
+        #{frame_options => false, content_type_options => false}, #{}
+    ),
+    ?assertEqual(
+        undefined,
+        livery_test_adapter:header(<<"x-frame-options">>, Cap)
+    ),
+    ?assertEqual(
+        undefined,
+        livery_test_adapter:header(<<"x-content-type-options">>, Cap)
+    ).
+
+cors_security_request_id_compose_test() ->
+    Stack = [
+        {livery_request_id, undefined},
+        {livery_cors, #{origins => [<<"http://app.test">>]}},
+        {livery_security_headers, #{}}
+    ],
+    Cap = livery_test_adapter:run(
+        Stack,
+        fun(_R) -> livery_resp:text(200, <<"ok">>) end,
+        #{
+            scheme => <<"https">>,
+            headers => [{<<"origin">>, <<"http://app.test">>}]
+        }
+    ),
+    ?assertEqual(200, livery_test_adapter:status(Cap)),
+    ?assert(is_binary(livery_test_adapter:header(<<"x-request-id">>, Cap))),
+    ?assertEqual(
+        <<"http://app.test">>,
+        livery_test_adapter:header(<<"access-control-allow-origin">>, Cap)
+    ),
+    ?assertEqual(
+        <<"nosniff">>,
+        livery_test_adapter:header(<<"x-content-type-options">>, Cap)
+    ),
+    ?assert(has_vary(<<"origin">>, Cap)).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+run_cors(Cfg, Spec) ->
+    livery_test_adapter:run(
+        [{livery_cors, Cfg}],
+        fun(_R) -> livery_resp:text(200, <<"ok">>) end,
+        Spec
+    ).
+
+run_sec(Cfg, Spec) ->
+    livery_test_adapter:run(
+        [{livery_security_headers, Cfg}],
+        fun(_R) -> livery_resp:text(200, <<"ok">>) end,
+        Spec
+    ).
+
+vary_tokens(Cap) ->
+    Values = [V || {<<"vary">>, V} <- livery_test_adapter:headers(Cap)],
+    lists:flatmap(
+        fun(V) ->
+            [normalize_token(T) || T <- binary:split(V, <<",">>, [global])]
+        end,
+        Values
+    ).
+
+has_vary(Token, Cap) ->
+    lists:member(normalize_token(Token), vary_tokens(Cap)).
+
+normalize_token(Token) ->
+    iolist_to_binary(string:trim(string:lowercase(Token))).


### PR DESCRIPTION
## Summary
- `livery_cors`: answers preflight `OPTIONS` (204, handler not called), origin allowlist / predicate / wildcard, credentials (echoes origin, never `*`), expose, max-age, mirror allowed-headers, and cache-correct `Vary` (Origin on every branch for origin-dependent configs, `Access-Control-Request-Headers` on mirror preflights, none for plain wildcard, no duplicate tokens).
- `livery_security_headers`: nosniff, `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`, HSTS gated on https/TLS, opt-in CSP; set-if-absent so handlers can override; `false` disables a header.
- Guides `enable-cors.md` and `set-security-headers.md`, ex_doc wiring, and `features.md` backlog items #2 and #6 marked done.

Resolves backlog items #2 (CORS) and #6 (security headers).