### PR TITLE
Add multipart and streaming form-body parsing

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -5,7 +5,7 @@ sibling library that owns the change.
 
 ## Framework-gap backlog (from the audit)
 
-Modern web/AI framework gaps, in priority order. Steps 1-3 are done.
+Modern web/AI framework gaps, in priority order. Steps 1-4 are done.
 
 1. Cancel on client disconnect. DONE: `livery_req:on_disconnect/2`
    plus the `{livery_disconnect, _, _}` message, delivered across
@@ -22,7 +22,11 @@ Modern web/AI framework gaps, in priority order. Steps 1-3 are done.
    PRs, link system libs): `livery_brotli` (NIF, `br`) and
    `livery_zstd` (cmake NIF, `zstd`) implement the same behaviour and
    self-register via `livery_codec:register/1`.
-4. Multipart / form-data body parsing (uploads, multimodal).
+4. Multipart / form-data body parsing (uploads, multimodal). DONE:
+   `livery_multipart` (streaming pull parser + `read_all`, bounded
+   buffering, filename returned verbatim) and `livery_ext:read_form/1,2`
+   (streaming urlencoded). See `docs/guides/handle-file-uploads.md` and
+   `docs/guides/parse-form-bodies.md`.
 5. Concurrency limit / load-shedding middleware (admission control).
 6. Security-headers middleware (HSTS/CSP/etc). DONE:
    `livery_security_headers` (nosniff, frame options, referrer policy,

--- a/docs/guides/handle-file-uploads.md
+++ b/docs/guides/handle-file-uploads.md
@@ -1,0 +1,82 @@
+# How to handle file uploads (multipart/form-data)
+
+## Problem
+
+A client POSTs `multipart/form-data` (a browser form with files, or a
+multimodal request) and you need the fields and uploaded files without
+buffering the whole request in memory.
+
+## Solution
+
+Use `livery_multipart`. Pull parts one at a time and stream each part's
+body, so a large upload never sits in RAM:
+
+```erlang
+upload(Req) ->
+    {ok, MP0} = livery_multipart:new(Req),
+    loop(MP0).
+
+loop(MP) ->
+    case livery_multipart:next_part(MP, 5000) of
+        {part, #{name := Name, filename := File}, MP1} ->
+            {ok, MP2} = consume(MP1, Name, File),
+            loop(MP2);
+        {done, _MP1} ->
+            livery_resp:text(200, <<"ok">>);
+        {error, Reason, _MP1} ->
+            livery_resp:text(400, atom_to_binary(element(1, {Reason, x})))
+    end.
+
+consume(MP, _Name, _File) ->
+    case livery_multipart:read_part(MP, 5000) of
+        {ok, Chunk, MP1} -> %% write Chunk to disk / forward / hash
+            consume(MP1, _Name, _File);
+        {done, MP1} -> {ok, MP1};
+        {error, _, MP1} -> {ok, MP1}
+    end.
+```
+
+`next_part/2` returns each part's `name`, `filename`, `content_type`,
+and raw `headers` (parsed from `Content-Disposition`). `read_part/2`
+streams that part's bytes; calling `next_part` again skips any unread
+remainder.
+
+## Small forms: read everything at once
+
+When the parts are small, `read_all/1,2` collects them into memory under
+the limits:
+
+```erlang
+{ok, Parts} = livery_multipart:read_all(Req),
+%% Parts :: [#{name, filename, content_type, headers, body}]
+```
+
+## Limits
+
+All buffering is bounded. Override the defaults via the options map on
+`new/2` / `read_all/2`:
+
+```erlang
+livery_multipart:read_all(Req, #{
+    max_parts => 50,             %% default 1000
+    max_part_size => 5_242_880,  %% read_all per-part bytes; default 10 MiB
+    max_header_bytes => 16_384,  %% per-part header block; default 64 KiB
+    max_header_count => 32,      %% header fields per part; default 64
+    max_body => 52_428_800,      %% total bytes consumed; default 100 MiB
+    part_timeout => 5000         %% per read; default 5000 ms
+}).
+```
+
+## Security: sanitize the filename
+
+`filename` is returned exactly as the client sent it and the parser
+never touches the filesystem. A hostile client can send
+`../../etc/passwd`. If you write uploads to disk, confine the path
+yourself (basename + a fixed directory); never join the raw `filename`
+onto a path.
+
+## See also
+
+- Reference: `livery_multipart`, `livery_body`
+- Recipe: [Parse form bodies](parse-form-bodies.md)
+- Recipe: [Read a streaming request body](read-streaming-body.md)

--- a/docs/guides/parse-form-bodies.md
+++ b/docs/guides/parse-form-bodies.md
@@ -1,0 +1,51 @@
+# How to parse form bodies and query strings
+
+## Problem
+
+You need the fields from an `application/x-www-form-urlencoded` request
+body, or the parameters from the URL query string.
+
+## Query string
+
+`livery_ext:query/2` pulls a single decoded parameter from the request
+URI:
+
+```erlang
+search(Req) ->
+    Term = livery_ext:query(<<"q">>, Req),     %% percent-decoded, or undefined
+    ...
+```
+
+## Form body (urlencoded)
+
+If the body is already buffered, `livery_ext:form/1` decodes it
+directly. Since adapters stream bodies by default, use `read_form/1,2`,
+which drains the stream (bounded) and decodes:
+
+```erlang
+submit(Req) ->
+    case livery_ext:read_form(Req) of
+        {ok, Pairs} ->            %% [{<<"name">>, <<"value">>}, ...]
+            Name = proplists:get_value(<<"name">>, Pairs),
+            ...;
+        {error, not_form} ->
+            livery_resp:text(415, <<"expected a form body">>);
+        {error, _} ->
+            livery_resp:text(400, <<"bad form body">>)
+    end.
+```
+
+The `Content-Type` check is case-insensitive and tolerates parameters
+(`Application/X-WWW-Form-Urlencoded; charset=utf-8`). Cap the body with
+`#{max_size => Bytes}` (default 1 MiB) and the per-read wait with
+`#{timeout => Ms}`.
+
+Decoding handles `%XX` escapes and `+` as space. A malformed escape
+(`%ZZ`) is kept verbatim rather than failing the whole body, matching
+`form/1`.
+
+## See also
+
+- Reference: `livery_ext`
+- Recipe: [Handle file uploads](handle-file-uploads.md)
+- Recipe: [Read query strings](read-query-strings.md)

--- a/rebar.config
+++ b/rebar.config
@@ -76,6 +76,8 @@
         {"docs/guides/mount-a-router.md", #{title => <<"Mount a router on a service">>}},
         {"docs/guides/parse-json-bodies.md", #{title => <<"Parse a JSON body">>}},
         {"docs/guides/read-query-strings.md", #{title => <<"Read query strings">>}},
+        {"docs/guides/parse-form-bodies.md", #{title => <<"Parse form bodies">>}},
+        {"docs/guides/handle-file-uploads.md", #{title => <<"Handle file uploads">>}},
         {"docs/guides/read-headers.md", #{title => <<"Read headers">>}},
         {"docs/guides/bearer-tokens.md", #{title => <<"Extract a bearer token">>}},
         {"docs/guides/token-introspection.md", #{
@@ -137,6 +139,8 @@
             <<"docs/guides/mount-a-router.md">>,
             <<"docs/guides/parse-json-bodies.md">>,
             <<"docs/guides/read-query-strings.md">>,
+            <<"docs/guides/parse-form-bodies.md">>,
+            <<"docs/guides/handle-file-uploads.md">>,
             <<"docs/guides/read-headers.md">>,
             <<"docs/guides/bearer-tokens.md">>,
             <<"docs/guides/token-introspection.md">>,
@@ -180,7 +184,12 @@
     ]},
     {groups_for_modules, [
         {<<"Public API">>, [livery]},
-        {<<"Request and response">>, [livery_req, livery_resp, livery_ext]},
+        {<<"Request and response">>, [
+            livery_req,
+            livery_resp,
+            livery_ext,
+            livery_multipart
+        ]},
         {<<"Routing and middleware">>, [livery_router, livery_middleware]},
         {<<"Built-in middleware">>, [
             livery_request_id,

--- a/src/livery_ext.erl
+++ b/src/livery_ext.erl
@@ -16,6 +16,8 @@ when the route is configured for buffered intake).
 -export([
     json/1,
     form/1,
+    read_form/1,
+    read_form/2,
     path_param/2,
     query/2,
     header/2,
@@ -27,10 +29,16 @@ when the route is configured for buffered intake).
     session/2
 ]).
 
--export_type([json_error/0, form_error/0]).
+-export_type([json_error/0, form_error/0, read_form_error/0]).
 
 -type json_error() :: no_body | invalid_json | not_buffered.
 -type form_error() :: no_body | not_buffered.
+-type read_form_error() ::
+    not_form
+    | no_body
+    | {limit, max_size}
+    | {client_reset, term()}
+    | timeout.
 
 %%====================================================================
 %% Body extractors
@@ -67,6 +75,81 @@ form(#livery_req{body = {buffered, IoData}}) ->
     {ok, decode_form(iolist_to_binary(IoData))};
 form(#livery_req{body = {stream, _}}) ->
     {error, not_buffered}.
+
+-doc """
+Decode an `application/x-www-form-urlencoded` body, draining the stream.
+
+Unlike `form/1` (which requires an already-buffered body), this reads a
+streaming body to completion (bounded by `max_size`, default 1 MiB) and
+decodes it. A buffered body is decoded directly. The Content-Type check
+is case-insensitive and parameter-tolerant. Malformed percent escapes
+are preserved verbatim (same decoder as `form/1`).
+""".
+-spec read_form(livery_req:req()) ->
+    {ok, [{binary(), binary()}]} | {error, read_form_error()}.
+read_form(Req) ->
+    read_form(Req, #{}).
+
+-doc "`read_form/1` with `#{max_size => Bytes, timeout => Ms}` options.".
+-spec read_form(livery_req:req(), map()) ->
+    {ok, [{binary(), binary()}]} | {error, read_form_error()}.
+read_form(Req, Opts) ->
+    case is_urlencoded(Req) of
+        false ->
+            {error, not_form};
+        true ->
+            MaxSize = maps:get(max_size, Opts, 1048576),
+            Timeout = maps:get(timeout, Opts, 5000),
+            read_form_body(livery_req:body(Req), MaxSize, Timeout)
+    end.
+
+-spec read_form_body(
+    empty | {buffered, iodata()} | {stream, term()},
+    pos_integer(),
+    timeout()
+) -> {ok, [{binary(), binary()}]} | {error, read_form_error()}.
+read_form_body(empty, _MaxSize, _Timeout) ->
+    {error, no_body};
+read_form_body({buffered, IoData}, MaxSize, _Timeout) ->
+    Bin = iolist_to_binary(IoData),
+    case byte_size(Bin) > MaxSize of
+        true -> {error, {limit, max_size}};
+        false -> {ok, decode_form(Bin)}
+    end;
+read_form_body({stream, Reader}, MaxSize, Timeout) ->
+    case drain(Reader, Timeout, MaxSize, []) of
+        {ok, Bin} -> {ok, decode_form(Bin)};
+        {error, Reason} -> {error, Reason}
+    end.
+
+-spec is_urlencoded(livery_req:req()) -> boolean().
+is_urlencoded(Req) ->
+    case livery_req:header(<<"content-type">>, Req) of
+        undefined -> false;
+        Value -> normalize_ct(Value) =:= <<"application/x-www-form-urlencoded">>
+    end.
+
+-spec normalize_ct(binary()) -> binary().
+normalize_ct(Value) ->
+    Lower = iolist_to_binary(string:lowercase(Value)),
+    [Main | _] = binary:split(Lower, <<";">>),
+    iolist_to_binary(string:trim(Main)).
+
+-spec drain(term(), timeout(), pos_integer(), [iodata()]) ->
+    {ok, binary()} | {error, read_form_error()}.
+drain(Reader, Timeout, MaxSize, Acc) ->
+    case livery_body:read(Reader, Timeout) of
+        {ok, Chunk, Reader1} ->
+            Acc1 = [Chunk | Acc],
+            case iolist_size(Acc1) > MaxSize of
+                true -> {error, {limit, max_size}};
+                false -> drain(Reader1, Timeout, MaxSize, Acc1)
+            end;
+        {done, _Reader1} ->
+            {ok, iolist_to_binary(lists:reverse(Acc))};
+        {error, Reason, _Reader1} ->
+            {error, Reason}
+    end.
 
 %%====================================================================
 %% Path, query, header, auth

--- a/src/livery_multipart.erl
+++ b/src/livery_multipart.erl
@@ -1,0 +1,567 @@
+-module(livery_multipart).
+-moduledoc """
+Streaming `multipart/form-data` parser (RFC 7578).
+
+Sits on the request body reader (`livery_body`) and works over both
+streamed (`{stream, _}`) and buffered (`{buffered, _}`) bodies. Pull the
+parts one at a time:
+
+```erlang
+{ok, MP0} = livery_multipart:new(Req),
+case livery_multipart:next_part(MP0, 5000) of
+    {part, #{name := Name, filename := File}, MP1} ->
+        %% drain this part's body incrementally
+        drain(MP1);
+    {done, _} -> ok
+end.
+```
+
+`read_all/1,2` is a convenience that collects every part fully into
+memory under the configured limits.
+
+Security: the parser bounds all buffering (`max_header_bytes`,
+`max_header_count`, `max_parts`, `max_part_size`, `max_body`) and never
+touches the filesystem. A part's `filename` is returned verbatim; a
+handler MUST confine/sanitize it before using it as a path.
+""".
+
+-include("livery.hrl").
+
+-export([
+    new/1,
+    new/2,
+    next_part/1,
+    next_part/2,
+    read_part/2,
+    read_all/1,
+    read_all/2
+]).
+
+-export_type([mp/0, part/0, part_full/0, opts/0, reason/0]).
+
+-record(mp, {
+    reader :: livery_body:reader() | undefined,
+    dash :: binary(),
+    crlfdash :: binary(),
+    buffer = <<>> :: binary(),
+    state = start :: start | after_boundary | body | closed,
+    opts :: opts(),
+    timeout = 5000 :: timeout(),
+    consumed = 0 :: non_neg_integer(),
+    parts = 0 :: non_neg_integer()
+}).
+
+-opaque mp() :: #mp{}.
+
+-type opts() :: #{
+    part_timeout => timeout(),
+    max_parts => pos_integer(),
+    max_header_bytes => pos_integer(),
+    max_header_count => pos_integer(),
+    max_part_size => pos_integer(),
+    max_body => pos_integer()
+}.
+
+-type part() :: #{
+    name := binary() | undefined,
+    filename := binary() | undefined,
+    content_type := binary() | undefined,
+    headers := [{binary(), binary()}]
+}.
+
+-type part_full() :: #{
+    name := binary() | undefined,
+    filename := binary() | undefined,
+    content_type := binary() | undefined,
+    headers := [{binary(), binary()}],
+    body := binary()
+}.
+
+-type reason() ::
+    malformed
+    | {client_reset, term()}
+    | timeout
+    | {limit,
+        max_parts
+        | max_header_bytes
+        | max_header_count
+        | max_part_size
+        | max_body}.
+
+-define(CRLF, <<"\r\n">>).
+
+%%====================================================================
+%% Construction
+%%====================================================================
+
+-doc "Build a parser from a request. Reads the boundary from Content-Type.".
+-spec new(livery_req:req()) -> {ok, mp()} | {error, not_multipart | no_boundary}.
+new(Req) ->
+    new(Req, #{}).
+
+-doc "`new/1` with parser options.".
+-spec new(livery_req:req(), opts()) ->
+    {ok, mp()} | {error, not_multipart | no_boundary}.
+new(Req, Opts0) ->
+    Opts = maps:merge(default_opts(), Opts0),
+    case livery_req:header(<<"content-type">>, Req) of
+        undefined ->
+            {error, not_multipart};
+        Value ->
+            case multipart_boundary(Value) of
+                {ok, Boundary} -> {ok, init_mp(Req, Boundary, Opts)};
+                {error, R} -> {error, R}
+            end
+    end.
+
+-spec init_mp(livery_req:req(), binary(), opts()) -> mp().
+init_mp(Req, Boundary, Opts) ->
+    {Buffer, Reader, Consumed} = source(Req),
+    #mp{
+        reader = Reader,
+        dash = <<"--", Boundary/binary>>,
+        crlfdash = <<"\r\n--", Boundary/binary>>,
+        buffer = Buffer,
+        opts = Opts,
+        timeout = maps:get(part_timeout, Opts),
+        consumed = Consumed
+    }.
+
+-spec source(livery_req:req()) ->
+    {binary(), livery_body:reader() | undefined, non_neg_integer()}.
+source(Req) ->
+    case livery_req:body(Req) of
+        empty ->
+            {<<>>, undefined, 0};
+        {buffered, IoData} ->
+            Bin = iolist_to_binary(IoData),
+            {Bin, undefined, byte_size(Bin)};
+        {stream, Reader} ->
+            {<<>>, Reader, 0}
+    end.
+
+%%====================================================================
+%% Streaming API
+%%====================================================================
+
+-doc "Advance to the next part, returning its parsed metadata.".
+-spec next_part(mp()) -> {part, part(), mp()} | {done, mp()} | {error, reason(), mp()}.
+next_part(MP) ->
+    next_part(MP, MP#mp.timeout).
+
+-doc "`next_part/1` with an explicit per-chunk timeout.".
+-spec next_part(mp(), timeout()) ->
+    {part, part(), mp()} | {done, mp()} | {error, reason(), mp()}.
+next_part(#mp{} = MP0, Timeout) ->
+    MP = MP0#mp{timeout = Timeout},
+    case max_body_ok(MP) of
+        false -> {error, {limit, max_body}, MP};
+        true -> advance(MP)
+    end.
+
+-spec advance(mp()) -> {part, part(), mp()} | {done, mp()} | {error, reason(), mp()}.
+advance(#mp{state = closed} = MP) ->
+    {done, MP};
+advance(#mp{state = start} = MP) ->
+    case start_scan(MP) of
+        {ok, MP1} -> at_boundary(MP1);
+        {done, MP1} -> {done, MP1};
+        {error, R, MP1} -> {error, R, MP1}
+    end;
+advance(#mp{state = body} = MP) ->
+    case skip_body(MP) of
+        {ok, MP1} -> at_boundary(MP1);
+        {error, R, MP1} -> {error, R, MP1}
+    end;
+advance(#mp{state = after_boundary} = MP) ->
+    at_boundary(MP).
+
+%% Positioned right after a `--boundary` token: decide closing vs a part.
+-spec at_boundary(mp()) ->
+    {part, part(), mp()} | {done, mp()} | {error, reason(), mp()}.
+at_boundary(MP0) ->
+    case ensure(MP0, 2) of
+        {ok, MP} ->
+            case MP#mp.buffer of
+                <<"--", _/binary>> ->
+                    {done, MP#mp{state = closed, buffer = <<>>}};
+                _ ->
+                    start_part(MP)
+            end;
+        {eof, MP} ->
+            %% boundary not followed by anything: tolerate as closing.
+            {done, MP#mp{state = closed, buffer = <<>>}};
+        {error, R, MP} ->
+            {error, R, MP}
+    end.
+
+-spec start_part(mp()) -> {part, part(), mp()} | {error, reason(), mp()}.
+start_part(MP0) ->
+    MaxParts = maps:get(max_parts, MP0#mp.opts),
+    case MP0#mp.parts + 1 > MaxParts of
+        true ->
+            {error, {limit, max_parts}, MP0};
+        false ->
+            %% consume the rest of the boundary line (transport padding)
+            case read_line(MP0, maps:get(max_header_bytes, MP0#mp.opts)) of
+                {line, _Padding, MP1} -> read_part_headers(MP1);
+                {error, R, MP1} -> {error, R, MP1}
+            end
+    end.
+
+-spec read_part_headers(mp()) -> {part, part(), mp()} | {error, reason(), mp()}.
+read_part_headers(MP0) ->
+    Max = maps:get(max_header_bytes, MP0#mp.opts),
+    MaxCount = maps:get(max_header_count, MP0#mp.opts),
+    case headers_loop(MP0, [], 0, Max, MaxCount) of
+        {ok, Headers, MP1} ->
+            Part = build_part(Headers),
+            {part, Part, MP1#mp{state = body, parts = MP1#mp.parts + 1}};
+        {error, R, MP1} ->
+            {error, R, MP1}
+    end.
+
+-spec headers_loop(mp(), [{binary(), binary()}], non_neg_integer(), pos_integer(), pos_integer()) ->
+    {ok, [{binary(), binary()}], mp()} | {error, reason(), mp()}.
+headers_loop(MP0, Acc, Bytes, Max, MaxCount) ->
+    case read_line(MP0, Max) of
+        {line, <<>>, MP1} ->
+            {ok, lists:reverse(Acc), MP1};
+        {line, Line, MP1} ->
+            NewBytes = Bytes + byte_size(Line) + 2,
+            check_header_line(MP1, Acc, Line, NewBytes, Max, MaxCount);
+        {error, R, MP1} ->
+            {error, R, MP1}
+    end.
+
+-spec check_header_line(
+    mp(), [{binary(), binary()}], binary(), non_neg_integer(), pos_integer(), pos_integer()
+) -> {ok, [{binary(), binary()}], mp()} | {error, reason(), mp()}.
+check_header_line(MP, _Acc, _Line, NewBytes, Max, _MaxCount) when NewBytes > Max ->
+    {error, {limit, max_header_bytes}, MP};
+check_header_line(MP, Acc, _Line, _NewBytes, _Max, MaxCount) when
+    length(Acc) + 1 > MaxCount
+->
+    {error, {limit, max_header_count}, MP};
+check_header_line(MP, Acc, Line, NewBytes, Max, MaxCount) ->
+    case parse_header(Line) of
+        {ok, KV} -> headers_loop(MP, [KV | Acc], NewBytes, Max, MaxCount);
+        error -> {error, malformed, MP}
+    end.
+
+-doc "Read the next chunk of the current part body.".
+-spec read_part(mp(), timeout()) ->
+    {ok, binary(), mp()} | {done, mp()} | {error, reason(), mp()}.
+read_part(#mp{state = body} = MP0, Timeout) ->
+    body_chunk(MP0#mp{timeout = Timeout});
+read_part(#mp{} = MP, _Timeout) ->
+    {done, MP}.
+
+-spec body_chunk(mp()) -> {ok, binary(), mp()} | {done, mp()} | {error, reason(), mp()}.
+body_chunk(#mp{buffer = Buf, crlfdash = Needle} = MP) ->
+    case binary:match(Buf, Needle) of
+        {Pos, Len} ->
+            <<Body:Pos/binary, _:Len/binary, Rest/binary>> = Buf,
+            MP1 = MP#mp{buffer = Rest, state = after_boundary},
+            case Pos of
+                0 -> {done, MP1};
+                _ -> {ok, Body, MP1}
+            end;
+        nomatch ->
+            HoldBack = byte_size(MP#mp.crlfdash) - 1,
+            case byte_size(Buf) > HoldBack of
+                true ->
+                    Emit = binary:part(Buf, 0, byte_size(Buf) - HoldBack),
+                    Keep = binary:part(Buf, byte_size(Buf) - HoldBack, HoldBack),
+                    {ok, Emit, MP#mp{buffer = Keep}};
+                false ->
+                    case pull(MP) of
+                        {ok, MP1} -> body_chunk(MP1);
+                        {eof, MP1} -> {error, malformed, MP1};
+                        {error, R, MP1} -> {error, R, MP1}
+                    end
+            end
+    end.
+
+-spec skip_body(mp()) -> {ok, mp()} | {error, reason(), mp()}.
+skip_body(MP0) ->
+    case read_part(MP0, MP0#mp.timeout) of
+        {ok, _Chunk, MP1} -> skip_body(MP1);
+        {done, MP1} -> {ok, MP1};
+        {error, R, MP1} -> {error, R, MP1}
+    end.
+
+%%====================================================================
+%% Buffered convenience
+%%====================================================================
+
+-doc "Collect every part fully into memory under the configured limits.".
+-spec read_all(livery_req:req()) -> {ok, [part_full()]} | {error, reason()}.
+read_all(Req) ->
+    read_all(Req, #{}).
+
+-doc "`read_all/1` with parser options.".
+-spec read_all(livery_req:req(), opts()) -> {ok, [part_full()]} | {error, reason()}.
+read_all(Req, Opts) ->
+    case new(Req, Opts) of
+        {error, R} -> {error, R};
+        {ok, MP} -> collect(MP, [])
+    end.
+
+-spec collect(mp(), [part_full()]) -> {ok, [part_full()]} | {error, reason()}.
+collect(MP0, Acc) ->
+    case next_part(MP0) of
+        {done, _MP1} ->
+            {ok, lists:reverse(Acc)};
+        {error, R, _MP1} ->
+            {error, R};
+        {part, Part, MP1} ->
+            Max = maps:get(max_part_size, MP1#mp.opts),
+            case collect_body(MP1, [], 0, Max) of
+                {ok, Body, MP2} ->
+                    collect(MP2, [Part#{body => Body} | Acc]);
+                {error, R, _MP2} ->
+                    {error, R}
+            end
+    end.
+
+-spec collect_body(mp(), [binary()], non_neg_integer(), pos_integer()) ->
+    {ok, binary(), mp()} | {error, reason(), mp()}.
+collect_body(MP0, Acc, Size, Max) ->
+    case read_part(MP0, MP0#mp.timeout) of
+        {ok, Chunk, MP1} ->
+            Size1 = Size + byte_size(Chunk),
+            case Size1 > Max of
+                true -> {error, {limit, max_part_size}, MP1};
+                false -> collect_body(MP1, [Chunk | Acc], Size1, Max)
+            end;
+        {done, MP1} ->
+            {ok, iolist_to_binary(lists:reverse(Acc)), MP1};
+        {error, R, MP1} ->
+            {error, R, MP1}
+    end.
+
+%%====================================================================
+%% Scanning primitives
+%%====================================================================
+
+%% Skip the preamble, locate the first `--boundary`, position after it.
+-spec start_scan(mp()) -> {ok, mp()} | {done, mp()} | {error, reason(), mp()}.
+start_scan(#mp{buffer = Buf, dash = Dash} = MP) ->
+    case binary:match(Buf, Dash) of
+        {Pos, Len} ->
+            Rest = binary:part(Buf, Pos + Len, byte_size(Buf) - Pos - Len),
+            {ok, MP#mp{buffer = Rest, state = after_boundary}};
+        nomatch ->
+            HoldBack = byte_size(Dash) - 1,
+            Keep = tail(Buf, HoldBack),
+            case pull(MP#mp{buffer = Keep}) of
+                {ok, MP1} ->
+                    start_scan(MP1);
+                {eof, MP1} ->
+                    case MP1#mp.consumed of
+                        0 -> {done, MP1#mp{state = closed}};
+                        _ -> {error, malformed, MP1}
+                    end;
+                {error, R, MP1} ->
+                    {error, R, MP1}
+            end
+    end.
+
+%% Read one CRLF-terminated line, returning the content before the CRLF.
+-spec read_line(mp(), integer()) -> {line, binary(), mp()} | {error, reason(), mp()}.
+read_line(#mp{buffer = Buf} = MP, MaxBytes) ->
+    case binary:match(Buf, ?CRLF) of
+        {Pos, Len} ->
+            <<Line:Pos/binary, _:Len/binary, Rest/binary>> = Buf,
+            {line, Line, MP#mp{buffer = Rest}};
+        nomatch ->
+            case byte_size(Buf) > MaxBytes of
+                true ->
+                    {error, {limit, max_header_bytes}, MP};
+                false ->
+                    case pull(MP) of
+                        {ok, MP1} -> read_line(MP1, MaxBytes);
+                        {eof, MP1} -> {error, malformed, MP1};
+                        {error, R, MP1} -> {error, R, MP1}
+                    end
+            end
+    end.
+
+%% Ensure at least N bytes are buffered (or EOF/error).
+-spec ensure(mp(), non_neg_integer()) -> {ok, mp()} | {eof, mp()} | {error, reason(), mp()}.
+ensure(#mp{buffer = Buf} = MP, N) when byte_size(Buf) >= N ->
+    {ok, MP};
+ensure(MP, N) ->
+    case pull(MP) of
+        {ok, MP1} -> ensure(MP1, N);
+        {eof, MP1} -> {eof, MP1};
+        {error, R, MP1} -> {error, R, MP1}
+    end.
+
+%% Read one chunk from the source into the buffer.
+-spec pull(mp()) -> {ok, mp()} | {eof, mp()} | {error, reason(), mp()}.
+pull(#mp{reader = undefined} = MP) ->
+    {eof, MP};
+pull(#mp{reader = Reader, timeout = Timeout, buffer = Buf, consumed = Consumed} = MP) ->
+    case livery_body:read(Reader, Timeout) of
+        {ok, Chunk, Reader1} ->
+            Bin = iolist_to_binary(Chunk),
+            MP1 = MP#mp{
+                reader = Reader1,
+                buffer = <<Buf/binary, Bin/binary>>,
+                consumed = Consumed + byte_size(Bin)
+            },
+            case max_body_ok(MP1) of
+                true -> {ok, MP1};
+                false -> {error, {limit, max_body}, MP1}
+            end;
+        {done, Reader1} ->
+            {eof, MP#mp{reader = Reader1}};
+        {error, Error, Reader1} ->
+            {error, normalize_error(Error), MP#mp{reader = Reader1}}
+    end.
+
+-spec max_body_ok(mp()) -> boolean().
+max_body_ok(#mp{consumed = C, opts = Opts}) ->
+    C =< maps:get(max_body, Opts).
+
+-spec normalize_error(timeout | {client_reset, term()}) -> reason().
+normalize_error(timeout) -> timeout;
+normalize_error({client_reset, _} = E) -> E.
+
+-spec tail(binary(), non_neg_integer()) -> binary().
+tail(Bin, N) when byte_size(Bin) =< N -> Bin;
+tail(Bin, N) -> binary:part(Bin, byte_size(Bin) - N, N).
+
+%%====================================================================
+%% Header / part parsing
+%%====================================================================
+
+-spec parse_header(binary()) -> {ok, {binary(), binary()}} | error.
+parse_header(Line) ->
+    case has_control(Line) of
+        true ->
+            error;
+        false ->
+            case binary:split(Line, <<":">>) of
+                [Name, Value] when Name =/= <<>> ->
+                    {ok, {downcase(trim(Name)), trim(Value)}};
+                _ ->
+                    error
+            end
+    end.
+
+-spec build_part([{binary(), binary()}]) -> part().
+build_part(Headers) ->
+    {Name, Filename} =
+        case lists:keyfind(<<"content-disposition">>, 1, Headers) of
+            {_, CD} -> disposition(CD);
+            false -> {undefined, undefined}
+        end,
+    CType =
+        case lists:keyfind(<<"content-type">>, 1, Headers) of
+            {_, CT} -> CT;
+            false -> undefined
+        end,
+    #{
+        name => Name,
+        filename => Filename,
+        content_type => CType,
+        headers => Headers
+    }.
+
+-spec disposition(binary()) -> {binary() | undefined, binary() | undefined}.
+disposition(Value) ->
+    Params = params(Value),
+    {param(<<"name">>, Params), param(<<"filename">>, Params)}.
+
+-spec param(binary(), [{binary(), binary()}]) -> binary() | undefined.
+param(Key, Params) ->
+    case lists:keyfind(Key, 1, Params) of
+        {_, V} -> V;
+        false -> undefined
+    end.
+
+%% Parse `;`-separated parameters after the leading token, unquoting
+%% double-quoted values. Keys are lowercased.
+-spec params(binary()) -> [{binary(), binary()}].
+params(Value) ->
+    case binary:split(Value, <<";">>, [global]) of
+        [_Type | Rest] -> lists:filtermap(fun param_pair/1, Rest);
+        [] -> []
+    end.
+
+-spec param_pair(binary()) -> {true, {binary(), binary()}} | false.
+param_pair(Part) ->
+    case binary:split(trim(Part), <<"=">>) of
+        [K, V] when K =/= <<>> -> {true, {downcase(trim(K)), unquote(trim(V))}};
+        _ -> false
+    end.
+
+-spec unquote(binary()) -> binary().
+unquote(<<$", Rest/binary>>) ->
+    case byte_size(Rest) of
+        0 ->
+            Rest;
+        N ->
+            case binary:at(Rest, N - 1) of
+                $" -> binary:part(Rest, 0, N - 1);
+                _ -> <<$", Rest/binary>>
+            end
+    end;
+unquote(V) ->
+    V.
+
+%%====================================================================
+%% Content-Type / boundary
+%%====================================================================
+
+-spec multipart_boundary(binary()) ->
+    {ok, binary()} | {error, not_multipart | no_boundary}.
+multipart_boundary(Value) ->
+    case binary:split(Value, <<";">>) of
+        [Type | _] ->
+            case downcase(trim(Type)) of
+                <<"multipart/form-data">> -> boundary_param(Value);
+                _ -> {error, not_multipart}
+            end;
+        [] ->
+            {error, not_multipart}
+    end.
+
+-spec boundary_param(binary()) -> {ok, binary()} | {error, no_boundary}.
+boundary_param(Value) ->
+    case param(<<"boundary">>, params(Value)) of
+        undefined -> {error, no_boundary};
+        <<>> -> {error, no_boundary};
+        Boundary -> {ok, Boundary}
+    end.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+-spec default_opts() -> opts().
+default_opts() ->
+    #{
+        part_timeout => 5000,
+        max_parts => 1000,
+        max_header_bytes => 65536,
+        max_header_count => 64,
+        max_part_size => 10485760,
+        max_body => 104857600
+    }.
+
+-spec has_control(binary()) -> boolean().
+has_control(<<>>) -> false;
+has_control(<<C, _/binary>>) when C < 32, C =/= $\t -> true;
+has_control(<<_, Rest/binary>>) -> has_control(Rest).
+
+-spec trim(binary()) -> binary().
+trim(Bin) ->
+    iolist_to_binary(string:trim(Bin)).
+
+-spec downcase(binary()) -> binary().
+downcase(Bin) ->
+    iolist_to_binary(string:lowercase(Bin)).

--- a/test/livery_ext_tests.erl
+++ b/test/livery_ext_tests.erl
@@ -165,6 +165,60 @@ form_malformed_percent_passes_through_test() ->
     ?assertEqual({ok, [{<<"a">>, <<"%ZZ">>}]}, livery_ext:form(Req)).
 
 %%====================================================================
+%% read_form (streaming urlencoded)
+%%====================================================================
+
+read_form_buffered_test() ->
+    Req = form_req(<<"a=1&b=two+words&c=%2F">>),
+    ?assertEqual(
+        {ok, [{<<"a">>, <<"1">>}, {<<"b">>, <<"two words">>}, {<<"c">>, <<"/">>}]},
+        livery_ext:read_form(Req)
+    ).
+
+read_form_stream_test() ->
+    Req = form_stream_req([<<"a=1&">>, <<"b=2">>]),
+    ?assertEqual(
+        {ok, [{<<"a">>, <<"1">>}, {<<"b">>, <<"2">>}]},
+        livery_ext:read_form(Req)
+    ).
+
+read_form_case_insensitive_ct_test() ->
+    Req = ct_req(
+        <<"Application/X-WWW-Form-Urlencoded; charset=utf-8">>,
+        {buffered, <<"a=1">>}
+    ),
+    ?assertEqual({ok, [{<<"a">>, <<"1">>}]}, livery_ext:read_form(Req)).
+
+read_form_malformed_escape_verbatim_test() ->
+    Req = form_req(<<"a=%ZZ">>),
+    ?assertEqual({ok, [{<<"a">>, <<"%ZZ">>}]}, livery_ext:read_form(Req)).
+
+read_form_wrong_content_type_test() ->
+    Req = ct_req(<<"application/json">>, {buffered, <<"a=1">>}),
+    ?assertEqual({error, not_form}, livery_ext:read_form(Req)).
+
+read_form_no_content_type_test() ->
+    ?assertEqual({error, not_form}, livery_ext:read_form(with_body(<<"a=1">>))).
+
+read_form_empty_body_test() ->
+    Req = ct_req(<<"application/x-www-form-urlencoded">>, empty),
+    ?assertEqual({error, no_body}, livery_ext:read_form(Req)).
+
+read_form_max_size_buffered_test() ->
+    Req = form_req(<<"a=1234567890">>),
+    ?assertEqual(
+        {error, {limit, max_size}},
+        livery_ext:read_form(Req, #{max_size => 4})
+    ).
+
+read_form_max_size_stream_test() ->
+    Req = form_stream_req([<<"aaaa">>, <<"bbbb">>, <<"cccc">>]),
+    ?assertEqual(
+        {error, {limit, max_size}},
+        livery_ext:read_form(Req, #{max_size => 5})
+    ).
+
+%%====================================================================
 %% Helpers
 %%====================================================================
 
@@ -189,3 +243,21 @@ req_with_auth(Value) ->
         path => <<"/">>,
         headers => [{<<"authorization">>, Value}]
     }).
+
+ct_req(ContentType, Body) ->
+    livery_req:new(#{
+        protocol => h1,
+        method => <<"POST">>,
+        path => <<"/">>,
+        headers => [{<<"content-type">>, ContentType}],
+        body => Body
+    }).
+
+form_req(Bin) ->
+    ct_req(<<"application/x-www-form-urlencoded">>, {buffered, Bin}).
+
+form_stream_req(Chunks) ->
+    Ref = make_ref(),
+    [self() ! {livery_body, Ref, {data, C}} || C <- Chunks],
+    self() ! {livery_body, Ref, eof},
+    ct_req(<<"application/x-www-form-urlencoded">>, {stream, livery_body:new(Ref)}).

--- a/test/livery_multipart_tests.erl
+++ b/test/livery_multipart_tests.erl
@@ -1,0 +1,275 @@
+-module(livery_multipart_tests).
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%====================================================================
+%% Buffered parsing
+%%====================================================================
+
+single_text_field_test() ->
+    B = <<"X">>,
+    Bin = build(B, [{[cd(<<"greeting">>)], <<"hello">>}]),
+    {ok, [Part]} = livery_multipart:read_all(buffered_req(B, Bin)),
+    ?assertEqual(<<"greeting">>, maps:get(name, Part)),
+    ?assertEqual(undefined, maps:get(filename, Part)),
+    ?assertEqual(<<"hello">>, maps:get(body, Part)).
+
+file_part_test() ->
+    B = <<"BOUNDARY">>,
+    CD = <<"form-data; name=\"file\"; filename=\"a.txt\"">>,
+    Hs = [{<<"Content-Disposition">>, CD}, {<<"Content-Type">>, <<"text/plain">>}],
+    Bin = build(B, [{Hs, <<"FILEDATA">>}]),
+    {ok, [P]} = livery_multipart:read_all(buffered_req(B, Bin)),
+    ?assertEqual(<<"file">>, maps:get(name, P)),
+    ?assertEqual(<<"a.txt">>, maps:get(filename, P)),
+    ?assertEqual(<<"text/plain">>, maps:get(content_type, P)),
+    ?assertEqual(<<"FILEDATA">>, maps:get(body, P)).
+
+case_insensitive_content_type_test() ->
+    B = <<"b">>,
+    Bin = build(B, [{[cd(<<"x">>)], <<"v">>}]),
+    Req = livery_req:new(#{
+        headers => [{<<"content-type">>, <<"Multipart/Form-Data; boundary=", B/binary>>}],
+        body => {buffered, Bin}
+    }),
+    {ok, [P]} = livery_multipart:read_all(Req),
+    ?assertEqual(<<"v">>, maps:get(body, P)).
+
+rfc_fixture_test() ->
+    B = <<"----WebKitFormBoundaryABC123">>,
+    FileHs = [
+        {<<"Content-Disposition">>, <<"form-data; name=\"upload\"; filename=\"hello.txt\"">>},
+        {<<"Content-Type">>, <<"text/plain">>}
+    ],
+    Inner = build(B, [
+        {[cd(<<"field1">>)], <<"value1">>},
+        {[cd(<<"field2">>)], <<"value2">>},
+        {FileHs, <<"file contents here">>}
+    ]),
+    WithPad = <<"preamble to ignore\r\n", Inner/binary, "epilogue ignored">>,
+    {ok, Parts} = livery_multipart:read_all(buffered_req(B, WithPad)),
+    ?assertEqual(3, length(Parts)),
+    [P1, P2, P3] = Parts,
+    ?assertEqual({<<"field1">>, <<"value1">>}, {maps:get(name, P1), maps:get(body, P1)}),
+    ?assertEqual({<<"field2">>, <<"value2">>}, {maps:get(name, P2), maps:get(body, P2)}),
+    ?assertEqual(<<"hello.txt">>, maps:get(filename, P3)),
+    ?assertEqual(<<"text/plain">>, maps:get(content_type, P3)),
+    ?assertEqual(<<"file contents here">>, maps:get(body, P3)).
+
+%%====================================================================
+%% Streaming parsing
+%%====================================================================
+
+multiple_parts_stream_test() ->
+    B = <<"B">>,
+    Bin = build(B, [{[cd(<<"a">>)], <<"one">>}, {[cd(<<"b">>)], <<"two">>}]),
+    {ok, MP0} = livery_multipart:new(stream_req(B, [Bin])),
+    {part, P1, MP1} = livery_multipart:next_part(MP0, 1000),
+    ?assertEqual(<<"a">>, maps:get(name, P1)),
+    {ok, Body1, MP2} = read_full(MP1),
+    ?assertEqual(<<"one">>, Body1),
+    {part, P2, MP3} = livery_multipart:next_part(MP2, 1000),
+    ?assertEqual(<<"b">>, maps:get(name, P2)),
+    {ok, Body2, MP4} = read_full(MP3),
+    ?assertEqual(<<"two">>, Body2),
+    ?assertMatch({done, _}, livery_multipart:next_part(MP4, 1000)).
+
+split_boundary_across_chunks_test() ->
+    B = <<"sep">>,
+    Body = <<"hello world">>,
+    Bin = build(B, [{[cd(<<"a">>)], Body}]),
+    Delim = <<"\r\n--", B/binary>>,
+    {Pos, _} = binary:match(Bin, Delim),
+    %% split in the middle of the part-terminating delimiter
+    SplitAt = Pos + 3,
+    <<C1:SplitAt/binary, C2/binary>> = Bin,
+    {ok, [P]} = livery_multipart:read_all(stream_req(B, [C1, C2])),
+    ?assertEqual(Body, maps:get(body, P)).
+
+buffered_matches_stream_test() ->
+    B = <<"b">>,
+    Bin = build(B, [{[cd(<<"x">>)], <<"some longer body value">>}]),
+    {ok, Buffered} = livery_multipart:read_all(buffered_req(B, Bin)),
+    {ok, Streamed} = livery_multipart:read_all(stream_req(B, chunks(Bin, 3))),
+    ?assertEqual(Buffered, Streamed).
+
+next_part_skips_unread_body_test() ->
+    B = <<"b">>,
+    Bin = build(B, [{[cd(<<"a">>)], <<"AAAA">>}, {[cd(<<"b">>)], <<"BBBB">>}]),
+    {ok, MP0} = livery_multipart:new(buffered_req(B, Bin)),
+    {part, _P1, MP1} = livery_multipart:next_part(MP0, 1000),
+    %% skip part 1's body entirely
+    {part, P2, MP2} = livery_multipart:next_part(MP1, 1000),
+    ?assertEqual(<<"b">>, maps:get(name, P2)),
+    ?assertEqual({ok, <<"BBBB">>}, drop_reader(read_full(MP2))).
+
+%%====================================================================
+%% Empty / malformed
+%%====================================================================
+
+empty_body_yields_done_test() ->
+    Req = livery_req:new(#{
+        headers => [{<<"content-type">>, <<"multipart/form-data; boundary=b">>}],
+        body => empty
+    }),
+    {ok, MP0} = livery_multipart:new(Req),
+    ?assertMatch({done, _}, livery_multipart:next_part(MP0, 1000)).
+
+garbage_without_boundary_is_malformed_test() ->
+    B = <<"b">>,
+    {ok, MP0} = livery_multipart:new(buffered_req(B, <<"no boundary here at all">>)),
+    ?assertMatch({error, malformed, _}, livery_multipart:next_part(MP0, 1000)).
+
+malformed_header_test() ->
+    B = <<"b">>,
+    Bin = <<"--b\r\nthisisnotaheader\r\n\r\nbody\r\n--b--\r\n">>,
+    {ok, MP0} = livery_multipart:new(buffered_req(B, Bin)),
+    ?assertMatch({error, malformed, _}, livery_multipart:next_part(MP0, 1000)).
+
+not_multipart_test() ->
+    Req = livery_req:new(#{
+        headers => [{<<"content-type">>, <<"application/json">>}],
+        body => {buffered, <<"{}">>}
+    }),
+    ?assertEqual({error, not_multipart}, livery_multipart:new(Req)).
+
+missing_content_type_test() ->
+    Req = livery_req:new(#{body => {buffered, <<>>}}),
+    ?assertEqual({error, not_multipart}, livery_multipart:new(Req)).
+
+no_boundary_test() ->
+    Req = livery_req:new(#{
+        headers => [{<<"content-type">>, <<"multipart/form-data">>}],
+        body => {buffered, <<>>}
+    }),
+    ?assertEqual({error, no_boundary}, livery_multipart:new(Req)).
+
+%%====================================================================
+%% Limits / security
+%%====================================================================
+
+max_parts_test() ->
+    B = <<"b">>,
+    Bin = build(B, [
+        {[cd(<<"a">>)], <<"1">>},
+        {[cd(<<"b">>)], <<"2">>},
+        {[cd(<<"c">>)], <<"3">>}
+    ]),
+    ?assertEqual(
+        {error, {limit, max_parts}},
+        livery_multipart:read_all(buffered_req(B, Bin), #{max_parts => 2})
+    ).
+
+max_part_size_test() ->
+    B = <<"b">>,
+    Bin = build(B, [{[cd(<<"a">>)], <<"abcdefghij">>}]),
+    ?assertEqual(
+        {error, {limit, max_part_size}},
+        livery_multipart:read_all(buffered_req(B, Bin), #{max_part_size => 4})
+    ).
+
+max_header_bytes_test() ->
+    B = <<"b">>,
+    Big = binary:copy(<<"x">>, 200),
+    Bin = build(B, [{[cd(<<"a">>), {<<"X-Big">>, Big}], <<"v">>}]),
+    {ok, MP0} = livery_multipart:new(buffered_req(B, Bin), #{max_header_bytes => 50}),
+    ?assertMatch({error, {limit, max_header_bytes}, _}, livery_multipart:next_part(MP0, 1000)).
+
+max_header_count_test() ->
+    B = <<"b">>,
+    Extra = [{<<"X-N">>, integer_to_binary(N)} || N <- lists:seq(1, 10)],
+    Bin = build(B, [{[cd(<<"a">>) | Extra], <<"v">>}]),
+    {ok, MP0} = livery_multipart:new(buffered_req(B, Bin), #{max_header_count => 3}),
+    ?assertMatch({error, {limit, max_header_count}, _}, livery_multipart:next_part(MP0, 1000)).
+
+max_body_test() ->
+    B = <<"b">>,
+    Bin = build(B, [{[cd(<<"a">>)], binary:copy(<<"z">>, 100)}]),
+    ?assertEqual(
+        {error, {limit, max_body}},
+        livery_multipart:read_all(buffered_req(B, Bin), #{max_body => 20})
+    ).
+
+traversal_filename_returned_verbatim_test() ->
+    B = <<"b">>,
+    CD = <<"form-data; name=\"f\"; filename=\"../../etc/passwd\"">>,
+    Bin = build(B, [{[{<<"Content-Disposition">>, CD}], <<"x">>}]),
+    {ok, [P]} = livery_multipart:read_all(buffered_req(B, Bin)),
+    ?assertEqual(<<"../../etc/passwd">>, maps:get(filename, P)).
+
+client_reset_mid_part_test() ->
+    B = <<"b">>,
+    Ref = make_ref(),
+    Head = <<"--b\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\npartial body data">>,
+    self() ! {livery_body, Ref, {data, Head}},
+    self() ! {livery_body, Ref, {reset, closed}},
+    Req = make_req(B, {stream, livery_body:new(Ref)}),
+    {ok, MP0} = livery_multipart:new(Req),
+    {part, _P, MP1} = livery_multipart:next_part(MP0, 1000),
+    ?assertMatch({error, {client_reset, closed}, _}, read_until_end(MP1)).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+cd(Name) ->
+    {<<"Content-Disposition">>, <<"form-data; name=\"", Name/binary, "\"">>}.
+
+build(Boundary, Parts) ->
+    Open = <<"--", Boundary/binary, "\r\n">>,
+    Mid = <<"\r\n--", Boundary/binary, "\r\n">>,
+    Close = <<"\r\n--", Boundary/binary, "--\r\n">>,
+    Blocks = [part_block(Hs, Body) || {Hs, Body} <- Parts],
+    iolist_to_binary([Open, lists:join(Mid, Blocks), Close]).
+
+part_block(Hs, Body) ->
+    HeaderLines = [[N, <<": ">>, V, <<"\r\n">>] || {N, V} <- Hs],
+    [HeaderLines, <<"\r\n">>, Body].
+
+buffered_req(Boundary, Bin) ->
+    make_req(Boundary, {buffered, Bin}).
+
+stream_req(Boundary, Chunks) ->
+    Ref = make_ref(),
+    [self() ! {livery_body, Ref, {data, C}} || C <- Chunks],
+    self() ! {livery_body, Ref, eof},
+    make_req(Boundary, {stream, livery_body:new(Ref)}).
+
+make_req(Boundary, Body) ->
+    livery_req:new(#{
+        headers => [
+            {<<"content-type">>, <<"multipart/form-data; boundary=", Boundary/binary>>}
+        ],
+        body => Body
+    }).
+
+chunks(Bin, N) ->
+    chunks(Bin, N, []).
+
+chunks(<<>>, _N, Acc) ->
+    lists:reverse(Acc);
+chunks(Bin, N, Acc) when byte_size(Bin) =< N ->
+    lists:reverse([Bin | Acc]);
+chunks(Bin, N, Acc) ->
+    <<Head:N/binary, Rest/binary>> = Bin,
+    chunks(Rest, N, [Head | Acc]).
+
+read_full(MP) ->
+    read_full(MP, []).
+
+read_full(MP, Acc) ->
+    case livery_multipart:read_part(MP, 1000) of
+        {ok, Chunk, MP1} -> read_full(MP1, [Chunk | Acc]);
+        {done, MP1} -> {ok, iolist_to_binary(lists:reverse(Acc)), MP1};
+        {error, R, MP1} -> {error, R, MP1}
+    end.
+
+read_until_end(MP) ->
+    case livery_multipart:read_part(MP, 1000) of
+        {ok, _Chunk, MP1} -> read_until_end(MP1);
+        Other -> Other
+    end.
+
+drop_reader({ok, Body, _MP}) -> {ok, Body};
+drop_reader(Other) -> Other.

--- a/test/livery_parity_SUITE.erl
+++ b/test/livery_parity_SUITE.erl
@@ -40,7 +40,8 @@
     middleware_after_response/1,
     full_pipeline_with_builtins/1,
     gzip_negotiation/1,
-    gzip_with_trailers/1
+    gzip_with_trailers/1,
+    multipart_echo/1
 ]).
 
 %%====================================================================
@@ -65,7 +66,8 @@ groups() ->
         middleware_after_response,
         full_pipeline_with_builtins,
         gzip_negotiation,
-        gzip_with_trailers
+        gzip_with_trailers,
+        multipart_echo
     ],
     [
         {test_adapter, [parallel], Shared ++ [response_with_trailers]},
@@ -370,6 +372,43 @@ gzip_with_trailers(Config) ->
         undefined -> ok;
         T -> ?assertEqual([{<<"x-checksum">>, <<"abc">>}], T)
     end.
+
+multipart_echo(Config) ->
+    Body = <<
+        "--PARITYBOUNDARY\r\n"
+        "Content-Disposition: form-data; name=\"a\"\r\n\r\n"
+        "hello\r\n"
+        "--PARITYBOUNDARY\r\n"
+        "Content-Disposition: form-data; name=\"b\"; filename=\"f.txt\"\r\n"
+        "Content-Type: text/plain\r\n\r\n"
+        "xy\r\n"
+        "--PARITYBOUNDARY--\r\n"
+    >>,
+    Handler = fun(R) ->
+        {ok, Parts} = livery_multipart:read_all(R),
+        Summary = lists:join(
+            <<",">>,
+            [
+                [maps:get(name, P), <<":">>, integer_to_binary(byte_size(maps:get(body, P)))]
+             || P <- Parts
+            ]
+        ),
+        livery_resp:text(200, iolist_to_binary(Summary))
+    end,
+    Resp = drive(
+        Config,
+        [],
+        Handler,
+        #{
+            method => <<"POST">>,
+            body => {buffered, Body},
+            headers => [
+                {<<"content-type">>, <<"multipart/form-data; boundary=PARITYBOUNDARY">>}
+            ]
+        }
+    ),
+    ?assertEqual(200, status(Resp)),
+    ?assertEqual(<<"a:5,b:2">>, body(Resp)).
 
 %%====================================================================
 %% Uniform driver API: returns a `response()' tuple


### PR DESCRIPTION
## Summary
- `livery_multipart`: streaming `multipart/form-data` parser (RFC 7578) over the body reader. `new/1,2` reads the boundary (case-insensitive, parameter-tolerant Content-Type); `next_part/1,2` yields each part's `name`/`filename`/`content_type`/`headers`; `read_part/2` streams that part's bytes; `read_all/1,2` collects everything under limits. Works over both `{stream,_}` and `{buffered,_}` bodies and matches a boundary split across chunks.
- Security: all buffering is bounded (`max_parts`, `max_header_bytes`, `max_header_count`, `max_part_size`, `max_body`); empty body -> `{done}`, malformed input -> `{error, malformed}`; `filename` is returned verbatim and never used as a path (the handler must confine it).
- `livery_ext:read_form/1,2`: drains a streamed (or buffered) `application/x-www-form-urlencoded` body (bounded by `max_size`) and decodes it, reusing the existing `decode_form/1` so malformed percent escapes stay verbatim. `form/1`/`query/2` unchanged.
- Cross-adapter `multipart_echo` parity case (test_adapter/h1/h2/h3) plus guides `handle-file-uploads.md` and `parse-form-bodies.md`.

Resolves backlog item #4.