### PR TITLE
Add per-key rate-limiting middleware

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -5,7 +5,7 @@ sibling library that owns the change.
 
 ## Framework-gap backlog (from the audit)
 
-Modern web/AI framework gaps, in priority order. Steps 1-5 are done.
+Modern web/AI framework gaps, in priority order. Steps 1-6 are done.
 
 1. Cancel on client disconnect. DONE: `livery_req:on_disconnect/2`
    plus the `{livery_disconnect, _, _}` message, delivered across
@@ -34,7 +34,11 @@ Modern web/AI framework gaps, in priority order. Steps 1-5 are done.
 6. Security-headers middleware (HSTS/CSP/etc). DONE:
    `livery_security_headers` (nosniff, frame options, referrer policy,
    HSTS on TLS, opt-in CSP). See `docs/guides/set-security-headers.md`.
-7. Rate limiting / throttling.
+7. Rate limiting / throttling. DONE: `livery_ratelimit` (per-key token
+   bucket via `limiter/2,3`, keyed by bearer token by default, `429` +
+   `RateLimit-*`/`Retry-After`), backed by the supervised
+   `livery_ratelimit_store` ETS table. See
+   `docs/guides/rate-limit-requests.md`.
 8. HTTP caching primitives (ETag, conditional GET, Cache-Control).
 9. Static-directory serving with ETag/MIME.
 10. Health/readiness endpoints + Prometheus `/metrics`.

--- a/docs/guides/rate-limit-requests.md
+++ b/docs/guides/rate-limit-requests.md
@@ -1,0 +1,75 @@
+# How to rate-limit requests
+
+## Problem
+
+You want to throttle how fast each client may call the API and answer
+`429 Too Many Requests` when a client exceeds its allowance.
+
+## Solution
+
+Add `livery_ratelimit` with the `limiter/2,3` factory. Each client gets
+a token bucket of `Capacity` tokens that refills at `RefillPerSec`:
+
+```erlang
+Stack = [
+    {livery_ratelimit, livery_ratelimit:limiter(100, 10)}  %% burst 100, 10/s
+].
+```
+
+A request consumes a token; an empty bucket sheds `429` (the handler is
+not called). "N requests per minute" maps to `limiter(N, N/60)` (burst
+N, sustained N/60).
+
+## Identifying clients
+
+The client IP is NOT available (the wire libraries do not surface the
+peer address), so the default key is the Authorization bearer token
+(`livery_ext:bearer_token/1`). A request with no token is NOT limited.
+Provide your own `key` fun to throttle by an API-key header or anything
+else:
+
+```erlang
+livery_ratelimit:limiter(60, 1, #{
+    key => fun(Req) -> livery_req:header(<<"x-api-key">>, Req) end
+})
+```
+
+A `key` fun that returns `undefined` skips limiting for that request.
+Keys are SHA-256 hashed before storage, so raw tokens are never kept in
+memory.
+
+## Headers and options
+
+Allowed responses carry `RateLimit-Limit`, `RateLimit-Remaining`, and
+`RateLimit-Reset`; a `429` adds `Retry-After`. Tune with:
+
+```erlang
+livery_ratelimit:limiter(100, 10, #{
+    status => 429,                 %% shed status (default 429)
+    body => <<"slow down">>,       %% shed body
+    headers => false,              %% suppress all RateLimit-*/Retry-After
+    name => my_api                 %% share one keyspace across stacks
+})
+```
+
+Each `limiter/2,3` call allocates an isolated keyspace, so a global limit
+and tighter per-route limits do not interfere. Pass an explicit `name`
+to deliberately share one budget across several stacks.
+
+## Notes
+
+- The token bucket is approximate-free under concurrency: the consume is
+  a lock-free compare-and-swap, so parallel requests for the same key
+  never over-admit.
+- `RefillPerSec => 0` is a pure fixed quota (no refill); those buckets
+  are kept until the node restarts (they cannot be safely reclaimed
+  without granting fresh quota).
+- Per-key state lives in the supervised `livery_ratelimit_store` ETS
+  table; idle buckets that have fully refilled are reclaimed
+  automatically.
+
+## See also
+
+- Reference: `livery_ratelimit`, `livery_ratelimit_store`
+- Recipe: [Limit concurrency](limit-concurrency.md)
+- Recipe: [Extract a bearer token](bearer-tokens.md)

--- a/rebar.config
+++ b/rebar.config
@@ -94,6 +94,7 @@
         {"docs/guides/cap-body-size.md", #{title => <<"Cap request body size">>}},
         {"docs/guides/add-deadlines.md", #{title => <<"Add per-request deadlines">>}},
         {"docs/guides/limit-concurrency.md", #{title => <<"Limit concurrency">>}},
+        {"docs/guides/rate-limit-requests.md", #{title => <<"Rate-limit requests">>}},
         {"docs/guides/log-requests.md", #{title => <<"Log every request">>}},
         {"docs/guides/propagate-request-ids.md", #{title => <<"Propagate request IDs">>}},
         {"docs/guides/handler-errors.md", #{title => <<"Catch handler errors">>}},
@@ -156,6 +157,7 @@
             <<"docs/guides/cap-body-size.md">>,
             <<"docs/guides/add-deadlines.md">>,
             <<"docs/guides/limit-concurrency.md">>,
+            <<"docs/guides/rate-limit-requests.md">>,
             <<"docs/guides/log-requests.md">>,
             <<"docs/guides/propagate-request-ids.md">>,
             <<"docs/guides/handler-errors.md">>,
@@ -200,7 +202,8 @@
             livery_access_log,
             livery_cors,
             livery_security_headers,
-            livery_concurrency
+            livery_concurrency,
+            livery_ratelimit
         ]},
         {<<"Compression">>, [
             livery_compress,
@@ -220,7 +223,13 @@
         {<<"WebSocket and WebTransport">>, [livery_ws, livery_wt]},
         {<<"Adapters">>, [livery_adapter, livery_test_adapter]},
         {<<"Body reader">>, [livery_body]},
-        {<<"Runtime">>, [livery_app, livery_sup, livery_req_proc, livery_req_sup]}
+        {<<"Runtime">>, [
+            livery_app,
+            livery_sup,
+            livery_req_proc,
+            livery_req_sup,
+            livery_ratelimit_store
+        ]}
     ]}
 ]}.
 
@@ -289,8 +298,11 @@
             {elvis_style, atom_naming_convention, #{
                 ignore => [livery_auth, livery_openapi_validate]
             }},
+            %% The new-bucket (insert_new) and existing-bucket (CAS
+            %% select_replace) branches share the allow shape but differ
+            %% in the atomic write primitive; keeping them apart is clearer.
             {elvis_style, dont_repeat_yourself, #{
-                ignore => [livery, livery_openapi]
+                ignore => [livery, livery_openapi, livery_ratelimit_store]
             }},
             {elvis_style, max_function_length, #{
                 ignore => [

--- a/src/livery_ratelimit.erl
+++ b/src/livery_ratelimit.erl
@@ -1,0 +1,130 @@
+-module(livery_ratelimit).
+-moduledoc """
+Per-key rate-limiting / throttling middleware (token bucket).
+
+Each client (by default identified by its Authorization bearer token) gets
+a token bucket: `Capacity` tokens that refill at `RefillPerSec`. A request
+consumes one token; when the bucket is empty the request is shed with
+`429 Too Many Requests`. A request with no key passes through unlimited.
+
+Build the stack entry with `limiter/2,3` (which allocates an isolated
+keyspace):
+
+```erlang
+Stack = [
+    {livery_ratelimit, livery_ratelimit:limiter(100, 10)}  %% burst 100, 10/s
+].
+```
+
+"N requests per minute" maps to `limiter(N, N/60)`. Per-key state lives in
+the supervised `livery_ratelimit_store` ETS table; the raw key is never
+stored (it is SHA-256 hashed). Client IP is not available from the wire
+libs, so identify clients by token or a custom `key` fun. Responses carry
+`RateLimit-Limit`/`-Remaining`/`-Reset` (and `Retry-After` on a 429)
+unless `headers => false`.
+""".
+-behaviour(livery_middleware).
+
+-export([limiter/2, limiter/3, call/3]).
+
+-export_type([state/0]).
+
+-type key_fun() :: fun((livery_req:req()) -> binary() | undefined).
+
+-type state() :: #{
+    name := term(),
+    capacity := non_neg_integer(),
+    rate := number(),
+    key := key_fun(),
+    status := 100..599,
+    body := iodata(),
+    headers := boolean()
+}.
+
+-doc "Build a limiter: `Capacity` burst tokens refilling at `RefillPerSec`.".
+-spec limiter(non_neg_integer(), number()) -> state().
+limiter(Capacity, RefillPerSec) ->
+    limiter(Capacity, RefillPerSec, #{}).
+
+-doc """
+`limiter/2` with options: `name`, `key` (a `req -> binary | undefined`
+fun, default the bearer token), `status` (default 429), `body`, and
+`headers` (default `true`).
+""".
+-spec limiter(non_neg_integer(), number(), map()) -> state().
+limiter(Capacity, RefillPerSec, Opts) when
+    is_integer(Capacity), Capacity >= 0, is_number(RefillPerSec), RefillPerSec >= 0
+->
+    #{
+        name => maps:get(name, Opts, make_ref()),
+        capacity => Capacity,
+        rate => RefillPerSec,
+        key => maps:get(key, Opts, fun default_key/1),
+        status => maps:get(status, Opts, 429),
+        body => maps:get(body, Opts, <<"too many requests">>),
+        headers => maps:get(headers, Opts, true)
+    }.
+
+-doc "Throttle the request by its key, or pass through when keyless.".
+-spec call(livery_req:req(), livery_middleware:next(), state()) ->
+    livery_resp:resp().
+call(Req, Next, #{key := KeyFun} = State) ->
+    case KeyFun(Req) of
+        undefined -> Next(Req);
+        Key when is_binary(Key) -> limit(Key, Req, Next, State)
+    end.
+
+-spec default_key(livery_req:req()) -> binary() | undefined.
+default_key(Req) ->
+    livery_ext:bearer_token(Req).
+
+-spec limit(binary(), livery_req:req(), livery_middleware:next(), state()) ->
+    livery_resp:resp().
+limit(Key, Req, Next, #{name := Name, capacity := Cap, rate := Rate} = State) ->
+    Digest = crypto:hash(sha256, Key),
+    Now = erlang:monotonic_time(microsecond),
+    case livery_ratelimit_store:check(Name, Digest, Cap, Rate, Now) of
+        {allow, Remaining, Reset} ->
+            allow_headers(Next(Req), State, Remaining, Reset);
+        {deny, RetryAfter} ->
+            denied(State, RetryAfter)
+    end.
+
+-spec allow_headers(
+    livery_resp:resp(), state(), float(), non_neg_integer() | undefined
+) -> livery_resp:resp().
+allow_headers(Resp, #{headers := false}, _Remaining, _Reset) ->
+    Resp;
+allow_headers(Resp, #{headers := true, capacity := Cap}, Remaining, Reset) ->
+    rl_headers(Resp, Cap, trunc(Remaining), Reset).
+
+-spec denied(state(), non_neg_integer() | undefined) -> livery_resp:resp().
+denied(#{headers := false, status := Status, body := Body}, _RetryAfter) ->
+    livery_resp:text(Status, Body);
+denied(#{headers := true, status := Status, body := Body, capacity := Cap}, RetryAfter) ->
+    Resp = rl_headers(livery_resp:text(Status, Body), Cap, 0, undefined),
+    maybe_retry_after(Resp, RetryAfter).
+
+-spec rl_headers(
+    livery_resp:resp(), non_neg_integer(), non_neg_integer(), non_neg_integer() | undefined
+) -> livery_resp:resp().
+rl_headers(Resp, Cap, Remaining, Reset) ->
+    R1 = livery_resp:with_header(<<"ratelimit-limit">>, integer_to_binary(Cap), Resp),
+    R2 = livery_resp:with_header(
+        <<"ratelimit-remaining">>, integer_to_binary(Remaining), R1
+    ),
+    maybe_reset(R2, Reset).
+
+-spec maybe_reset(livery_resp:resp(), non_neg_integer() | undefined) ->
+    livery_resp:resp().
+maybe_reset(Resp, undefined) ->
+    Resp;
+maybe_reset(Resp, Reset) ->
+    livery_resp:with_header(<<"ratelimit-reset">>, integer_to_binary(Reset), Resp).
+
+-spec maybe_retry_after(livery_resp:resp(), non_neg_integer() | undefined) ->
+    livery_resp:resp().
+maybe_retry_after(Resp, undefined) ->
+    Resp;
+maybe_retry_after(Resp, Secs) ->
+    livery_resp:with_header(<<"retry-after">>, integer_to_binary(Secs), Resp).

--- a/src/livery_ratelimit_store.erl
+++ b/src/livery_ratelimit_store.erl
@@ -1,0 +1,170 @@
+-module(livery_ratelimit_store).
+-moduledoc """
+Owner and store for `livery_ratelimit` token buckets.
+
+A supervised gen_server that owns one public named ETS table and reaps
+idle buckets on a timer. The per-request token-bucket decision
+(`check/5`) runs in the calling process directly against the public
+table (lock-free CAS), so the gen_server is never on the hot path - it
+only owns the table and runs cleanup.
+
+Each row is `{{Name, KeyDigest}, Tokens, LastMicros, Cap, Rate}`.
+`KeyDigest` is a SHA-256 of the rate-limit key, so raw bearer tokens are
+never stored. `Cap`/`Rate` are denormalized so the sweep can compute
+refill without the limiter config.
+""".
+-behaviour(gen_server).
+
+-export([start_link/0, check/5, sweep/0]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
+
+-define(TABLE, livery_ratelimit).
+-define(CLEANUP_INTERVAL, 600000).
+
+-record(state, {}).
+-type state() :: #state{}.
+
+-type result() ::
+    {allow, float(), non_neg_integer() | undefined}
+    | {deny, non_neg_integer() | undefined}.
+
+-export_type([result/0]).
+
+%%====================================================================
+%% API
+%%====================================================================
+
+-spec start_link() -> {ok, pid()} | {error, term()}.
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-doc """
+Token-bucket decision for `{Name, KeyDigest}`.
+
+Returns `{allow, RemainingTokens, ResetSecs}` (a token was consumed) or
+`{deny, RetryAfterSecs}`. `ResetSecs`/`RetryAfterSecs` are `undefined`
+when `Rate =< 0` (no refill). Runs in the caller; lock-free.
+""".
+-spec check(term(), binary(), non_neg_integer(), number(), integer()) -> result().
+check(Name, KeyDigest, Cap, Rate, Now) ->
+    do_check({Name, KeyDigest}, Cap, Rate, Now).
+
+-doc "Reap fully-refilled buckets now; returns the number removed.".
+-spec sweep() -> non_neg_integer().
+sweep() ->
+    gen_server:call(?MODULE, sweep).
+
+%%====================================================================
+%% Token bucket (runs in the caller against the public table)
+%%====================================================================
+
+-spec do_check({term(), binary()}, non_neg_integer(), number(), integer()) ->
+    result().
+do_check(Id, Cap, Rate, Now) ->
+    case ets:lookup(?TABLE, Id) of
+        [] ->
+            decide_new(Id, float(Cap), Now, Cap, Rate);
+        [{_Id, Tokens, Last, _Cap, _Rate} = Old] ->
+            Refilled = min(float(Cap), Tokens + (Now - Last) / 1.0e6 * Rate),
+            decide_existing(Id, Old, Refilled, Now, Cap, Rate)
+    end.
+
+-spec decide_new({term(), binary()}, float(), integer(), non_neg_integer(), number()) ->
+    result().
+decide_new(Id, Tokens, Now, Cap, Rate) when Tokens >= 1.0 ->
+    New = {Id, Tokens - 1.0, Now, Cap, Rate},
+    case ets:insert_new(?TABLE, New) of
+        true -> {allow, Tokens - 1.0, reset_secs(Tokens - 1.0, Cap, Rate)};
+        false -> do_check(Id, Cap, Rate, Now)
+    end;
+decide_new(_Id, Tokens, _Now, _Cap, Rate) ->
+    {deny, retry_secs(Tokens, Rate)}.
+
+-spec decide_existing(
+    {term(), binary()}, tuple(), float(), integer(), non_neg_integer(), number()
+) -> result().
+decide_existing(Id, Old, Refilled, Now, Cap, Rate) when Refilled >= 1.0 ->
+    New = {Id, Refilled - 1.0, Now, Cap, Rate},
+    case ets:select_replace(?TABLE, [{Old, [], [{const, New}]}]) of
+        1 -> {allow, Refilled - 1.0, reset_secs(Refilled - 1.0, Cap, Rate)};
+        0 -> do_check(Id, Cap, Rate, Now)
+    end;
+decide_existing(_Id, _Old, Refilled, _Now, _Cap, Rate) ->
+    {deny, retry_secs(Refilled, Rate)}.
+
+-spec reset_secs(float(), non_neg_integer(), number()) ->
+    non_neg_integer() | undefined.
+reset_secs(_Tokens, _Cap, Rate) when Rate =< 0 ->
+    undefined;
+reset_secs(Tokens, Cap, Rate) ->
+    erlang:ceil((float(Cap) - Tokens) / Rate).
+
+-spec retry_secs(float(), number()) -> non_neg_integer() | undefined.
+retry_secs(_Tokens, Rate) when Rate =< 0 ->
+    undefined;
+retry_secs(Tokens, Rate) ->
+    erlang:ceil((1.0 - Tokens) / Rate).
+
+%%====================================================================
+%% gen_server
+%%====================================================================
+
+-spec init([]) -> {ok, state()}.
+init([]) ->
+    _ = ets:new(?TABLE, [
+        named_table,
+        public,
+        set,
+        {write_concurrency, true},
+        {read_concurrency, true}
+    ]),
+    schedule_cleanup(),
+    {ok, #state{}}.
+
+-spec handle_call(term(), gen_server:from(), state()) -> {reply, term(), state()}.
+handle_call(sweep, _From, State) ->
+    {reply, do_sweep(now_micros()), State};
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+-spec handle_cast(term(), state()) -> {noreply, state()}.
+handle_cast(_Request, State) ->
+    {noreply, State}.
+
+-spec handle_info(term(), state()) -> {noreply, state()}.
+handle_info(cleanup, State) ->
+    _ = do_sweep(now_micros()),
+    schedule_cleanup(),
+    {noreply, State};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%%====================================================================
+%% Cleanup
+%%====================================================================
+
+-spec schedule_cleanup() -> reference().
+schedule_cleanup() ->
+    erlang:send_after(?CLEANUP_INTERVAL, self(), cleanup).
+
+%% Delete only buckets that are (or by now would be) fully refilled:
+%% `Tokens + (Now - Last)/1e6 * Rate >= Cap`. A fully-refilled bucket is
+%% behaviorally identical to a fresh one, so this never grants extra
+%% budget and never resets a hot/exhausted key (its refill is < Cap).
+-spec do_sweep(integer()) -> non_neg_integer().
+do_sweep(Now) ->
+    NowF = float(Now),
+    Spec = [
+        {
+            {'_', '$2', '$3', '$4', '$5'},
+            [
+                {'>=', {'+', '$2', {'*', {'/', {'-', NowF, '$3'}, 1.0e6}, '$5'}}, '$4'}
+            ],
+            [true]
+        }
+    ],
+    ets:select_delete(?TABLE, Spec).
+
+-spec now_micros() -> integer().
+now_micros() ->
+    erlang:monotonic_time(microsecond).

--- a/src/livery_sup.erl
+++ b/src/livery_sup.erl
@@ -3,7 +3,8 @@
 Top-level Livery supervisor.
 
 Supervises `livery_req_sup`, the simple-one-for-one parent of
-per-request workers. Listeners are owned by their wire libraries
+per-request workers, and `livery_ratelimit_store`, the owner of the
+rate-limiter ETS table. Listeners are owned by their wire libraries
 (`h1`/`h2`/`quic`); `livery_service` starts and stops them per
 service rather than under this supervisor.
 """.
@@ -27,4 +28,12 @@ init([]) ->
         type => supervisor,
         modules => [livery_req_sup]
     },
-    {ok, {SupFlags, [ReqSup]}}.
+    RateLimitStore = #{
+        id => livery_ratelimit_store,
+        start => {livery_ratelimit_store, start_link, []},
+        restart => permanent,
+        shutdown => 5000,
+        type => worker,
+        modules => [livery_ratelimit_store]
+    },
+    {ok, {SupFlags, [ReqSup, RateLimitStore]}}.

--- a/test/livery_parity_SUITE.erl
+++ b/test/livery_parity_SUITE.erl
@@ -42,7 +42,8 @@
     gzip_negotiation/1,
     gzip_with_trailers/1,
     multipart_echo/1,
-    concurrency_shed/1
+    concurrency_shed/1,
+    rate_limit_shed/1
 ]).
 
 %%====================================================================
@@ -69,7 +70,8 @@ groups() ->
         gzip_negotiation,
         gzip_with_trailers,
         multipart_echo,
-        concurrency_shed
+        concurrency_shed,
+        rate_limit_shed
     ],
     [
         {test_adapter, [parallel], Shared ++ [response_with_trailers]},
@@ -423,6 +425,14 @@ concurrency_shed(Config) ->
     ),
     ?assertEqual(503, status(Resp)),
     ?assertEqual(<<"service unavailable">>, body(Resp)).
+
+rate_limit_shed(Config) ->
+    %% capacity 1, no refill, fixed key: 1st request 200, 2nd 429.
+    Limiter = livery_ratelimit:limiter(1, 0, #{key => fun(_R) -> <<"parity">> end}),
+    Stack = [{livery_ratelimit, Limiter}],
+    H = fun(_R) -> livery_resp:text(200, <<"ok">>) end,
+    ?assertEqual(200, status(drive(Config, Stack, H, #{}))),
+    ?assertEqual(429, status(drive(Config, Stack, H, #{}))).
 
 %%====================================================================
 %% Uniform driver API: returns a `response()' tuple

--- a/test/livery_ratelimit_tests.erl
+++ b/test/livery_ratelimit_tests.erl
@@ -1,0 +1,165 @@
+-module(livery_ratelimit_tests).
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% The store is a supervised gen_server, so the livery application must be
+%% running. Start it once for the whole module.
+ratelimit_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        {"burst then shed", fun burst/0},
+        {"refill admits again", fun refill/0},
+        {"no key passes through", fun no_key/0},
+        {"allow + 429 headers", fun headers/0},
+        {"keys are isolated", fun isolation/0},
+        {"custom key fun", fun custom_key/0},
+        {"headers can be disabled", fun headers_off/0},
+        {"custom status and body", fun custom_status/0},
+        {"CAS under contention", fun contention/0},
+        {"cleanup keeps an exhausted key", fun cleanup_keeps_exhausted/0},
+        {"cleanup removes a full key", fun cleanup_removes_full/0}
+    ]}.
+
+setup() ->
+    {ok, _} = application:ensure_all_started(livery),
+    ok.
+
+cleanup(_) ->
+    %% Stop the app we started so other test modules (which start
+    %% livery_req_sup standalone) are not affected by a running livery.
+    _ = application:stop(livery),
+    ok.
+
+%%====================================================================
+%% Cases
+%%====================================================================
+
+burst() ->
+    L = livery_ratelimit:limiter(3, 0),
+    T = <<"burst">>,
+    ?assertEqual(200, status(run(L, T))),
+    ?assertEqual(200, status(run(L, T))),
+    ?assertEqual(200, status(run(L, T))),
+    ?assertEqual(429, status(run(L, T))).
+
+refill() ->
+    L = livery_ratelimit:limiter(1, 100),
+    T = <<"refill">>,
+    ?assertEqual(200, status(run(L, T))),
+    ?assertEqual(429, status(run(L, T))),
+    timer:sleep(20),
+    ?assertEqual(200, status(run(L, T))).
+
+no_key() ->
+    L = livery_ratelimit:limiter(0, 0),
+    Cap = livery_test_adapter:run(
+        [{livery_ratelimit, L}],
+        fun(_R) -> livery_resp:text(200, <<"ok">>) end,
+        #{}
+    ),
+    ?assertEqual(200, status(Cap)).
+
+headers() ->
+    L = livery_ratelimit:limiter(5, 10),
+    Cap = run(L, <<"hdr">>),
+    ?assertEqual(200, status(Cap)),
+    ?assertEqual(<<"5">>, hdr(<<"ratelimit-limit">>, Cap)),
+    ?assertEqual(<<"4">>, hdr(<<"ratelimit-remaining">>, Cap)),
+    L2 = livery_ratelimit:limiter(1, 10),
+    ?assertEqual(200, status(run(L2, <<"hdr2">>))),
+    Denied = run(L2, <<"hdr2">>),
+    ?assertEqual(429, status(Denied)),
+    ?assert(is_binary(hdr(<<"retry-after">>, Denied))).
+
+isolation() ->
+    L = livery_ratelimit:limiter(1, 0),
+    ?assertEqual(200, status(run(L, <<"key-a">>))),
+    ?assertEqual(429, status(run(L, <<"key-a">>))),
+    ?assertEqual(200, status(run(L, <<"key-b">>))).
+
+custom_key() ->
+    L = livery_ratelimit:limiter(1, 0, #{key => fun(_R) -> <<"fixed">> end}),
+    H = fun(_R) -> livery_resp:text(200, <<"ok">>) end,
+    %% No Authorization header, but the custom key always returns "fixed".
+    ?assertEqual(
+        200,
+        livery_test_adapter:status(
+            livery_test_adapter:run([{livery_ratelimit, L}], H, #{})
+        )
+    ),
+    ?assertEqual(
+        429,
+        livery_test_adapter:status(
+            livery_test_adapter:run([{livery_ratelimit, L}], H, #{})
+        )
+    ).
+
+headers_off() ->
+    L = livery_ratelimit:limiter(1, 0, #{headers => false}),
+    Allowed = run(L, <<"off">>),
+    ?assertEqual(200, status(Allowed)),
+    ?assertEqual(undefined, hdr(<<"ratelimit-limit">>, Allowed)),
+    Denied = run(L, <<"off">>),
+    ?assertEqual(429, status(Denied)),
+    ?assertEqual(undefined, hdr(<<"retry-after">>, Denied)).
+
+custom_status() ->
+    L = livery_ratelimit:limiter(0, 0, #{status => 503, body => <<"nope">>}),
+    Cap = run(L, <<"cust">>),
+    ?assertEqual(503, status(Cap)),
+    ?assertEqual(<<"nope">>, livery_test_adapter:body(Cap)).
+
+contention() ->
+    L = livery_ratelimit:limiter(5, 0),
+    T = <<"cas">>,
+    Self = self(),
+    N = 20,
+    [
+        spawn(fun() -> Self ! {result, status(run(L, T))} end)
+     || _ <- lists:seq(1, N)
+    ],
+    Statuses = [
+        receive
+            {result, S} -> S
+        after 5000 -> error(timeout)
+        end
+     || _ <- lists:seq(1, N)
+    ],
+    ?assertEqual(5, length([ok || 200 <- Statuses])),
+    ?assertEqual(15, length([ok || 429 <- Statuses])).
+
+cleanup_keeps_exhausted() ->
+    L = livery_ratelimit:limiter(1, 0),
+    T = <<"hot">>,
+    ?assertEqual(200, status(run(L, T))),
+    ?assertEqual(429, status(run(L, T))),
+    _ = livery_ratelimit_store:sweep(),
+    ?assertEqual(429, status(run(L, T))).
+
+cleanup_removes_full() ->
+    L = livery_ratelimit:limiter(1, 1000),
+    Name = maps:get(name, L),
+    F = <<"fullkey">>,
+    ?assertEqual(200, status(run(L, F))),
+    timer:sleep(10),
+    _ = livery_ratelimit_store:sweep(),
+    ?assertEqual(
+        [], ets:lookup(livery_ratelimit, {Name, crypto:hash(sha256, F)})
+    ).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+run(Limiter, Token) ->
+    livery_test_adapter:run(
+        [{livery_ratelimit, Limiter}],
+        fun(_R) -> livery_resp:text(200, <<"ok">>) end,
+        #{headers => [{<<"authorization">>, <<"Bearer ", Token/binary>>}]}
+    ).
+
+status(Cap) ->
+    livery_test_adapter:status(Cap).
+
+hdr(Name, Cap) ->
+    livery_test_adapter:header(Name, Cap).


### PR DESCRIPTION
## Summary
- `livery_ratelimit`: per-key token-bucket throttling. `limiter/2,3` builds the stack State (`Capacity` burst + `RefillPerSec`); a request consumes a token, an empty bucket sheds `429`. The key defaults to the Authorization bearer token (client IP is not surfaced by the wire libs); a keyless request passes through. Keys are SHA-256 hashed before storage, so raw tokens are never kept. Allowed responses carry `RateLimit-Limit`/`-Remaining`/`-Reset`; a 429 adds `Retry-After`. `status`/`body`/`headers`/`name`/`key` are configurable.
- `livery_ratelimit_store`: a supervised gen_server owning a public ETS table. The token-bucket decision runs lock-free in the caller (first touch via `insert_new`, consume via a CAS `select_replace`, no write on deny). Cleanup deletes ONLY fully-refilled buckets, so a hot/exhausted key is never reset; `RefillPerSec = 0` buckets persist (pure quota).
- Tests: EUnit (burst, refill, no-key skip, headers, isolation, custom key/status/body, a count-based CAS-contention test, and cleanup correctness) plus a deterministic `rate_limit_shed` parity case (200 then 429) across test_adapter/h1/h2/h3.

Resolves backlog item #7.