### PR TITLE
Add concurrency-limit load-shedding middleware

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -5,7 +5,7 @@ sibling library that owns the change.
 
 ## Framework-gap backlog (from the audit)
 
-Modern web/AI framework gaps, in priority order. Steps 1-4 are done.
+Modern web/AI framework gaps, in priority order. Steps 1-5 are done.
 
 1. Cancel on client disconnect. DONE: `livery_req:on_disconnect/2`
    plus the `{livery_disconnect, _, _}` message, delivered across
@@ -28,6 +28,9 @@ Modern web/AI framework gaps, in priority order. Steps 1-4 are done.
    (streaming urlencoded). See `docs/guides/handle-file-uploads.md` and
    `docs/guides/parse-form-bodies.md`.
 5. Concurrency limit / load-shedding middleware (admission control).
+   DONE: `livery_concurrency` (`limiter/1,2` factory over a lock-free
+   `atomics` counter; over the limit sheds `503` immediately, optional
+   Retry-After). See `docs/guides/limit-concurrency.md`.
 6. Security-headers middleware (HSTS/CSP/etc). DONE:
    `livery_security_headers` (nosniff, frame options, referrer policy,
    HSTS on TLS, opt-in CSP). See `docs/guides/set-security-headers.md`.

--- a/docs/guides/limit-concurrency.md
+++ b/docs/guides/limit-concurrency.md
@@ -1,0 +1,65 @@
+# How to limit concurrency (load-shedding)
+
+## Problem
+
+A traffic spike can pile up more in-flight requests than your workers
+(or a downstream model) can handle. You want to cap concurrency and shed
+the overflow with `503` instead of collapsing.
+
+## Solution
+
+Add `livery_concurrency` to the stack, built with the `limiter/1`
+factory (which creates the shared counter once):
+
+```erlang
+Stack = [
+    {livery_concurrency, livery_concurrency:limiter(1000)}
+    %% ... handler runs only while fewer than 1000 requests are in flight
+].
+```
+
+While at or under the limit the request proceeds; over the limit it is
+shed immediately with `503 Service Unavailable` and the handler is never
+called. The counter is a lock-free `atomics` cell shared across request
+processes, so there is no extra process and no lock.
+
+## Options
+
+```erlang
+livery_concurrency:limiter(500, #{
+    status => 429,                 %% default 503
+    body => <<"slow down">>,       %% default <<"service unavailable">>
+    retry_after => 5               %% adds Retry-After: 5 (seconds, or a binary)
+})
+```
+
+## Global vs per-route
+
+`limiter/1,2` returns a State carrying its own counter, so each call is
+an independent limiter:
+
+```erlang
+%% one global limit in the service stack
+ServiceStack = [{livery_concurrency, livery_concurrency:limiter(2000)}],
+
+%% a tighter limit on an expensive route group
+InferStack = [{livery_concurrency, livery_concurrency:limiter(8)} | Common].
+```
+
+## Scope and caveats
+
+- A slot is held from admission until the handler RETURNS its response.
+  Body streaming runs after that (outside the middleware stack), so the
+  slot does not cover a long streamed/SSE body. For inference that
+  streams tokens, gate the streaming work yourself if you need to bound
+  active streams.
+- The slot is always released, including when the handler crashes.
+- The limit is approximate under a burst (a request that increments past
+  the limit decrements again), which is the expected behavior for
+  load-shedding.
+
+## See also
+
+- Reference: `livery_concurrency`
+- Recipe: [Add per-request deadlines](add-deadlines.md)
+- Recipe: [Cap request body size](cap-body-size.md)

--- a/rebar.config
+++ b/rebar.config
@@ -93,6 +93,7 @@
         {"docs/guides/custom-middleware.md", #{title => <<"Write a custom middleware">>}},
         {"docs/guides/cap-body-size.md", #{title => <<"Cap request body size">>}},
         {"docs/guides/add-deadlines.md", #{title => <<"Add per-request deadlines">>}},
+        {"docs/guides/limit-concurrency.md", #{title => <<"Limit concurrency">>}},
         {"docs/guides/log-requests.md", #{title => <<"Log every request">>}},
         {"docs/guides/propagate-request-ids.md", #{title => <<"Propagate request IDs">>}},
         {"docs/guides/handler-errors.md", #{title => <<"Catch handler errors">>}},
@@ -154,6 +155,7 @@
             <<"docs/guides/custom-middleware.md">>,
             <<"docs/guides/cap-body-size.md">>,
             <<"docs/guides/add-deadlines.md">>,
+            <<"docs/guides/limit-concurrency.md">>,
             <<"docs/guides/log-requests.md">>,
             <<"docs/guides/propagate-request-ids.md">>,
             <<"docs/guides/handler-errors.md">>,
@@ -197,7 +199,8 @@
             livery_timeout,
             livery_access_log,
             livery_cors,
-            livery_security_headers
+            livery_security_headers,
+            livery_concurrency
         ]},
         {<<"Compression">>, [
             livery_compress,

--- a/src/livery_concurrency.erl
+++ b/src/livery_concurrency.erl
@@ -1,0 +1,92 @@
+-module(livery_concurrency).
+-moduledoc """
+Concurrency-limit / load-shedding middleware (admission control).
+
+Caps the number of in-flight requests. Over the limit it sheds load
+immediately with `503 Service Unavailable` and never calls the handler;
+at or under the limit the request proceeds and the slot is released when
+the handler returns.
+
+Build the stack entry with the `limiter/1,2` factory, which creates the
+shared counter once:
+
+```erlang
+Stack = [
+    {livery_concurrency, livery_concurrency:limiter(1000)}
+    %% ... handler runs only while < 1000 requests are in flight
+].
+```
+
+The counter is a lock-free `atomics` cell shared across the request
+processes (no extra process). A global limiter is one factory call in
+the service stack; per-route limiters are independent factory calls.
+
+Scope: a slot is held from admission until the handler RETURNS its
+response. Body streaming happens after that (outside the middleware
+stack), so the slot does not cover the duration of a streamed/SSE body.
+The limit is approximate under a burst (a request that increments past
+the limit decrements again), which is acceptable for load-shedding.
+""".
+-behaviour(livery_middleware).
+
+-export([limiter/1, limiter/2, call/3]).
+
+-export_type([state/0]).
+
+-type state() :: #{
+    ref := atomics:atomics_ref(),
+    limit := non_neg_integer(),
+    status := 100..599,
+    body := iodata(),
+    retry_after := non_neg_integer() | binary() | undefined
+}.
+
+-doc "Build a limiter stack State capping in-flight requests at `Limit`.".
+-spec limiter(non_neg_integer()) -> state().
+limiter(Limit) ->
+    limiter(Limit, #{}).
+
+-doc """
+`limiter/1` with options.
+
+`status` (default 503), `body` (default `<<"service unavailable">>`),
+and `retry_after` (seconds as an integer, a literal binary, or
+`undefined`) shape the shed response.
+""".
+-spec limiter(non_neg_integer(), map()) -> state().
+limiter(Limit, Opts) when is_integer(Limit), Limit >= 0 ->
+    #{
+        ref => atomics:new(1, [{signed, false}]),
+        limit => Limit,
+        status => maps:get(status, Opts, 503),
+        body => maps:get(body, Opts, <<"service unavailable">>),
+        retry_after => maps:get(retry_after, Opts, undefined)
+    }.
+
+-doc "Admit the request if under the limit, otherwise shed with 503.".
+-spec call(livery_req:req(), livery_middleware:next(), state()) ->
+    livery_resp:resp().
+call(Req, Next, #{ref := Ref, limit := Limit} = State) ->
+    case atomics:add_get(Ref, 1, 1) of
+        Count when Count > Limit ->
+            atomics:sub(Ref, 1, 1),
+            overloaded(State);
+        _Count ->
+            try
+                Next(Req)
+            after
+                atomics:sub(Ref, 1, 1)
+            end
+    end.
+
+-spec overloaded(state()) -> livery_resp:resp().
+overloaded(#{status := Status, body := Body} = State) ->
+    Resp = livery_resp:text(Status, Body),
+    case maps:get(retry_after, State) of
+        undefined -> Resp;
+        Value -> livery_resp:with_header(<<"retry-after">>, retry_value(Value), Resp)
+    end.
+
+-spec retry_value(non_neg_integer() | binary()) -> binary().
+retry_value(Value) when is_integer(Value) -> integer_to_binary(Value);
+retry_value(Value) when is_binary(Value) -> Value.

--- a/test/livery_builtin_middleware_tests.erl
+++ b/test/livery_builtin_middleware_tests.erl
@@ -477,6 +477,94 @@ cors_security_request_id_compose_test() ->
     ?assert(has_vary(<<"origin">>, Cap)).
 
 %%====================================================================
+%% livery_concurrency
+%%====================================================================
+
+concurrency_under_limit_test() ->
+    Cap = livery_test_adapter:run(
+        [{livery_concurrency, livery_concurrency:limiter(5)}],
+        fun(_R) -> livery_resp:text(200, <<"ok">>) end,
+        #{}
+    ),
+    ?assertEqual(200, livery_test_adapter:status(Cap)).
+
+concurrency_sheds_over_limit_test() ->
+    Cap = livery_test_adapter:run(
+        [{livery_concurrency, livery_concurrency:limiter(0)}],
+        fun(_R) -> error(must_not_be_called) end,
+        #{}
+    ),
+    ?assertEqual(503, livery_test_adapter:status(Cap)),
+    ?assertEqual(<<"service unavailable">>, livery_test_adapter:body(Cap)).
+
+concurrency_retry_after_test() ->
+    Cap = livery_test_adapter:run(
+        [{livery_concurrency, livery_concurrency:limiter(0, #{retry_after => 30})}],
+        fun(_R) -> error(must_not_be_called) end,
+        #{}
+    ),
+    ?assertEqual(503, livery_test_adapter:status(Cap)),
+    ?assertEqual(<<"30">>, livery_test_adapter:header(<<"retry-after">>, Cap)).
+
+concurrency_custom_status_test() ->
+    Opts = #{status => 429, body => <<"slow down">>},
+    Cap = livery_test_adapter:run(
+        [{livery_concurrency, livery_concurrency:limiter(0, Opts)}],
+        fun(_R) -> error(must_not_be_called) end,
+        #{}
+    ),
+    ?assertEqual(429, livery_test_adapter:status(Cap)),
+    ?assertEqual(<<"slow down">>, livery_test_adapter:body(Cap)).
+
+concurrency_holds_and_releases_test() ->
+    %% Shared limiter (one atomics ref) across all requests.
+    Stack = [{livery_concurrency, livery_concurrency:limiter(2)}],
+    Self = self(),
+    Blocking = fun(_R) ->
+        %% The slot is acquired before the handler runs, so by here it is
+        %% held; signal readiness, then block until released.
+        Self ! {entered, self()},
+        receive
+            finish -> ok
+        end,
+        livery_resp:text(200, <<"ok">>)
+    end,
+    Runners = [
+        spawn(fun() ->
+            Cap = livery_test_adapter:run(Stack, Blocking, #{}),
+            Self ! {done, self(), livery_test_adapter:status(Cap)}
+        end)
+     || _ <- lists:seq(1, 2)
+    ],
+    %% Wait until BOTH slots are provably occupied before the 3rd request.
+    Entered = [
+        receive
+            {entered, P} -> P
+        after 2000 -> error(handler_did_not_enter)
+        end
+     || _ <- lists:seq(1, 2)
+    ],
+    %% Third request is shed before its handler runs (no block).
+    Cap3 = livery_test_adapter:run(
+        Stack, fun(_R) -> error(must_not_be_called) end, #{}
+    ),
+    ?assertEqual(503, livery_test_adapter:status(Cap3)),
+    %% Release the held handlers; both complete with 200.
+    [P ! finish || P <- Entered],
+    [
+        receive
+            {done, _, S} -> ?assertEqual(200, S)
+        after 2000 -> error(runner_did_not_finish)
+        end
+     || _ <- Runners
+    ],
+    %% Slots returned: a fresh request is admitted.
+    Cap4 = livery_test_adapter:run(
+        Stack, fun(_R) -> livery_resp:text(200, <<"ok">>) end, #{}
+    ),
+    ?assertEqual(200, livery_test_adapter:status(Cap4)).
+
+%%====================================================================
 %% Helpers
 %%====================================================================
 

--- a/test/livery_parity_SUITE.erl
+++ b/test/livery_parity_SUITE.erl
@@ -41,7 +41,8 @@
     full_pipeline_with_builtins/1,
     gzip_negotiation/1,
     gzip_with_trailers/1,
-    multipart_echo/1
+    multipart_echo/1,
+    concurrency_shed/1
 ]).
 
 %%====================================================================
@@ -67,7 +68,8 @@ groups() ->
         full_pipeline_with_builtins,
         gzip_negotiation,
         gzip_with_trailers,
-        multipart_echo
+        multipart_echo,
+        concurrency_shed
     ],
     [
         {test_adapter, [parallel], Shared ++ [response_with_trailers]},
@@ -409,6 +411,18 @@ multipart_echo(Config) ->
     ),
     ?assertEqual(200, status(Resp)),
     ?assertEqual(<<"a:5,b:2">>, body(Resp)).
+
+concurrency_shed(Config) ->
+    %% limiter(0) rejects every request: deterministic 503 on all adapters.
+    Stack = [{livery_concurrency, livery_concurrency:limiter(0)}],
+    Resp = drive(
+        Config,
+        Stack,
+        fun(_R) -> livery_resp:text(200, <<"ok">>) end,
+        #{}
+    ),
+    ?assertEqual(503, status(Resp)),
+    ?assertEqual(<<"service unavailable">>, body(Resp)).
 
 %%====================================================================
 %% Uniform driver API: returns a `response()' tuple


### PR DESCRIPTION
## Summary
- `livery_concurrency`: admission-control middleware. `limiter/1,2` builds the stack State with a lock-free `atomics` counter created once. Over the limit it sheds `503` immediately and never calls the handler; at/under the limit the request runs and the slot is released when the handler returns (`try ... after`, so it is freed even on a handler crash).
- Options: `status` (default 503), `body`, `retry_after` (seconds or a binary). Each `limiter/1,2` call is an independent counter, so a global limit lives in the service stack and tighter per-route limits live in route stacks.
- Scope: a slot covers admission + handler execution, not body streaming (which runs after the stack returns); the limit is approximate under a burst. Both documented.
- Tests: EUnit (under-limit, shed, Retry-After, custom status, and a concurrent hold/release with an explicit readiness handshake) plus a deterministic `concurrency_shed` parity case (`limiter(0)` -> 503) across test_adapter/h1/h2/h3.

Resolves backlog item #5.