### PR TITLE
Add HTTP caching middleware (ETag and conditional GET)

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -5,7 +5,7 @@ sibling library that owns the change.
 
 ## Framework-gap backlog (from the audit)
 
-Modern web/AI framework gaps, in priority order. Steps 1-6 are done.
+Modern web/AI framework gaps, in priority order. Steps 1-7 are done.
 
 1. Cancel on client disconnect. DONE: `livery_req:on_disconnect/2`
    plus the `{livery_disconnect, _, _}` message, delivered across
@@ -40,6 +40,9 @@ Modern web/AI framework gaps, in priority order. Steps 1-6 are done.
    `livery_ratelimit_store` ETS table. See
    `docs/guides/rate-limit-requests.md`.
 8. HTTP caching primitives (ETag, conditional GET, Cache-Control).
+   DONE: `livery_etag` (auto strong/weak ETag, `If-None-Match` -> 304,
+   handler override) plus `livery_resp:with_etag/2` and
+   `with_cache_control/2`. See `docs/guides/http-caching.md`.
 9. Static-directory serving with ETag/MIME.
 10. Health/readiness endpoints + Prometheus `/metrics`.
 

--- a/docs/guides/http-caching.md
+++ b/docs/guides/http-caching.md
@@ -1,0 +1,81 @@
+# How to add HTTP caching (ETag and Cache-Control)
+
+## Problem
+
+You want clients and CDNs to revalidate cheaply: hold a copy, send
+`If-None-Match`, and get a bodyless `304 Not Modified` when nothing
+changed. You also want to set `Cache-Control`.
+
+## Solution
+
+Add `livery_etag` to the stack. It gives a strong ETag to cacheable
+`GET`/`HEAD` responses and answers `304` on a matching `If-None-Match`:
+
+```erlang
+Stack = [
+    {livery_etag, #{}}
+    %% ... handler
+].
+```
+
+A first request returns `200` with an `ETag`; a later request that sends
+that ETag in `If-None-Match` gets a `304` with no body.
+
+## Setting your own ETag and Cache-Control
+
+The middleware computes an ETag automatically from `{full, _}` bodies
+that don't already have one. A handler can set its own (respected on any
+body type, including `file`/`chunked`):
+
+```erlang
+show(Req) ->
+    Resp = livery_resp:json(200, render(Req)),
+    R1 = livery_resp:with_etag(<<"post-42-v3">>, Resp),     %% -> ETag: "post-42-v3"
+    livery_resp:with_cache_control([public, {max_age, 300}], R1).
+```
+
+`with_cache_control/2` takes a verbatim binary or a directive list
+(`no_cache`, `no_store`, `public`, `private`, `immutable`,
+`must_revalidate`, `proxy_revalidate`, `no_transform`, `{max_age, N}`,
+`{s_maxage, N}`, `{stale_while_revalidate, N}`, `{stale_if_error, N}`).
+
+## Options
+
+```erlang
+{livery_etag, #{
+    auto => true,        %% auto-hash full bodies without an ETag (default)
+    weak => false,       %% auto ETags are strong "..."; true emits W/"..."
+    statuses => [200]    %% statuses eligible for ETag/304 (default [200])
+}}
+```
+
+With `auto => false` the middleware only acts on handler-set ETags.
+
+## Placement relative to compression
+
+Put `livery_etag` OUTSIDE `livery_compress` (earlier in the stack list)
+so the ETag covers the bytes actually sent on the wire:
+
+```erlang
+Stack = [{livery_etag, #{}}, {livery_compress, #{}} | Rest].
+```
+
+If you place it inside compression, the ETag is computed from the
+uncompressed body; rely on `Vary: Accept-Encoding` (which
+`livery_compress` already sets) so caches keep per-encoding variants
+distinct.
+
+## Notes
+
+- `If-None-Match: *` matches any current representation; weak comparison
+  (RFC 9110) is used, so `W/"x"` and `"x"` match.
+- The `304` is bodyless and drops `content-*` headers while preserving
+  `ETag`, `Cache-Control`, and `Vary`.
+- Only `GET`/`HEAD` are handled; unsafe-method preconditions (`412`) are
+  out of scope.
+
+## See also
+
+- Reference: `livery_etag`, `livery_resp` (`with_etag/2`,
+  `with_cache_control/2`)
+- Recipe: [Compress responses](compress-responses.md)

--- a/rebar.config
+++ b/rebar.config
@@ -104,6 +104,7 @@
         {"docs/guides/enable-cors.md", #{title => <<"Enable CORS">>}},
         {"docs/guides/set-security-headers.md", #{title => <<"Set security headers">>}},
         {"docs/guides/compress-responses.md", #{title => <<"Compress responses">>}},
+        {"docs/guides/http-caching.md", #{title => <<"Add HTTP caching">>}},
         {"docs/guides/openapi-and-validation.md", #{title => <<"OpenAPI docs and validation">>}},
         {"docs/guides/serve-mcp-tools.md", #{title => <<"Serve MCP tools">>}},
         {"docs/guides/serve-webtransport.md", #{title => <<"Serve WebTransport">>}},
@@ -165,6 +166,7 @@
             <<"docs/guides/enable-cors.md">>,
             <<"docs/guides/set-security-headers.md">>,
             <<"docs/guides/compress-responses.md">>,
+            <<"docs/guides/http-caching.md">>,
             <<"docs/guides/openapi-and-validation.md">>,
             <<"docs/guides/serve-mcp-tools.md">>,
             <<"docs/guides/serve-webtransport.md">>,
@@ -203,7 +205,8 @@
             livery_cors,
             livery_security_headers,
             livery_concurrency,
-            livery_ratelimit
+            livery_ratelimit,
+            livery_etag
         ]},
         {<<"Compression">>, [
             livery_compress,

--- a/src/livery_etag.erl
+++ b/src/livery_etag.erl
@@ -1,0 +1,164 @@
+-module(livery_etag).
+-moduledoc """
+ETag / conditional-GET middleware.
+
+For cacheable `GET`/`HEAD` responses it ensures an `ETag` header and
+answers `304 Not Modified` when the request's `If-None-Match` matches,
+skipping the body transfer.
+
+```erlang
+Stack = [{livery_etag, #{}} | Rest].
+```
+
+By default a strong ETag is computed automatically from a `{full, _}`
+body that has no ETag; a handler may instead set its own (via
+`livery_resp:with_etag/2`), which is respected on ANY body variant.
+Config keys (all optional): `auto` (default `true`), `weak` (default
+`false`, auto ETags are strong), `statuses` (cacheable statuses, default
+`[200]`).
+
+Placement: put `livery_etag` OUTSIDE `livery_compress` (earlier in the
+stack list) so the ETag covers the bytes actually sent; otherwise the
+ETag is of the uncompressed body and you rely on `Vary: Accept-Encoding`
+(which `livery_compress` already sets).
+""".
+-behaviour(livery_middleware).
+
+-export([call/3]).
+
+-define(STRIPPED, [
+    <<"content-length">>,
+    <<"content-type">>,
+    <<"content-encoding">>,
+    <<"content-range">>
+]).
+
+-doc "Add an ETag and answer 304 on a matching conditional GET.".
+-spec call(livery_req:req(), livery_middleware:next(), map() | undefined) ->
+    livery_resp:resp().
+call(Req, Next, State) ->
+    Cfg = config(State),
+    Resp = Next(Req),
+    case eligible(Req, Resp, Cfg) of
+        false -> Resp;
+        true -> conditional(Req, ensure_etag(Resp, Cfg))
+    end.
+
+%%====================================================================
+%% Eligibility
+%%====================================================================
+
+-spec config(map() | undefined) -> map().
+config(undefined) ->
+    config(#{});
+config(State) when is_map(State) ->
+    #{
+        auto => maps:get(auto, State, true),
+        weak => maps:get(weak, State, false),
+        statuses => maps:get(statuses, State, [200])
+    }.
+
+-spec eligible(livery_req:req(), livery_resp:resp(), map()) -> boolean().
+eligible(Req, Resp, #{statuses := Statuses}) ->
+    conditional_method(livery_req:method(Req)) andalso
+        lists:member(livery_resp:status(Resp), Statuses).
+
+-spec conditional_method(binary()) -> boolean().
+conditional_method(<<"GET">>) -> true;
+conditional_method(<<"HEAD">>) -> true;
+conditional_method(_Other) -> false.
+
+%%====================================================================
+%% ETag
+%%====================================================================
+
+-spec ensure_etag(livery_resp:resp(), map()) -> livery_resp:resp().
+ensure_etag(Resp, #{auto := Auto, weak := Weak}) ->
+    case {has_etag(Resp), Auto} of
+        {true, _} -> Resp;
+        {false, true} -> auto_etag(Resp, Weak);
+        {false, false} -> Resp
+    end.
+
+-spec has_etag(livery_resp:resp()) -> boolean().
+has_etag(Resp) ->
+    lists:keymember(<<"etag">>, 1, livery_resp:headers(Resp)).
+
+-spec auto_etag(livery_resp:resp(), boolean()) -> livery_resp:resp().
+auto_etag(Resp, Weak) ->
+    case livery_resp:body(Resp) of
+        {full, Body} ->
+            livery_resp:with_header(<<"etag">>, compute_etag(Body, Weak), Resp);
+        _Other ->
+            Resp
+    end.
+
+-spec compute_etag(iodata(), boolean()) -> binary().
+compute_etag(Body, Weak) ->
+    Hash = base64:encode(binary:part(crypto:hash(sha256, Body), 0, 16)),
+    case Weak of
+        true -> <<"W/\"", Hash/binary, "\"">>;
+        false -> <<$", Hash/binary, $">>
+    end.
+
+%%====================================================================
+%% Conditional GET
+%%====================================================================
+
+-spec conditional(livery_req:req(), livery_resp:resp()) -> livery_resp:resp().
+conditional(Req, Resp) ->
+    case etag_value(Resp) of
+        undefined ->
+            Resp;
+        ETag ->
+            case matches(Req, ETag) of
+                true -> to_304(Resp);
+                false -> Resp
+            end
+    end.
+
+-spec etag_value(livery_resp:resp()) -> binary() | undefined.
+etag_value(Resp) ->
+    case lists:keyfind(<<"etag">>, 1, livery_resp:headers(Resp)) of
+        {_, Value} -> Value;
+        false -> undefined
+    end.
+
+-spec matches(livery_req:req(), binary()) -> boolean().
+matches(Req, ETag) ->
+    Tags = if_none_match_tags(Req),
+    lists:member(<<"*">>, Tags) orelse
+        lists:any(fun(Tag) -> weak_equal(Tag, ETag) end, Tags).
+
+%% Collect every If-None-Match instance and comma-split each.
+-spec if_none_match_tags(livery_req:req()) -> [binary()].
+if_none_match_tags(Req) ->
+    Values = livery_req:headers_all(<<"if-none-match">>, Req),
+    lists:flatmap(fun split_tags/1, Values).
+
+-spec split_tags(binary()) -> [binary()].
+split_tags(Value) ->
+    Parts = [trim(P) || P <- binary:split(Value, <<",">>, [global])],
+    [P || P <- Parts, P =/= <<>>].
+
+%% Weak comparison (RFC 9110): ignore a leading `W/` on either side.
+-spec weak_equal(binary(), binary()) -> boolean().
+weak_equal(A, B) ->
+    strip_weak(A) =:= strip_weak(B).
+
+-spec strip_weak(binary()) -> binary().
+strip_weak(<<"W/", Rest/binary>>) -> Rest;
+strip_weak(Tag) -> Tag.
+
+-spec to_304(livery_resp:resp()) -> livery_resp:resp().
+to_304(Resp) ->
+    Kept = [
+        Header
+     || {Name, _} = Header <- livery_resp:headers(Resp),
+        not lists:member(Name, ?STRIPPED)
+    ],
+    livery_resp:new(304, Kept, empty).
+
+-spec trim(binary()) -> binary().
+trim(Bin) ->
+    iolist_to_binary(string:trim(Bin)).

--- a/src/livery_resp.erl
+++ b/src/livery_resp.erl
@@ -25,6 +25,8 @@ Response builders here are pure: they never touch sockets.
     delete_header/2,
     with_trailers/2,
     with_body/2,
+    with_etag/2,
+    with_cache_control/2,
 
     text/2,
     text/3,
@@ -51,7 +53,21 @@ Response builders here are pure: they never touch sockets.
     upgrade/2
 ]).
 
--export_type([resp/0, body/0]).
+-export_type([resp/0, body/0, cache_directive/0]).
+
+-type cache_directive() ::
+    no_cache
+    | no_store
+    | public
+    | private
+    | immutable
+    | must_revalidate
+    | proxy_revalidate
+    | no_transform
+    | {max_age, non_neg_integer()}
+    | {s_maxage, non_neg_integer()}
+    | {stale_while_revalidate, non_neg_integer()}
+    | {stale_if_error, non_neg_integer()}.
 
 -type resp() :: #livery_resp{}.
 -type header_name() :: binary().
@@ -147,6 +163,29 @@ after the handler has produced the response.
 -spec with_body(body(), resp()) -> resp().
 with_body(Body, Resp) ->
     Resp#livery_resp{body = Body}.
+
+-doc """
+Set the `ETag` header.
+
+A value already shaped as a strong (`"..."`) or weak (`W/"..."`) tag is
+used as-is; a bare token is wrapped as a strong ETag.
+""".
+-spec with_etag(binary(), resp()) -> resp().
+with_etag(Tag, Resp) ->
+    with_header(<<"etag">>, format_etag(Tag), Resp).
+
+-doc """
+Set the `Cache-Control` header.
+
+Pass a verbatim binary, or a list of directives: the atoms `no_cache`,
+`no_store`, `public`, `private`, `immutable`, `must_revalidate`,
+`proxy_revalidate`, `no_transform`, or the tuples `{max_age, Secs}`,
+`{s_maxage, Secs}`, `{stale_while_revalidate, Secs}`,
+`{stale_if_error, Secs}`.
+""".
+-spec with_cache_control(binary() | [cache_directive()], resp()) -> resp().
+with_cache_control(Value, Resp) ->
+    with_header(<<"cache-control">>, format_cache_control(Value), Resp).
 
 %%====================================================================
 %% Convenience builders
@@ -368,3 +407,40 @@ is_lower_ascii(_) -> false.
 -spec delete_all(binary(), [{binary(), term()}]) -> [{binary(), term()}].
 delete_all(Key, L) ->
     [KV || {K, _} = KV <- L, K =/= Key].
+
+-spec format_etag(binary()) -> binary().
+format_etag(<<"W/", _/binary>> = Weak) -> Weak;
+format_etag(<<$", _/binary>> = Quoted) -> Quoted;
+format_etag(Tag) -> <<$", Tag/binary, $">>.
+
+-spec format_cache_control(binary() | [cache_directive()]) -> binary().
+format_cache_control(Value) when is_binary(Value) ->
+    Value;
+format_cache_control(Directives) when is_list(Directives) ->
+    iolist_to_binary(lists:join(<<", ">>, [cc_directive(D) || D <- Directives])).
+
+-spec cc_directive(cache_directive()) -> binary().
+cc_directive(no_cache) ->
+    <<"no-cache">>;
+cc_directive(no_store) ->
+    <<"no-store">>;
+cc_directive(public) ->
+    <<"public">>;
+cc_directive(private) ->
+    <<"private">>;
+cc_directive(immutable) ->
+    <<"immutable">>;
+cc_directive(must_revalidate) ->
+    <<"must-revalidate">>;
+cc_directive(proxy_revalidate) ->
+    <<"proxy-revalidate">>;
+cc_directive(no_transform) ->
+    <<"no-transform">>;
+cc_directive({max_age, Secs}) ->
+    <<"max-age=", (integer_to_binary(Secs))/binary>>;
+cc_directive({s_maxage, Secs}) ->
+    <<"s-maxage=", (integer_to_binary(Secs))/binary>>;
+cc_directive({stale_while_revalidate, Secs}) ->
+    <<"stale-while-revalidate=", (integer_to_binary(Secs))/binary>>;
+cc_directive({stale_if_error, Secs}) ->
+    <<"stale-if-error=", (integer_to_binary(Secs))/binary>>.

--- a/test/livery_builtin_middleware_tests.erl
+++ b/test/livery_builtin_middleware_tests.erl
@@ -565,8 +565,157 @@ concurrency_holds_and_releases_test() ->
     ?assertEqual(200, livery_test_adapter:status(Cap4)).
 
 %%====================================================================
+%% livery_etag
+%%====================================================================
+
+etag_auto_added_on_full_get_test() ->
+    Cap = run_get([{livery_etag, #{}}], json_handler(), []),
+    ?assertEqual(200, livery_test_adapter:status(Cap)),
+    E = livery_test_adapter:header(<<"etag">>, Cap),
+    ?assertMatch(<<$", _/binary>>, E).
+
+etag_absent_on_chunked_test() ->
+    Producer = fun(Emit) ->
+        Emit(<<"x">>),
+        ok
+    end,
+    Cap = run_get(
+        [{livery_etag, #{}}],
+        fun(_R) -> livery_resp:stream(200, [], Producer) end,
+        []
+    ),
+    ?assertEqual(undefined, livery_test_adapter:header(<<"etag">>, Cap)).
+
+etag_absent_on_post_test() ->
+    Cap = livery_test_adapter:run(
+        [{livery_etag, #{}}], json_handler(), #{method => <<"POST">>}
+    ),
+    ?assertEqual(undefined, livery_test_adapter:header(<<"etag">>, Cap)).
+
+etag_304_on_match_test() ->
+    First = run_get([{livery_etag, #{}}], json_handler(), []),
+    E = livery_test_adapter:header(<<"etag">>, First),
+    Cap = run_get([{livery_etag, #{}}], json_handler(), [{<<"if-none-match">>, E}]),
+    ?assertEqual(304, livery_test_adapter:status(Cap)),
+    ?assertEqual(<<>>, livery_test_adapter:body(Cap)),
+    ?assertEqual(E, livery_test_adapter:header(<<"etag">>, Cap)),
+    ?assertEqual(undefined, livery_test_adapter:header(<<"content-type">>, Cap)).
+
+etag_304_on_star_test() ->
+    Cap = run_get(
+        [{livery_etag, #{}}], json_handler(), [{<<"if-none-match">>, <<"*">>}]
+    ),
+    ?assertEqual(304, livery_test_adapter:status(Cap)).
+
+etag_200_on_nomatch_test() ->
+    Cap = run_get(
+        [{livery_etag, #{}}], json_handler(), [{<<"if-none-match">>, <<"\"other\"">>}]
+    ),
+    ?assertEqual(200, livery_test_adapter:status(Cap)),
+    ?assertEqual(<<"{\"a\":1}">>, livery_test_adapter:body(Cap)),
+    ?assert(is_binary(livery_test_adapter:header(<<"etag">>, Cap))).
+
+etag_handler_set_preserved_test() ->
+    H = fun(_R) -> livery_resp:with_etag(<<"v1">>, livery_resp:json(200, <<"{}">>)) end,
+    Cap = run_get([{livery_etag, #{}}], H, []),
+    ?assertEqual(<<"\"v1\"">>, livery_test_adapter:header(<<"etag">>, Cap)),
+    Cap2 = run_get([{livery_etag, #{}}], H, [{<<"if-none-match">>, <<"\"v1\"">>}]),
+    ?assertEqual(304, livery_test_adapter:status(Cap2)).
+
+etag_handler_set_on_chunked_304_test() ->
+    %% Conditional handling is NOT gated on {full, _}.
+    Producer = fun(Emit) ->
+        Emit(<<"data">>),
+        ok
+    end,
+    H = fun(_R) ->
+        livery_resp:with_etag(<<"c1">>, livery_resp:stream(200, [], Producer))
+    end,
+    Cap = run_get([{livery_etag, #{}}], H, [{<<"if-none-match">>, <<"\"c1\"">>}]),
+    ?assertEqual(304, livery_test_adapter:status(Cap)),
+    ?assertEqual(<<>>, livery_test_adapter:body(Cap)).
+
+etag_weak_output_test() ->
+    Cap = run_get([{livery_etag, #{weak => true}}], json_handler(), []),
+    E = livery_test_adapter:header(<<"etag">>, Cap),
+    ?assertMatch(<<"W/\"", _/binary>>, E),
+    Cap2 = run_get(
+        [{livery_etag, #{weak => true}}], json_handler(), [{<<"if-none-match">>, E}]
+    ),
+    ?assertEqual(304, livery_test_adapter:status(Cap2)).
+
+etag_weak_comparison_test() ->
+    H = fun(_R) -> livery_resp:with_etag(<<"v1">>, livery_resp:json(200, <<"{}">>)) end,
+    Cap = run_get([{livery_etag, #{}}], H, [{<<"if-none-match">>, <<"W/\"v1\"">>}]),
+    ?assertEqual(304, livery_test_adapter:status(Cap)).
+
+etag_multiple_inm_headers_test() ->
+    H = fun(_R) -> livery_resp:with_etag(<<"v1">>, livery_resp:json(200, <<"{}">>)) end,
+    Cap = run_get([{livery_etag, #{}}], H, [
+        {<<"if-none-match">>, <<"\"nope\"">>},
+        {<<"if-none-match">>, <<"\"v1\"">>}
+    ]),
+    ?assertEqual(304, livery_test_adapter:status(Cap)).
+
+etag_auto_off_test() ->
+    Cap = run_get([{livery_etag, #{auto => false}}], json_handler(), []),
+    ?assertEqual(undefined, livery_test_adapter:header(<<"etag">>, Cap)).
+
+etag_cache_control_survives_304_test() ->
+    H = fun(_R) ->
+        R = livery_resp:with_cache_control(
+            [public, {max_age, 60}], livery_resp:json(200, <<"{}">>)
+        ),
+        livery_resp:with_etag(<<"v1">>, R)
+    end,
+    Cap = run_get([{livery_etag, #{}}], H, [{<<"if-none-match">>, <<"\"v1\"">>}]),
+    ?assertEqual(304, livery_test_adapter:status(Cap)),
+    ?assertEqual(
+        <<"public, max-age=60">>,
+        livery_test_adapter:header(<<"cache-control">>, Cap)
+    ).
+
+with_etag_quoting_test() ->
+    ?assertEqual(<<"\"abc\"">>, resp_etag(livery_resp:with_etag(<<"abc">>, base_resp()))),
+    ?assertEqual(
+        <<"\"abc\"">>, resp_etag(livery_resp:with_etag(<<"\"abc\"">>, base_resp()))
+    ),
+    ?assertEqual(
+        <<"W/\"abc\"">>, resp_etag(livery_resp:with_etag(<<"W/\"abc\"">>, base_resp()))
+    ).
+
+with_cache_control_format_test() ->
+    R1 = livery_resp:with_cache_control([public, {max_age, 60}, immutable], base_resp()),
+    ?assertEqual(<<"public, max-age=60, immutable">>, resp_cc(R1)),
+    R2 = livery_resp:with_cache_control(<<"no-store">>, base_resp()),
+    ?assertEqual(<<"no-store">>, resp_cc(R2)).
+
+%%====================================================================
 %% Helpers
 %%====================================================================
+
+run_get(Stack, Handler, ReqHeaders) ->
+    livery_test_adapter:run(
+        Stack, Handler, #{method => <<"GET">>, headers => ReqHeaders}
+    ).
+
+json_handler() ->
+    fun(_R) -> livery_resp:json(200, <<"{\"a\":1}">>) end.
+
+base_resp() ->
+    livery_resp:json(200, <<"{}">>).
+
+resp_etag(Resp) ->
+    resp_header(<<"etag">>, Resp).
+
+resp_cc(Resp) ->
+    resp_header(<<"cache-control">>, Resp).
+
+resp_header(Name, Resp) ->
+    case lists:keyfind(Name, 1, livery_resp:headers(Resp)) of
+        {_, V} -> V;
+        false -> undefined
+    end.
 
 run_cors(Cfg, Spec) ->
     livery_test_adapter:run(

--- a/test/livery_parity_SUITE.erl
+++ b/test/livery_parity_SUITE.erl
@@ -43,7 +43,8 @@
     gzip_with_trailers/1,
     multipart_echo/1,
     concurrency_shed/1,
-    rate_limit_shed/1
+    rate_limit_shed/1,
+    conditional_get/1
 ]).
 
 %%====================================================================
@@ -71,7 +72,8 @@ groups() ->
         gzip_with_trailers,
         multipart_echo,
         concurrency_shed,
-        rate_limit_shed
+        rate_limit_shed,
+        conditional_get
     ],
     [
         {test_adapter, [parallel], Shared ++ [response_with_trailers]},
@@ -433,6 +435,17 @@ rate_limit_shed(Config) ->
     H = fun(_R) -> livery_resp:text(200, <<"ok">>) end,
     ?assertEqual(200, status(drive(Config, Stack, H, #{}))),
     ?assertEqual(429, status(drive(Config, Stack, H, #{}))).
+
+conditional_get(Config) ->
+    Stack = [{livery_etag, #{}}],
+    H = fun(_R) -> livery_resp:json(200, <<"{\"v\":1}">>) end,
+    R1 = drive(Config, Stack, H, #{}),
+    ?assertEqual(200, status(R1)),
+    ETag = header(<<"etag">>, R1),
+    ?assert(is_binary(ETag)),
+    R2 = drive(Config, Stack, H, #{headers => [{<<"if-none-match">>, ETag}]}),
+    ?assertEqual(304, status(R2)),
+    ?assertEqual(<<>>, body(R2)).
 
 %%====================================================================
 %% Uniform driver API: returns a `response()' tuple


### PR DESCRIPTION
## Summary
- `livery_etag`: conditional-GET middleware. For cacheable `GET`/`HEAD` responses it ensures an `ETag` (auto strong hash of `{full,_}` bodies, or `W/"..."` with `weak => true`) and answers `304 Not Modified` when the request `If-None-Match` matches, skipping the body. A handler-set ETag (via `with_etag/2`) is respected on ANY body variant (so `file`/`chunked` responses can revalidate too); auto-hashing alone is limited to `{full,_}`. `If-None-Match` is parsed across all header instances, supports `*`, and uses RFC 9110 weak comparison. The `304` is bodyless and drops `content-*` while keeping `ETag`/`Cache-Control`/`Vary`.
- `livery_resp:with_etag/2` (quotes a bare token; keeps `W/`/quoted) and `with_cache_control/2` (verbatim binary or a directive list).
- Config: `auto` (default true), `weak` (default false), `statuses` (default `[200]`). Docs note placement relative to `livery_compress`.
- Tests: 15 EUnit cases plus a `conditional_get` parity case (200 + ETag, then 304) across test_adapter/h1/h2/h3.

Resolves backlog item #8.