### PR TITLE
Add response compression middleware with pluggable codecs

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -5,7 +5,7 @@ sibling library that owns the change.
 
 ## Framework-gap backlog (from the audit)
 
-Modern web/AI framework gaps, in priority order. Steps 1 and 2 are done.
+Modern web/AI framework gaps, in priority order. Steps 1-3 are done.
 
 1. Cancel on client disconnect. DONE: `livery_req:on_disconnect/2`
    plus the `{livery_disconnect, _, _}` message, delivered across
@@ -14,7 +14,14 @@ Modern web/AI framework gaps, in priority order. Steps 1 and 2 are done.
 2. CORS middleware. DONE: `livery_cors` (preflight short-circuit,
    origin allowlist/predicate, credentials, expose, max-age, and
    cache-correct `Vary`). See `docs/guides/enable-cors.md`.
-3. Response compression (gzip/br/zstd) with Accept-Encoding.
+3. Response compression with Accept-Encoding. DONE (gzip + deflate):
+   `livery_compress` negotiates over the `livery_codec` registry and
+   compresses full + chunked bodies; `livery_codec_gzip` and
+   `livery_codec_deflate` are built in over OTP `zlib`. See
+   `docs/guides/compress-responses.md`. Follow-up codec apps (separate
+   PRs, link system libs): `livery_brotli` (NIF, `br`) and
+   `livery_zstd` (cmake NIF, `zstd`) implement the same behaviour and
+   self-register via `livery_codec:register/1`.
 4. Multipart / form-data body parsing (uploads, multimodal).
 5. Concurrency limit / load-shedding middleware (admission control).
 6. Security-headers middleware (HSTS/CSP/etc). DONE:

--- a/docs/guides/compress-responses.md
+++ b/docs/guides/compress-responses.md
@@ -1,0 +1,69 @@
+# How to compress responses
+
+## Problem
+
+You want responses gzip/deflate-compressed when the client supports it,
+without touching every handler.
+
+## Solution
+
+Add `livery_compress` to the stack. gzip and deflate are built in:
+
+```erlang
+Stack = [
+    {livery_compress, #{}}
+    %% ... handler
+].
+```
+
+It reads the request `Accept-Encoding`, picks a codec the client
+accepts, compresses the response body, and sets `Content-Encoding` plus
+`Vary: Accept-Encoding`. A client that sends no `Accept-Encoding` (or
+none the server has) gets the response uncompressed, so any HTTP client
+works: those that advertise gzip decode it transparently, the rest get
+identity.
+
+## What gets compressed
+
+Eligible responses are `{full, _}` bodies at least `min_size` bytes and
+`{chunked, _}` streams, with a compressible `Content-Type` and no
+existing `Content-Encoding`. SSE, file, empty, and upgrade responses
+pass through untouched.
+
+```erlang
+{livery_compress, #{
+    min_size => 1024,                       %% default; full bodies only
+    types => [<<"text/">>, <<"application/json">>]  %% compressible prefixes
+}}
+```
+
+`Content-Type` matching is case-insensitive and ignores parameters, so
+`Application/JSON; charset=utf-8` is compressed.
+
+## Negotiation and server preference
+
+A coding is acceptable when its `Accept-Encoding` q-value is greater
+than zero (`q=0` rejects). Among acceptable codings the SERVER decides
+which to use, in the order of the codec list; client q-weights are only
+an accept/reject filter. Control the order with `codecs`:
+
+```erlang
+{livery_compress, #{codecs => [livery_codec_gzip]}}   %% gzip only
+```
+
+## Adding more codecs
+
+`livery_compress` negotiates over `livery_codec:registered()`, which is
+`[livery_codec_gzip, livery_codec_deflate]` plus any codec a separate
+app registered. A codec app implements the `livery_codec` behaviour and
+calls `livery_codec:register(Module)` at its own start; it is then
+negotiated automatically (e.g. a future `livery_brotli` advertising
+`br`). The built-ins are always present and cannot be displaced by
+registration.
+
+## See also
+
+- Reference: `livery_compress`, `livery_codec`, `livery_codec_gzip`,
+  `livery_codec_deflate`
+- Recipe: [Enable CORS](enable-cors.md)
+- Recipe: [Set security headers](set-security-headers.md)

--- a/rebar.config
+++ b/rebar.config
@@ -99,6 +99,7 @@
         }},
         {"docs/guides/enable-cors.md", #{title => <<"Enable CORS">>}},
         {"docs/guides/set-security-headers.md", #{title => <<"Set security headers">>}},
+        {"docs/guides/compress-responses.md", #{title => <<"Compress responses">>}},
         {"docs/guides/openapi-and-validation.md", #{title => <<"OpenAPI docs and validation">>}},
         {"docs/guides/serve-mcp-tools.md", #{title => <<"Serve MCP tools">>}},
         {"docs/guides/serve-webtransport.md", #{title => <<"Serve WebTransport">>}},
@@ -155,6 +156,7 @@
             <<"docs/guides/cancel-on-disconnect.md">>,
             <<"docs/guides/enable-cors.md">>,
             <<"docs/guides/set-security-headers.md">>,
+            <<"docs/guides/compress-responses.md">>,
             <<"docs/guides/openapi-and-validation.md">>,
             <<"docs/guides/serve-mcp-tools.md">>,
             <<"docs/guides/serve-webtransport.md">>,
@@ -187,6 +189,12 @@
             livery_access_log,
             livery_cors,
             livery_security_headers
+        ]},
+        {<<"Compression">>, [
+            livery_compress,
+            livery_codec,
+            livery_codec_gzip,
+            livery_codec_deflate
         ]},
         {<<"Authentication">>, [
             livery_auth,
@@ -237,7 +245,7 @@
             %% The adapter behaviour is dispatched dynamically by
             %% design (Adapter:send_*, accept_ws/accept_wt).
             {elvis_style, invalid_dynamic_call, #{
-                ignore => [livery, livery_mcp, livery_ws, livery_wt]
+                ignore => [livery, livery_mcp, livery_ws, livery_wt, livery_compress]
             }},
             %% Per-stream translators block on receive and exit on the
             %% monitored worker's DOWN, so an after clause is wrong.

--- a/src/livery_codec.erl
+++ b/src/livery_codec.erl
@@ -1,0 +1,91 @@
+-module(livery_codec).
+-moduledoc """
+Content-coding codec behaviour and registry.
+
+A codec turns response bytes into a single content-coding (the token
+sent in `Content-Encoding`, e.g. `gzip`). `livery_compress` negotiates
+the client's `Accept-Encoding` against the registered codecs and applies
+the chosen one to `{full, _}` and `{chunked, _}` bodies.
+
+The built-in codecs `livery_codec_gzip` and `livery_codec_deflate` are
+always available (over OTP `zlib`, no dependency). A separate app (a
+future `livery_brotli` or `livery_zstd`) adds its coding by calling
+`register/1` at its own application start; it then participates in
+negotiation without any change to livery core.
+
+## Callbacks
+
+- `name/0` — the `Content-Encoding` token (lowercase binary).
+- `compress/1` — one-shot compression of a whole body (`{full, _}`).
+- `stream_init/0` — open a streaming context.
+- `stream_update/2` — feed a chunk and FLUSH, returning the bytes
+  emittable now (so each producer chunk reaches the client promptly).
+- `stream_finish/1` — return the trailing bytes that finalize the
+  stream. Does not release the context.
+- `stream_close/1` — release the context; always called, including on
+  the error path.
+""".
+
+-compile({no_auto_import, [registered/0]}).
+
+-export([register/1, registered/0, lookup/1]).
+
+-export_type([codec/0]).
+
+-type codec() :: module().
+
+-callback name() -> binary().
+-callback compress(iodata()) -> iodata().
+-callback stream_init() -> term().
+-callback stream_update(term(), iodata()) -> iodata().
+-callback stream_finish(term()) -> iodata().
+-callback stream_close(term()) -> ok.
+
+-define(EXTRAS_KEY, {?MODULE, extras}).
+-define(BUILTINS, [livery_codec_gzip, livery_codec_deflate]).
+
+-doc """
+Register an extra codec module.
+
+Idempotent; built-in codecs are ignored (always present). Intended to be
+called once at the registering app's start, not per request.
+""".
+-spec register(codec()) -> ok.
+register(Module) when is_atom(Module) ->
+    Extras = persistent_term:get(?EXTRAS_KEY, []),
+    case lists:member(Module, Extras) orelse lists:member(Module, ?BUILTINS) of
+        true ->
+            ok;
+        false ->
+            persistent_term:put(?EXTRAS_KEY, Extras ++ [Module]),
+            ok
+    end.
+
+-doc """
+All registered codecs in server-preference order.
+
+Always begins with the built-ins (`gzip`, then `deflate`), followed by
+any extras in registration order. The built-ins can never be dropped by
+registration.
+""".
+-spec registered() -> [codec()].
+registered() ->
+    ?BUILTINS ++ persistent_term:get(?EXTRAS_KEY, []).
+
+-doc "Find a registered codec by `Content-Encoding` token (case-insensitive).".
+-spec lookup(binary()) -> {ok, codec()} | error.
+lookup(Name) when is_binary(Name) ->
+    find(normalize(Name), registered()).
+
+-spec find(binary(), [codec()]) -> {ok, codec()} | error.
+find(_Lower, []) ->
+    error;
+find(Lower, [Module | Rest]) ->
+    case normalize(Module:name()) =:= Lower of
+        true -> {ok, Module};
+        false -> find(Lower, Rest)
+    end.
+
+-spec normalize(binary()) -> binary().
+normalize(Bin) ->
+    iolist_to_binary(string:lowercase(Bin)).

--- a/src/livery_codec_deflate.erl
+++ b/src/livery_codec_deflate.erl
@@ -1,0 +1,37 @@
+-module(livery_codec_deflate).
+-moduledoc """
+Built-in `deflate` content-coding over OTP `zlib`.
+
+Emits zlib-wrapped DEFLATE (RFC 1950, WindowBits 15), which is the
+spec-correct `deflate` content-coding (NOT raw DEFLATE). Decodes with
+`zlib:uncompress/1` and any conformant client.
+""".
+-behaviour(livery_codec).
+
+-export([name/0, compress/1, stream_init/0, stream_update/2, stream_finish/1, stream_close/1]).
+
+-define(WINDOW_BITS, 15).
+
+-doc "Content-Encoding token.".
+-spec name() -> binary().
+name() -> <<"deflate">>.
+
+-doc "One-shot zlib-wrapped DEFLATE of a whole body.".
+-spec compress(iodata()) -> iodata().
+compress(Data) -> zlib:compress(Data).
+
+-doc "Open a streaming deflate context.".
+-spec stream_init() -> zlib:zstream().
+stream_init() -> livery_codec_zlib:stream_init(?WINDOW_BITS).
+
+-doc "Compress and flush one chunk.".
+-spec stream_update(zlib:zstream(), iodata()) -> iodata().
+stream_update(Z, Data) -> livery_codec_zlib:stream_update(Z, Data).
+
+-doc "Trailing bytes finalizing the deflate stream.".
+-spec stream_finish(zlib:zstream()) -> iodata().
+stream_finish(Z) -> livery_codec_zlib:stream_finish(Z).
+
+-doc "Release the streaming context.".
+-spec stream_close(zlib:zstream()) -> ok.
+stream_close(Z) -> livery_codec_zlib:stream_close(Z).

--- a/src/livery_codec_gzip.erl
+++ b/src/livery_codec_gzip.erl
@@ -1,0 +1,37 @@
+-module(livery_codec_gzip).
+-moduledoc """
+Built-in `gzip` content-coding over OTP `zlib`.
+
+Emits RFC 1952 gzip framing (zlib WindowBits 31): one valid gzip member
+with the header written once and the CRC/ISIZE trailer at finish, so the
+streamed output decodes in any conformant client.
+""".
+-behaviour(livery_codec).
+
+-export([name/0, compress/1, stream_init/0, stream_update/2, stream_finish/1, stream_close/1]).
+
+-define(WINDOW_BITS, 31).
+
+-doc "Content-Encoding token.".
+-spec name() -> binary().
+name() -> <<"gzip">>.
+
+-doc "One-shot gzip of a whole body.".
+-spec compress(iodata()) -> iodata().
+compress(Data) -> zlib:gzip(Data).
+
+-doc "Open a streaming gzip context.".
+-spec stream_init() -> zlib:zstream().
+stream_init() -> livery_codec_zlib:stream_init(?WINDOW_BITS).
+
+-doc "Compress and flush one chunk.".
+-spec stream_update(zlib:zstream(), iodata()) -> iodata().
+stream_update(Z, Data) -> livery_codec_zlib:stream_update(Z, Data).
+
+-doc "Trailing bytes finalizing the gzip member.".
+-spec stream_finish(zlib:zstream()) -> iodata().
+stream_finish(Z) -> livery_codec_zlib:stream_finish(Z).
+
+-doc "Release the streaming context.".
+-spec stream_close(zlib:zstream()) -> ok.
+stream_close(Z) -> livery_codec_zlib:stream_close(Z).

--- a/src/livery_codec_zlib.erl
+++ b/src/livery_codec_zlib.erl
@@ -1,0 +1,34 @@
+-module(livery_codec_zlib).
+-moduledoc """
+Shared OTP `zlib` streaming backend for the gzip and deflate codecs.
+
+The two built-in codecs differ only in the zlib `WindowBits` value
+(31 for gzip framing, 15 for zlib-wrapped DEFLATE), so the streaming
+machinery lives here once. `stream_update/2` uses a sync flush so each
+producer chunk is emittable immediately.
+""".
+
+-export([stream_init/1, stream_update/2, stream_finish/1, stream_close/1]).
+
+-doc "Open a deflate stream with the given zlib WindowBits.".
+-spec stream_init(integer()) -> zlib:zstream().
+stream_init(WindowBits) ->
+    Z = zlib:open(),
+    ok = zlib:deflateInit(Z, default, deflated, WindowBits, 8, default),
+    Z.
+
+-doc "Compress a chunk and flush, returning the bytes emittable now.".
+-spec stream_update(zlib:zstream(), iodata()) -> iodata().
+stream_update(Z, Data) ->
+    zlib:deflate(Z, Data, sync).
+
+-doc "Return the trailing bytes that finalize the stream.".
+-spec stream_finish(zlib:zstream()) -> iodata().
+stream_finish(Z) ->
+    zlib:deflate(Z, <<>>, finish).
+
+-doc "Release the stream. Frees the underlying zlib resource.".
+-spec stream_close(zlib:zstream()) -> ok.
+stream_close(Z) ->
+    zlib:close(Z),
+    ok.

--- a/src/livery_compress.erl
+++ b/src/livery_compress.erl
@@ -1,0 +1,298 @@
+-module(livery_compress).
+-moduledoc """
+Response-compression middleware.
+
+Negotiates the client's `Accept-Encoding` against the registered
+`livery_codec` codecs and compresses eligible responses, setting
+`Content-Encoding` and a cache-correct `Vary: Accept-Encoding`. gzip and
+deflate are built in (OTP `zlib`); brotli/zstd become available when
+their apps register a codec. Configure as a stack entry
+`{livery_compress, Config}` where every key is optional:
+
+- `codecs` — list of codec modules in server-preference order
+  (default `livery_codec:registered()`); restricts/overrides the set.
+- `min_size` — minimum `{full, _}` body size to compress (default 1024).
+- `types` — compressible `Content-Type` prefixes (default text and the
+  common structured types).
+
+## Negotiation
+
+A coding is acceptable iff its `Accept-Encoding` q-value is `> 0` (by
+exact name or `*`; `q=0` rejects). Among acceptable codings the SERVER
+preference order wins; client q-weights are only an accept/reject
+filter. With no acceptable coding the response is sent uncompressed
+(identity); `identity;q=0` is deliberately treated as identity, not a
+`406`.
+
+## Scope
+
+Only `{full, _}` (>= `min_size`) and `{chunked, _}` bodies with a
+compressible `Content-Type` and no existing `Content-Encoding` are
+eligible. SSE, file, empty, and upgrade bodies pass through unchanged.
+""".
+-behaviour(livery_middleware).
+
+-export([call/3]).
+
+-doc "Compress the downstream response when the client accepts a codec.".
+-spec call(livery_req:req(), livery_middleware:next(), map() | undefined) ->
+    livery_resp:resp().
+call(Req, Next, State) ->
+    Cfg = config(State),
+    Resp = Next(Req),
+    case eligible(Resp, Cfg) of
+        false ->
+            Resp;
+        true ->
+            Resp1 = append_vary(<<"Accept-Encoding">>, Resp),
+            Accept = livery_req:header(<<"accept-encoding">>, Req, <<>>),
+            case choose(Accept, maps:get(codecs, Cfg)) of
+                none -> Resp1;
+                {ok, Codec} -> apply_codec(Codec, Resp1)
+            end
+    end.
+
+%%====================================================================
+%% Eligibility
+%%====================================================================
+
+-spec eligible(livery_resp:resp(), map()) -> boolean().
+eligible(Resp, Cfg) ->
+    not has_content_encoding(Resp) andalso
+        body_eligible(livery_resp:body(Resp), Cfg) andalso
+        type_compressible(Resp, Cfg).
+
+-spec has_content_encoding(livery_resp:resp()) -> boolean().
+has_content_encoding(Resp) ->
+    lists:keymember(<<"content-encoding">>, 1, livery_resp:headers(Resp)).
+
+-spec body_eligible(livery_resp:body(), map()) -> boolean().
+body_eligible({full, Body}, Cfg) ->
+    iolist_size(Body) >= maps:get(min_size, Cfg);
+body_eligible({chunked, _Producer}, _Cfg) ->
+    true;
+body_eligible(_Other, _Cfg) ->
+    false.
+
+-spec type_compressible(livery_resp:resp(), map()) -> boolean().
+type_compressible(Resp, Cfg) ->
+    case content_type(Resp) of
+        undefined ->
+            false;
+        Value ->
+            Norm = normalize_ct(Value),
+            lists:any(
+                fun(Prefix) -> is_prefix(Prefix, Norm) end,
+                maps:get(types, Cfg)
+            )
+    end.
+
+-spec content_type(livery_resp:resp()) -> binary() | undefined.
+content_type(Resp) ->
+    case lists:keyfind(<<"content-type">>, 1, livery_resp:headers(Resp)) of
+        {_, Value} -> Value;
+        false -> undefined
+    end.
+
+-spec normalize_ct(binary()) -> binary().
+normalize_ct(Value) ->
+    Lower = iolist_to_binary(string:lowercase(Value)),
+    [Main | _] = binary:split(Lower, <<";">>),
+    iolist_to_binary(string:trim(Main)).
+
+-spec is_prefix(binary(), binary()) -> boolean().
+is_prefix(Prefix, Bin) when byte_size(Bin) >= byte_size(Prefix) ->
+    PrefixSize = byte_size(Prefix),
+    <<Head:PrefixSize/binary, _/binary>> = Bin,
+    Head =:= Prefix;
+is_prefix(_Prefix, _Bin) ->
+    false.
+
+%%====================================================================
+%% Negotiation
+%%====================================================================
+
+-spec choose(binary(), [module()]) -> none | {ok, module()}.
+choose(Accept, Codecs) ->
+    select(Codecs, parse_accept_encoding(Accept)).
+
+-spec select([module()], #{binary() => float()}) -> none | {ok, module()}.
+select([], _Accepted) ->
+    none;
+select([Codec | Rest], Accepted) ->
+    case acceptable(normalize(Codec:name()), Accepted) of
+        true -> {ok, Codec};
+        false -> select(Rest, Accepted)
+    end.
+
+-spec acceptable(binary(), #{binary() => float()}) -> boolean().
+acceptable(Name, Accepted) ->
+    case maps:find(Name, Accepted) of
+        {ok, Q} -> Q > 0;
+        error -> wildcard_q(Accepted) > 0
+    end.
+
+-spec wildcard_q(#{binary() => float()}) -> float().
+wildcard_q(Accepted) ->
+    maps:get(<<"*">>, Accepted, 0.0).
+
+-spec parse_accept_encoding(binary()) -> #{binary() => float()}.
+parse_accept_encoding(Bin) ->
+    lists:foldl(
+        fun parse_entry/2, #{}, binary:split(Bin, <<",">>, [global])
+    ).
+
+-spec parse_entry(binary(), #{binary() => float()}) -> #{binary() => float()}.
+parse_entry(Part, Acc) ->
+    case iolist_to_binary(string:trim(Part)) of
+        <<>> ->
+            Acc;
+        Trimmed ->
+            {Coding, Q} = split_q(Trimmed),
+            maps:put(normalize(Coding), Q, Acc)
+    end.
+
+-spec split_q(binary()) -> {binary(), float()}.
+split_q(Entry) ->
+    case binary:split(Entry, <<";">>) of
+        [Coding] -> {Coding, 1.0};
+        [Coding, Params] -> {Coding, parse_q(Params)}
+    end.
+
+-spec parse_q(binary()) -> float().
+parse_q(Params) ->
+    Lower = iolist_to_binary(string:lowercase(Params)),
+    find_q(binary:split(Lower, <<";">>, [global])).
+
+-spec find_q([binary()]) -> float().
+find_q([]) ->
+    1.0;
+find_q([Token | Rest]) ->
+    case iolist_to_binary(string:trim(Token)) of
+        <<"q=", Value/binary>> -> to_q(Value);
+        _Other -> find_q(Rest)
+    end.
+
+-spec to_q(binary()) -> float().
+to_q(Value) ->
+    Str = binary_to_list(iolist_to_binary(string:trim(Value))),
+    case string:to_float(Str) of
+        {Float, _Rest} when is_float(Float) ->
+            Float;
+        {error, _} ->
+            case string:to_integer(Str) of
+                {Int, _} when is_integer(Int) -> float(Int);
+                {error, _} -> 0.0
+            end
+    end.
+
+%%====================================================================
+%% Apply
+%%====================================================================
+
+-spec apply_codec(module(), livery_resp:resp()) -> livery_resp:resp().
+apply_codec(Codec, Resp) ->
+    case livery_resp:body(Resp) of
+        {full, Body} -> apply_full(Codec, Body, Resp);
+        {chunked, Producer} -> apply_chunked(Codec, Producer, Resp)
+    end.
+
+-spec apply_full(module(), iodata(), livery_resp:resp()) -> livery_resp:resp().
+apply_full(Codec, Body, Resp) ->
+    Comp = iolist_to_binary(Codec:compress(Body)),
+    R1 = livery_resp:with_body({full, Comp}, Resp),
+    R2 = livery_resp:with_header(<<"content-encoding">>, Codec:name(), R1),
+    case livery_resp:trailers(Resp) of
+        undefined ->
+            livery_resp:with_header(
+                <<"content-length">>, integer_to_binary(byte_size(Comp)), R2
+            );
+        _Trailers ->
+            livery_resp:delete_header(<<"content-length">>, R2)
+    end.
+
+-spec apply_chunked(
+    module(), fun((term()) -> ok | {error, term()}), livery_resp:resp()
+) -> livery_resp:resp().
+apply_chunked(Codec, Producer, Resp) ->
+    Wrapped = fun(Emit) -> stream(Codec, Producer, Emit) end,
+    R1 = livery_resp:with_body({chunked, Wrapped}, Resp),
+    R2 = livery_resp:with_header(<<"content-encoding">>, Codec:name(), R1),
+    livery_resp:delete_header(<<"content-length">>, R2).
+
+-spec stream(
+    module(),
+    fun((term()) -> ok | {error, term()}),
+    fun((term()) -> ok | {error, term()})
+) -> ok | {error, term()}.
+stream(Codec, Producer, Emit) ->
+    Ctx = Codec:stream_init(),
+    EmitC = fun(Chunk) -> emit_compressed(Codec:stream_update(Ctx, Chunk), Emit) end,
+    try Producer(EmitC) of
+        {error, _} = Err -> Err;
+        _Ok -> emit_compressed(Codec:stream_finish(Ctx), Emit)
+    after
+        Codec:stream_close(Ctx)
+    end.
+
+-spec emit_compressed(iodata(), fun((term()) -> ok | {error, term()})) ->
+    ok | {error, term()}.
+emit_compressed(Out, Emit) ->
+    case iolist_size(Out) of
+        0 -> ok;
+        _ -> Emit(Out)
+    end.
+
+%%====================================================================
+%% Vary
+%%====================================================================
+
+-spec append_vary(binary(), livery_resp:resp()) -> livery_resp:resp().
+append_vary(Token, Resp) ->
+    case vary_present(Token, Resp) of
+        true -> Resp;
+        false -> livery_resp:append_header(<<"vary">>, Token, Resp)
+    end.
+
+-spec vary_present(binary(), livery_resp:resp()) -> boolean().
+vary_present(Token, Resp) ->
+    LToken = normalize(Token),
+    Existing = [V || {<<"vary">>, V} <- livery_resp:headers(Resp)],
+    lists:any(
+        fun(Value) -> lists:member(LToken, split_tokens(Value)) end, Existing
+    ).
+
+-spec split_tokens(binary()) -> [binary()].
+split_tokens(Value) ->
+    [normalize(P) || P <- binary:split(Value, <<",">>, [global])].
+
+%%====================================================================
+%% Config and helpers
+%%====================================================================
+
+-spec config(map() | undefined) -> map().
+config(undefined) ->
+    config(#{});
+config(State) when is_map(State) ->
+    #{
+        codecs => maps:get(codecs, State, livery_codec:registered()),
+        min_size => maps:get(min_size, State, 1024),
+        types => maps:get(types, State, default_types())
+    }.
+
+-spec default_types() -> [binary()].
+default_types() ->
+    [
+        <<"text/">>,
+        <<"application/json">>,
+        <<"application/javascript">>,
+        <<"application/xml">>,
+        <<"application/xhtml+xml">>,
+        <<"image/svg+xml">>,
+        <<"application/wasm">>,
+        <<"application/x-ndjson">>
+    ].
+
+-spec normalize(binary()) -> binary().
+normalize(Bin) ->
+    iolist_to_binary(string:trim(string:lowercase(Bin))).

--- a/src/livery_resp.erl
+++ b/src/livery_resp.erl
@@ -24,6 +24,7 @@ Response builders here are pure: they never touch sockets.
     append_header/3,
     delete_header/2,
     with_trailers/2,
+    with_body/2,
 
     text/2,
     text/3,
@@ -136,6 +137,16 @@ been emitted.
 ) -> resp().
 with_trailers(Trailers, Resp) ->
     Resp#livery_resp{trailers = Trailers}.
+
+-doc """
+Replace the body variant, keeping status, headers, and trailers.
+
+Used by middleware (e.g. `livery_compress`) that rewrites the body
+after the handler has produced the response.
+""".
+-spec with_body(body(), resp()) -> resp().
+with_body(Body, Resp) ->
+    Resp#livery_resp{body = Body}.
 
 %%====================================================================
 %% Convenience builders

--- a/test/livery_compress_tests.erl
+++ b/test/livery_compress_tests.erl
@@ -1,0 +1,240 @@
+-module(livery_compress_tests).
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(JSON, <<"{\"hello\":\"world\",\"n\":12345,\"list\":[1,2,3,4,5]}">>).
+
+%%====================================================================
+%% Full-body negotiation
+%%====================================================================
+
+gzip_full_roundtrip_test() ->
+    Cap = run_full(#{min_size => 0}, ?JSON, [{<<"accept-encoding">>, <<"gzip">>}]),
+    ?assertEqual(<<"gzip">>, h(<<"content-encoding">>, Cap)),
+    ?assert(has_vary(<<"accept-encoding">>, Cap)),
+    Body = livery_test_adapter:body(Cap),
+    ?assertEqual(integer_to_binary(byte_size(Body)), h(<<"content-length">>, Cap)),
+    ?assertEqual(?JSON, zlib:gunzip(Body)).
+
+deflate_full_roundtrip_test() ->
+    Cap = run_full(#{min_size => 0}, ?JSON, [{<<"accept-encoding">>, <<"deflate">>}]),
+    ?assertEqual(<<"deflate">>, h(<<"content-encoding">>, Cap)),
+    ?assertEqual(?JSON, zlib:uncompress(livery_test_adapter:body(Cap))).
+
+server_preference_wins_test() ->
+    %% Client lists deflate first, but server order is [gzip, deflate].
+    Cap = run_full(
+        #{min_size => 0}, ?JSON, [{<<"accept-encoding">>, <<"deflate, gzip">>}]
+    ),
+    ?assertEqual(<<"gzip">>, h(<<"content-encoding">>, Cap)).
+
+no_accept_encoding_passes_through_with_vary_test() ->
+    Cap = run_full(#{min_size => 0}, ?JSON, []),
+    ?assertEqual(undefined, h(<<"content-encoding">>, Cap)),
+    ?assert(has_vary(<<"accept-encoding">>, Cap)),
+    ?assertEqual(?JSON, livery_test_adapter:body(Cap)).
+
+q_zero_rejects_gzip_test() ->
+    Cap = run_full(
+        #{min_size => 0}, ?JSON, [{<<"accept-encoding">>, <<"gzip;q=0">>}]
+    ),
+    ?assertEqual(undefined, h(<<"content-encoding">>, Cap)),
+    ?assert(has_vary(<<"accept-encoding">>, Cap)).
+
+wildcard_accept_encoding_test() ->
+    Cap = run_full(#{min_size => 0}, ?JSON, [{<<"accept-encoding">>, <<"*">>}]),
+    ?assertEqual(<<"gzip">>, h(<<"content-encoding">>, Cap)).
+
+empty_codec_list_sends_identity_with_vary_test() ->
+    Cap = run_full(
+        #{min_size => 0, codecs => []},
+        ?JSON,
+        [{<<"accept-encoding">>, <<"gzip">>}]
+    ),
+    ?assertEqual(undefined, h(<<"content-encoding">>, Cap)),
+    ?assert(has_vary(<<"accept-encoding">>, Cap)),
+    ?assertEqual(?JSON, livery_test_adapter:body(Cap)).
+
+%%====================================================================
+%% Eligibility
+%%====================================================================
+
+already_encoded_passes_through_test() ->
+    Handler = fun(_R) ->
+        livery_resp:with_header(
+            <<"content-encoding">>, <<"gzip">>, livery_resp:json(200, ?JSON)
+        )
+    end,
+    Cap = livery_test_adapter:run(
+        [{livery_compress, #{min_size => 0}}],
+        Handler,
+        #{headers => [{<<"accept-encoding">>, <<"gzip">>}]}
+    ),
+    %% unchanged: still the original (already-tagged) body, no Vary added
+    ?assertEqual(?JSON, livery_test_adapter:body(Cap)),
+    ?assertEqual([], vary_tokens(Cap)).
+
+below_min_size_passes_through_test() ->
+    Small = <<"hi">>,
+    Cap = run_full(#{}, Small, [{<<"accept-encoding">>, <<"gzip">>}]),
+    ?assertEqual(undefined, h(<<"content-encoding">>, Cap)),
+    ?assertEqual([], vary_tokens(Cap)),
+    ?assertEqual(Small, livery_test_adapter:body(Cap)).
+
+non_compressible_type_passes_through_test() ->
+    Handler = fun(_R) ->
+        livery_resp:new(
+            200,
+            [{<<"content-type">>, <<"image/png">>}],
+            {full, binary:copy(<<"x">>, 2000)}
+        )
+    end,
+    Cap = livery_test_adapter:run(
+        [{livery_compress, #{min_size => 0}}],
+        Handler,
+        #{headers => [{<<"accept-encoding">>, <<"gzip">>}]}
+    ),
+    ?assertEqual(undefined, h(<<"content-encoding">>, Cap)),
+    ?assertEqual([], vary_tokens(Cap)).
+
+content_type_with_params_is_compressible_test() ->
+    Handler = fun(_R) ->
+        livery_resp:new(
+            200,
+            [{<<"content-type">>, <<"Application/JSON; charset=utf-8">>}],
+            {full, ?JSON}
+        )
+    end,
+    Cap = livery_test_adapter:run(
+        [{livery_compress, #{min_size => 0}}],
+        Handler,
+        #{headers => [{<<"accept-encoding">>, <<"gzip">>}]}
+    ),
+    ?assertEqual(<<"gzip">>, h(<<"content-encoding">>, Cap)),
+    ?assertEqual(?JSON, zlib:gunzip(livery_test_adapter:body(Cap))).
+
+sse_passes_through_test() ->
+    Producer = fun(Emit) ->
+        Emit(#{data => <<"1">>}),
+        ok
+    end,
+    Cap = livery_test_adapter:run(
+        [{livery_compress, #{min_size => 0}}],
+        fun(_R) -> livery_resp:sse(200, Producer) end,
+        #{headers => [{<<"accept-encoding">>, <<"gzip">>}]}
+    ),
+    ?assertEqual(undefined, h(<<"content-encoding">>, Cap)),
+    ?assertEqual([], vary_tokens(Cap)).
+
+empty_passes_through_test() ->
+    Cap = livery_test_adapter:run(
+        [{livery_compress, #{min_size => 0}}],
+        fun(_R) -> livery_resp:empty(204) end,
+        #{headers => [{<<"accept-encoding">>, <<"gzip">>}]}
+    ),
+    ?assertEqual(204, livery_test_adapter:status(Cap)),
+    ?assertEqual(undefined, h(<<"content-encoding">>, Cap)),
+    ?assertEqual([], vary_tokens(Cap)).
+
+%%====================================================================
+%% Chunked streaming
+%%====================================================================
+
+chunked_roundtrip_test() ->
+    Producer = fun(Emit) ->
+        Emit(<<"chunk-one-">>),
+        Emit(<<"chunk-two-">>),
+        Emit(<<"chunk-three">>),
+        ok
+    end,
+    Handler = fun(_R) ->
+        livery_resp:stream(
+            200, [{<<"content-type">>, <<"application/json">>}], Producer
+        )
+    end,
+    Cap = livery_test_adapter:run(
+        [{livery_compress, #{}}],
+        Handler,
+        #{headers => [{<<"accept-encoding">>, <<"gzip">>}]}
+    ),
+    ?assertEqual(<<"gzip">>, h(<<"content-encoding">>, Cap)),
+    ?assertEqual(undefined, h(<<"content-length">>, Cap)),
+    ?assert(has_vary(<<"accept-encoding">>, Cap)),
+    ?assertEqual(
+        <<"chunk-one-chunk-two-chunk-three">>,
+        zlib:gunzip(livery_test_adapter:body(Cap))
+    ).
+
+%%====================================================================
+%% Trailers
+%%====================================================================
+
+full_with_trailers_drops_content_length_test() ->
+    Handler = fun(_R) ->
+        Resp = livery_resp:json(200, ?JSON),
+        livery_resp:with_trailers([{<<"x-checksum">>, <<"abc">>}], Resp)
+    end,
+    Cap = livery_test_adapter:run(
+        [{livery_compress, #{min_size => 0}}],
+        Handler,
+        #{headers => [{<<"accept-encoding">>, <<"gzip">>}]}
+    ),
+    ?assertEqual(<<"gzip">>, h(<<"content-encoding">>, Cap)),
+    ?assertEqual(undefined, h(<<"content-length">>, Cap)),
+    ?assertEqual([{<<"x-checksum">>, <<"abc">>}], livery_test_adapter:trailers(Cap)),
+    ?assertEqual(?JSON, zlib:gunzip(livery_test_adapter:body(Cap))).
+
+%%====================================================================
+%% Registry
+%%====================================================================
+
+codec_registry_default_test() ->
+    ?assertEqual(
+        [livery_codec_gzip, livery_codec_deflate], livery_codec:registered()
+    ).
+
+codec_registry_append_test() ->
+    try
+        ok = livery_codec:register(fake_codec_xyz),
+        R = livery_codec:registered(),
+        ?assertEqual(
+            [livery_codec_gzip, livery_codec_deflate, fake_codec_xyz], R
+        ),
+        %% idempotent
+        ok = livery_codec:register(fake_codec_xyz),
+        ?assertEqual(R, livery_codec:registered()),
+        %% built-ins cannot be displaced
+        ok = livery_codec:register(livery_codec_gzip),
+        ?assertEqual(R, livery_codec:registered())
+    after
+        persistent_term:erase({livery_codec, extras})
+    end.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+run_full(Cfg, Body, ReqHeaders) ->
+    Handler = fun(_R) -> livery_resp:json(200, Body) end,
+    livery_test_adapter:run(
+        [{livery_compress, Cfg}], Handler, #{headers => ReqHeaders}
+    ).
+
+h(Name, Cap) ->
+    livery_test_adapter:header(Name, Cap).
+
+vary_tokens(Cap) ->
+    Values = [V || {<<"vary">>, V} <- livery_test_adapter:headers(Cap)],
+    lists:flatmap(
+        fun(V) ->
+            [normalize_token(T) || T <- binary:split(V, <<",">>, [global])]
+        end,
+        Values
+    ).
+
+has_vary(Token, Cap) ->
+    lists:member(normalize_token(Token), vary_tokens(Cap)).
+
+normalize_token(Token) ->
+    iolist_to_binary(string:trim(string:lowercase(Token))).

--- a/test/livery_interop_SUITE.erl
+++ b/test/livery_interop_SUITE.erl
@@ -1,0 +1,142 @@
+%% @doc External-client interop SUITE for response compression.
+%%
+%% Proves the gzip output is standards-compliant by decoding it with
+%% tools that are NOT the OTP `zlib' encoder: the system `curl' (its own
+%% zlib, via `--compressed') and the system `gzip(1)' CLI. Skips cleanly
+%% when curl or gzip are not on the PATH.
+-module(livery_interop_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([
+    all/0,
+    init_per_suite/1,
+    end_per_suite/1,
+    init_per_testcase/2,
+    end_per_testcase/2
+]).
+
+-export([
+    h1_curl_auto_decompress/1,
+    h1_os_gzip_decode/1,
+    h1_identity_without_accept_encoding/1
+]).
+
+-define(BODY,
+    <<"{\"message\":\"interop body proving any client can decode gzip\",\"items\":[1,2,3,4,5,6,7,8,9,10]}">>
+).
+
+%% H2/H3 gzip is proven by the parity SUITE (real h2/h3 clients decode
+%% the body); the bytes are identical across adapters, so this
+%% external-tool check on H1 establishes standards compliance for all.
+all() ->
+    [
+        h1_curl_auto_decompress,
+        h1_os_gzip_decode,
+        h1_identity_without_accept_encoding
+    ].
+
+init_per_suite(Config) ->
+    case {os:find_executable("curl"), os:find_executable("gzip")} of
+        {false, _} ->
+            {skip, "curl not on PATH"};
+        {_, false} ->
+            {skip, "gzip not on PATH"};
+        {Curl, Gzip} ->
+            {ok, _} = application:ensure_all_started(livery),
+            {ok, _} = application:ensure_all_started(h1),
+            [{curl, Curl}, {gzip, Gzip} | Config]
+    end.
+
+end_per_suite(_Config) ->
+    _ = application:stop(h1),
+    _ = application:stop(livery),
+    ok.
+
+%% Start the H1 listener in the test-case process so it stays reachable
+%% for the duration of the case (a listener tied to init_per_suite is
+%% torn down before the case runs).
+init_per_testcase(_TC, Config) ->
+    {ok, Listener} = livery_h1:start(#{
+        port => 0,
+        stack => [{livery_compress, #{min_size => 0}}],
+        handler => fun(_R) -> livery_resp:json(200, ?BODY) end
+    }),
+    Port = h1:server_port(Listener),
+    [{listener, Listener}, {port, Port} | Config].
+
+end_per_testcase(_TC, Config) ->
+    livery_h1:stop(?config(listener, Config)),
+    ok.
+
+%%====================================================================
+%% H1 cases
+%%====================================================================
+
+h1_curl_auto_decompress(Config) ->
+    %% curl sends Accept-Encoding and auto-decompresses with its own zlib.
+    Url = url(Config),
+    Headers = sh(Config, [curl(Config), "-sS --max-time 15 -D - -o /dev/null --compressed", Url]),
+    ?assert(header_has(Headers, "content-encoding", "gzip")),
+    ?assert(header_has(Headers, "vary", "accept-encoding")),
+    Body = sh(Config, [curl(Config), "-sS --max-time 15 --compressed", Url]),
+    ?assertEqual(?BODY, Body).
+
+h1_os_gzip_decode(Config) ->
+    %% Decode with the OS gzip(1), a different implementation than OTP.
+    Url = url(Config),
+    Cmd = [
+        curl(Config),
+        "-sS --max-time 15 -H 'Accept-Encoding: gzip'",
+        Url,
+        "|",
+        gzip(Config),
+        "-dc"
+    ],
+    ?assertEqual(?BODY, sh(Config, Cmd)).
+
+h1_identity_without_accept_encoding(Config) ->
+    %% No Accept-Encoding: a client that cannot decode gets identity.
+    Url = url(Config),
+    Headers = sh(Config, [curl(Config), "-sS --max-time 15 -D - -o /dev/null", Url]),
+    ?assertNot(header_present(Headers, "content-encoding")),
+    Body = sh(Config, [curl(Config), "-sS", Url]),
+    ?assertEqual(?BODY, Body).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+curl(Config) -> ?config(curl, Config).
+gzip(Config) -> ?config(gzip, Config).
+
+url(Config) ->
+    "http://127.0.0.1:" ++ integer_to_list(?config(port, Config)) ++ "/".
+
+sh(_Config, Parts) ->
+    Cmd = lists:flatten(lists:join(" ", Parts)),
+    iolist_to_binary(os:cmd(Cmd)).
+
+%% Header dump from `curl -D -' is CRLF-delimited "Name: Value" lines.
+header_present(Dump, NameLower) ->
+    lists:any(
+        fun(Line) -> is_header_line(Line, NameLower) end,
+        header_lines(Dump)
+    ).
+
+header_has(Dump, NameLower, ValueLower) ->
+    lists:any(
+        fun(Line) ->
+            is_header_line(Line, NameLower) andalso
+                string:find(string:lowercase(Line), ValueLower) =/= nomatch
+        end,
+        header_lines(Dump)
+    ).
+
+header_lines(Dump) ->
+    string:split(binary_to_list(Dump), "\n", all).
+
+is_header_line(Line, NameLower) ->
+    Lower = string:lowercase(string:trim(Line)),
+    string:prefix(Lower, NameLower ++ ":") =/= nomatch.

--- a/test/livery_parity_SUITE.erl
+++ b/test/livery_parity_SUITE.erl
@@ -38,7 +38,9 @@
     handler_crash_returns_500/1,
     middleware_short_circuit/1,
     middleware_after_response/1,
-    full_pipeline_with_builtins/1
+    full_pipeline_with_builtins/1,
+    gzip_negotiation/1,
+    gzip_with_trailers/1
 ]).
 
 %%====================================================================
@@ -61,7 +63,9 @@ groups() ->
         handler_crash_returns_500,
         middleware_short_circuit,
         middleware_after_response,
-        full_pipeline_with_builtins
+        full_pipeline_with_builtins,
+        gzip_negotiation,
+        gzip_with_trailers
     ],
     [
         {test_adapter, [parallel], Shared ++ [response_with_trailers]},
@@ -326,6 +330,47 @@ full_pipeline_with_builtins(Config) ->
     ?assert(is_binary(Id)),
     ?assertEqual(32, byte_size(Id)).
 
+gzip_negotiation(Config) ->
+    Body = <<"{\"message\":\"compress me across every adapter\",\"items\":[1,2,3,4,5]}">>,
+    Stack = [{livery_compress, #{min_size => 0}}],
+    Resp = drive(
+        Config,
+        Stack,
+        fun(_R) -> livery_resp:json(200, Body) end,
+        #{headers => [{<<"accept-encoding">>, <<"gzip">>}]}
+    ),
+    ?assertEqual(200, status(Resp)),
+    ?assertEqual(<<"gzip">>, header(<<"content-encoding">>, Resp)),
+    %% Decode the wire bytes with an independent zlib call: identical on
+    %% test_adapter, h1, h2, h3.
+    ?assertEqual(Body, zlib:gunzip(body(Resp))).
+
+gzip_with_trailers(Config) ->
+    Body = <<"{\"k\":\"trailer body that is gzip compressed on the wire\"}">>,
+    Stack = [{livery_compress, #{min_size => 0}}],
+    Handler = fun(_R) ->
+        Resp0 = livery_resp:json(200, Body),
+        livery_resp:with_trailers([{<<"x-checksum">>, <<"abc">>}], Resp0)
+    end,
+    Resp = drive(
+        Config,
+        Stack,
+        Handler,
+        #{headers => [{<<"accept-encoding">>, <<"gzip">>}]}
+    ),
+    ?assertEqual(<<"gzip">>, header(<<"content-encoding">>, Resp)),
+    %% No Content-Length: H1 must stay chunked so send_trailers works;
+    %% H2/H3 send trailers as a HEADERS frame. The body must still gunzip
+    %% (a broken send_trailers would truncate/reset the stream).
+    ?assertEqual(undefined, header(<<"content-length">>, Resp)),
+    ?assertEqual(Body, zlib:gunzip(body(Resp))),
+    %% Drivers that surface trailers (test_adapter/h2/h3) also check them;
+    %% the h1 driver returns undefined trailers (hackney drops them).
+    case trailers(Resp) of
+        undefined -> ok;
+        T -> ?assertEqual([{<<"x-checksum">>, <<"abc">>}], T)
+    end.
+
 %%====================================================================
 %% Uniform driver API: returns a `response()' tuple
 %%====================================================================
@@ -390,11 +435,12 @@ drive_h1(Stack, Handler, Spec) ->
             integer_to_binary(Port),
             <<"/">>
         ]),
-        Headers =
+        Base =
             case byte_size(Body) of
                 0 -> [];
                 _ -> [{<<"content-length">>, integer_to_binary(byte_size(Body))}]
             end,
+        Headers = Base ++ maps:get(headers, Spec, []),
         {ok, Status, RespHeaders, RespBody} =
             hackney:request(
                 Method,
@@ -430,7 +476,8 @@ drive_h2(Stack, Handler, Spec) ->
         Port = h2:server_port(Listener),
         {ok, Conn} = h2:connect("127.0.0.1", Port, #{transport => tcp}),
         try
-            Headers = [{<<"host">>, <<"127.0.0.1">>}],
+            Headers =
+                [{<<"host">>, <<"127.0.0.1">>}] ++ maps:get(headers, Spec, []),
             HasBody = byte_size(Body) > 0,
             {ok, StreamId} =
                 case HasBody of
@@ -508,12 +555,13 @@ drive_h3(Cert, Key, Stack, Handler, Spec) ->
             #{verify => verify_none, sync => true}
         ),
         try
-            Headers = [
-                {<<":method">>, Method},
-                {<<":path">>, <<"/">>},
-                {<<":scheme">>, <<"https">>},
-                {<<":authority">>, <<"localhost">>}
-            ],
+            Headers =
+                [
+                    {<<":method">>, Method},
+                    {<<":path">>, <<"/">>},
+                    {<<":scheme">>, <<"https">>},
+                    {<<":authority">>, <<"localhost">>}
+                ] ++ maps:get(headers, Spec, []),
             HasBody = byte_size(Body) > 0,
             StreamId =
                 case HasBody of


### PR DESCRIPTION
## Summary
- `livery_compress`: negotiates `Accept-Encoding` (server-preference-wins, `q` as accept/reject filter, case-insensitive) and compresses `{full, _}` (>= `min_size`) and `{chunked, _}` bodies for compressible, not-already-encoded content types. Sets `Content-Encoding` and a cache-correct `Vary: Accept-Encoding`; drops `Content-Length` when trailers are present so H1 stays chunked.
- `livery_codec` behaviour + persistent_term registry; `livery_codec_gzip` and `livery_codec_deflate` built in over OTP `zlib` (shared `livery_codec_zlib` helper). A separate app can register a codec (`livery_codec:register/1`) and be negotiated automatically.
- `livery_resp:with_body/2` lets middleware rewrite a body.
- Cross-adapter parity (`gzip_negotiation`, `gzip_with_trailers` on H1/H2/H3) plus an external-client interop suite (curl `--compressed` and the OS `gzip` decoder, identity fallback) prove standards-compliant output that any client decodes.

Resolves backlog item #3 (gzip + deflate). brotli (`livery_brotli`) and zstd (`livery_zstd`) follow as separate codec apps implementing the same behaviour.