### PR TITLE
Add static-directory file handler

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -5,7 +5,7 @@ sibling library that owns the change.
 
 ## Framework-gap backlog (from the audit)
 
-Modern web/AI framework gaps, in priority order. Steps 1-7 are done.
+Modern web/AI framework gaps, in priority order. Steps 1-8 are done.
 
 1. Cancel on client disconnect. DONE: `livery_req:on_disconnect/2`
    plus the `{livery_disconnect, _, _}` message, delivered across
@@ -43,7 +43,10 @@ Modern web/AI framework gaps, in priority order. Steps 1-7 are done.
    DONE: `livery_etag` (auto strong/weak ETag, `If-None-Match` -> 304,
    handler override) plus `livery_resp:with_etag/2` and
    `with_cache_control/2`. See `docs/guides/http-caching.md`.
-9. Static-directory serving with ETag/MIME.
+9. Static-directory serving with ETag/MIME. DONE: `livery_static`
+   (`handler/1,2` mounted on a `*path` wildcard route; MIME by extension,
+   weak ETag + conditional GET, Range, directory index, strict path
+   confinement). See `docs/guides/serve-static-files.md`.
 10. Health/readiness endpoints + Prometheus `/metrics`.
 
 ## Benchmarking: H3 needs an external client

--- a/docs/guides/serve-static-files.md
+++ b/docs/guides/serve-static-files.md
@@ -1,0 +1,77 @@
+# How to serve static files
+
+## Problem
+
+You want to serve a directory of files (assets, a built SPA, downloads)
+over HTTP, with correct `Content-Type`, conditional GET, and `Range`
+support - without exposing anything outside the directory.
+
+## Solution
+
+Mount `livery_static:handler/1,2` on a router WILDCARD route. The `*path`
+segment captures the rest of the URL, which the handler maps to a file
+under the root:
+
+```erlang
+Router = livery_router:add(
+    '_', <<"/assets/*path">>, livery_static:handler("priv/assets"), #{}, Router0
+).
+```
+
+`GET /assets/css/app.css` serves `priv/assets/css/app.css` with
+`Content-Type: text/css`, an `ETag`, and (if the client sends `Range`)
+partial content.
+
+## Without the router
+
+If you are not using the router, configure a `prefix` to strip from the
+request path:
+
+```erlang
+{livery_static, never}  %% NB: it is a handler, not middleware
+%% as a service handler:
+livery:start_listener(h1, #{
+    port => 8080,
+    handler => livery_static:handler("public", #{prefix => <<"/">>})
+}).
+```
+
+## Options
+
+```erlang
+livery_static:handler("priv/assets", #{
+    binding => <<"path">>,                 %% router binding name (default)
+    prefix => <<"/assets/">>,              %% fallback when there is no binding
+    index => <<"index.html">>,             %% served for a directory; false to disable
+    cache_control => [{max_age, 3600}, public],  %% optional Cache-Control
+    etag => true,                          %% weak ETag from size+mtime (default)
+    range => true                          %% honor Range requests (default)
+}).
+```
+
+## Behavior
+
+- `Content-Type` is inferred from the file extension (text types get
+  `; charset=utf-8`), defaulting to `application/octet-stream`.
+- A weak `ETag` (`W/"size-mtime"`) is emitted; a matching
+  `If-None-Match` returns `304 Not Modified`.
+- `Range: bytes=...` returns `206 Partial Content`; an unsatisfiable
+  range returns `416`.
+- `HEAD` returns headers (including `Content-Length`) with no body.
+- Only `GET`/`HEAD` are served; other methods get `405` with `Allow`.
+- A directory request serves `index` if present, else `404` (no
+  directory listing).
+
+## Security
+
+The sub-path is percent-decoded and then confined: any `..` segment,
+absolute path, control byte, or bad escape is rejected with `404`, so a
+request can never traverse out of the root. Only regular files are
+served - directories and symlinks yield `404` - so a symlink inside the
+root cannot be used to escape it.
+
+## See also
+
+- Reference: `livery_static`, `livery_resp` (`file/2,3`)
+- Recipe: [Add HTTP caching](http-caching.md)
+- Recipe: [Serve a file](serve-a-file.md)

--- a/rebar.config
+++ b/rebar.config
@@ -5,6 +5,7 @@
 ]}.
 
 {deps, [
+    {mimerl, "1.5.0"},
     {h1, "0.2.2", {pkg, erlang_h1}},
     {h2, "0.6.0"},
     {quic, "1.4.2"},
@@ -310,8 +311,6 @@
             {elvis_style, dont_repeat_yourself, #{
                 ignore => [livery, livery_openapi, livery_ratelimit_store]
             }},
-            %% livery_static: the MIME extension table is a long but flat
-            %% map literal.
             {elvis_style, max_function_length, #{
                 ignore => [
                     livery,
@@ -320,8 +319,7 @@
                     livery_h3,
                     livery_mcp,
                     livery_openapi_validate,
-                    livery_router,
-                    livery_static
+                    livery_router
                 ]
             }},
             {elvis_style, max_function_clause_length, #{
@@ -332,8 +330,7 @@
                     livery_h3,
                     livery_mcp,
                     livery_openapi_validate,
-                    livery_router,
-                    livery_static
+                    livery_router
                 ]
             }},
             %% Long lines are CDN URL string literals in the doc-UI

--- a/rebar.config
+++ b/rebar.config
@@ -89,6 +89,7 @@
         {"docs/guides/server-sent-events.md", #{title => <<"Return Server-Sent Events">>}},
         {"docs/guides/return-trailers.md", #{title => <<"Return trailers">>}},
         {"docs/guides/serve-a-file.md", #{title => <<"Serve a file">>}},
+        {"docs/guides/serve-static-files.md", #{title => <<"Serve static files">>}},
         {"docs/guides/empty-and-redirects.md", #{title => <<"Empty and redirect responses">>}},
         {"docs/guides/custom-middleware.md", #{title => <<"Write a custom middleware">>}},
         {"docs/guides/cap-body-size.md", #{title => <<"Cap request body size">>}},
@@ -153,6 +154,7 @@
             <<"docs/guides/server-sent-events.md">>,
             <<"docs/guides/return-trailers.md">>,
             <<"docs/guides/serve-a-file.md">>,
+            <<"docs/guides/serve-static-files.md">>,
             <<"docs/guides/empty-and-redirects.md">>,
             <<"docs/guides/custom-middleware.md">>,
             <<"docs/guides/cap-body-size.md">>,
@@ -194,7 +196,8 @@
             livery_req,
             livery_resp,
             livery_ext,
-            livery_multipart
+            livery_multipart,
+            livery_static
         ]},
         {<<"Routing and middleware">>, [livery_router, livery_middleware]},
         {<<"Built-in middleware">>, [
@@ -307,6 +310,8 @@
             {elvis_style, dont_repeat_yourself, #{
                 ignore => [livery, livery_openapi, livery_ratelimit_store]
             }},
+            %% livery_static: the MIME extension table is a long but flat
+            %% map literal.
             {elvis_style, max_function_length, #{
                 ignore => [
                     livery,
@@ -315,7 +320,8 @@
                     livery_h3,
                     livery_mcp,
                     livery_openapi_validate,
-                    livery_router
+                    livery_router,
+                    livery_static
                 ]
             }},
             {elvis_style, max_function_clause_length, #{
@@ -326,7 +332,8 @@
                     livery_h3,
                     livery_mcp,
                     livery_openapi_validate,
-                    livery_router
+                    livery_router,
+                    livery_static
                 ]
             }},
             %% Long lines are CDN URL string literals in the doc-UI

--- a/src/livery.app.src
+++ b/src/livery.app.src
@@ -10,6 +10,7 @@
         crypto,
         public_key,
         inets,
+        mimerl,
         h1,
         h2,
         quic,

--- a/src/livery_etag.erl
+++ b/src/livery_etag.erl
@@ -24,7 +24,7 @@ ETag is of the uncompressed body and you rely on `Vary: Accept-Encoding`
 """.
 -behaviour(livery_middleware).
 
--export([call/3]).
+-export([call/3, if_none_match/2]).
 
 -define(STRIPPED, [
     <<"content-length">>,
@@ -111,7 +111,7 @@ conditional(Req, Resp) ->
         undefined ->
             Resp;
         ETag ->
-            case matches(Req, ETag) of
+            case if_none_match(Req, ETag) of
                 true -> to_304(Resp);
                 false -> Resp
             end
@@ -124,8 +124,14 @@ etag_value(Resp) ->
         false -> undefined
     end.
 
--spec matches(livery_req:req(), binary()) -> boolean().
-matches(Req, ETag) ->
+-doc """
+True if the request's `If-None-Match` matches `ETag`.
+
+Honors `*` and uses RFC 9110 weak comparison. Exposed so other handlers
+(e.g. `livery_static`) share one conditional-request implementation.
+""".
+-spec if_none_match(livery_req:req(), binary()) -> boolean().
+if_none_match(Req, ETag) ->
     Tags = if_none_match_tags(Req),
     lists:member(<<"*">>, Tags) orelse
         lists:any(fun(Tag) -> weak_equal(Tag, ETag) end, Tags).

--- a/src/livery_static.erl
+++ b/src/livery_static.erl
@@ -251,47 +251,16 @@ etag(Size, Mtime) ->
     M = integer_to_binary(Mtime),
     <<"W/\"", S/binary, "-", M/binary, "\"">>.
 
+%% Look up the MIME type via `mimerl` (it expects a binary path so that
+%% `filename:extension/1` yields a binary), then add a UTF-8 charset to
+%% `text/*` types.
 -spec mime_type(string()) -> binary().
 mime_type(Path) ->
-    Ext = string:lowercase(filename:extension(Path)),
-    maps:get(iolist_to_binary(Ext), mime_map(), <<"application/octet-stream">>).
+    with_charset(mimerl:filename(iolist_to_binary(Path))).
 
--spec mime_map() -> #{binary() => binary()}.
-mime_map() ->
-    #{
-        <<".html">> => <<"text/html; charset=utf-8">>,
-        <<".htm">> => <<"text/html; charset=utf-8">>,
-        <<".css">> => <<"text/css; charset=utf-8">>,
-        <<".js">> => <<"text/javascript; charset=utf-8">>,
-        <<".mjs">> => <<"text/javascript; charset=utf-8">>,
-        <<".json">> => <<"application/json">>,
-        <<".xml">> => <<"application/xml">>,
-        <<".txt">> => <<"text/plain; charset=utf-8">>,
-        <<".md">> => <<"text/markdown; charset=utf-8">>,
-        <<".csv">> => <<"text/csv; charset=utf-8">>,
-        <<".svg">> => <<"image/svg+xml">>,
-        <<".png">> => <<"image/png">>,
-        <<".jpg">> => <<"image/jpeg">>,
-        <<".jpeg">> => <<"image/jpeg">>,
-        <<".gif">> => <<"image/gif">>,
-        <<".webp">> => <<"image/webp">>,
-        <<".avif">> => <<"image/avif">>,
-        <<".ico">> => <<"image/x-icon">>,
-        <<".woff">> => <<"font/woff">>,
-        <<".woff2">> => <<"font/woff2">>,
-        <<".ttf">> => <<"font/ttf">>,
-        <<".otf">> => <<"font/otf">>,
-        <<".wasm">> => <<"application/wasm">>,
-        <<".pdf">> => <<"application/pdf">>,
-        <<".zip">> => <<"application/zip">>,
-        <<".gz">> => <<"application/gzip">>,
-        <<".map">> => <<"application/json">>,
-        <<".webmanifest">> => <<"application/manifest+json">>,
-        <<".mp4">> => <<"video/mp4">>,
-        <<".webm">> => <<"video/webm">>,
-        <<".mp3">> => <<"audio/mpeg">>,
-        <<".wav">> => <<"audio/wav">>
-    }.
+-spec with_charset(binary()) -> binary().
+with_charset(<<"text/", _/binary>> = Type) -> <<Type/binary, "; charset=utf-8">>;
+with_charset(Type) -> Type.
 
 %% Parse a single `Range: bytes=A-B | A- | -N` into `{Offset, Length|eof}`;
 %% `undefined` when absent, multi-range, or malformed (emit yields 416 on

--- a/src/livery_static.erl
+++ b/src/livery_static.erl
@@ -1,0 +1,364 @@
+-module(livery_static).
+-moduledoc """
+Static-directory file handler.
+
+Returns a handler that serves files from a root directory, inferring
+`Content-Type` from the extension, emitting a weak ETag for conditional
+GET, honoring `Range`, and confining every path under the root so a
+request can never traverse out of it.
+
+Mount it on a router wildcard route and read the captured sub-path:
+
+```erlang
+Router = livery_router:add(
+    '_', <<"/assets/*path">>, livery_static:handler("priv/assets"), #{}, Router0
+).
+```
+
+Without a router binding it falls back to stripping a configured
+`prefix` from the request path. Options (all optional): `binding`
+(default `<<"path">>`), `prefix`, `index` (default `<<"index.html">>`,
+or `false`), `cache_control` (binary | directive list | `undefined`),
+`etag` (default `true`), `range` (default `true`).
+
+Security: the sub-path is percent-decoded and then confined - any `..`
+segment, control byte, or escape is rejected - and only regular files
+are served (directories and symlinks yield `404`).
+""".
+
+-include_lib("kernel/include/file.hrl").
+
+-export([handler/1, handler/2]).
+
+-type opts() :: #{
+    binding => binary(),
+    prefix => binary(),
+    index => binary() | false,
+    cache_control => binary() | [livery_resp:cache_directive()] | undefined,
+    etag => boolean(),
+    range => boolean()
+}.
+
+-export_type([opts/0]).
+
+-doc "Static handler serving regular files under `Root`.".
+-spec handler(file:name_all()) -> livery_middleware:handler().
+handler(Root) ->
+    handler(Root, #{}).
+
+-doc "`handler/1` with options.".
+-spec handler(file:name_all(), opts()) -> livery_middleware:handler().
+handler(Root, Opts) ->
+    NormRoot = normalize_root(Root),
+    Cfg = config(Opts),
+    fun(Req) -> serve(NormRoot, Cfg, Req) end.
+
+%%====================================================================
+%% Request handling
+%%====================================================================
+
+-spec serve(string(), map(), livery_req:req()) -> livery_resp:resp().
+serve(Root, Cfg, Req) ->
+    case livery_req:method(Req) of
+        <<"GET">> -> locate(Root, Cfg, Req, <<"GET">>);
+        <<"HEAD">> -> locate(Root, Cfg, Req, <<"HEAD">>);
+        _Other -> method_not_allowed()
+    end.
+
+-spec locate(string(), map(), livery_req:req(), binary()) -> livery_resp:resp().
+locate(Root, Cfg, Req, Method) ->
+    case resolve(Root, sub_path(Req, Cfg), maps:get(index, Cfg)) of
+        {ok, Path, Size, Mtime} ->
+            serve_file(Req, Method, Path, Size, Mtime, Cfg);
+        error ->
+            not_found()
+    end.
+
+-spec serve_file(
+    livery_req:req(), binary(), string(), non_neg_integer(), integer(), map()
+) -> livery_resp:resp().
+serve_file(Req, Method, Path, Size, Mtime, Cfg) ->
+    ETag = etag(Size, Mtime),
+    case maps:get(etag, Cfg) andalso livery_etag:if_none_match(Req, ETag) of
+        true ->
+            decorate(livery_resp:new(304, [], empty), ETag, Cfg);
+        false ->
+            body_response(Req, Method, Path, Size, ETag, Cfg)
+    end.
+
+-spec body_response(
+    livery_req:req(), binary(), string(), non_neg_integer(), binary(), map()
+) -> livery_resp:resp().
+body_response(_Req, <<"HEAD">>, Path, Size, ETag, Cfg) ->
+    Resp = livery_resp:new(
+        200,
+        [
+            {<<"content-type">>, mime_type(Path)},
+            {<<"content-length">>, integer_to_binary(Size)}
+        ],
+        empty
+    ),
+    decorate(Resp, ETag, Cfg);
+body_response(Req, <<"GET">>, Path, Size, ETag, Cfg) ->
+    Base =
+        case maps:get(range, Cfg) andalso parse_range(Req, Size) of
+            {Offset, Length} -> livery_resp:file(206, Path, {Offset, Length});
+            _NoRange -> livery_resp:file(200, Path)
+        end,
+    Resp = livery_resp:with_header(<<"content-type">>, mime_type(Path), Base),
+    decorate(Resp, ETag, Cfg).
+
+-spec decorate(livery_resp:resp(), binary(), map()) -> livery_resp:resp().
+decorate(Resp, ETag, #{etag := EtagOn, cache_control := CacheControl}) ->
+    R1 =
+        case EtagOn of
+            true -> livery_resp:with_header(<<"etag">>, ETag, Resp);
+            false -> Resp
+        end,
+    case CacheControl of
+        undefined -> R1;
+        _ -> livery_resp:with_cache_control(CacheControl, R1)
+    end.
+
+-spec method_not_allowed() -> livery_resp:resp().
+method_not_allowed() ->
+    livery_resp:with_header(
+        <<"allow">>, <<"GET, HEAD">>, livery_resp:text(405, <<"method not allowed">>)
+    ).
+
+-spec not_found() -> livery_resp:resp().
+not_found() ->
+    livery_resp:text(404, <<"not found">>).
+
+%%====================================================================
+%% Path resolution + confinement
+%%====================================================================
+
+-spec sub_path(livery_req:req(), map()) -> binary().
+sub_path(Req, #{binding := Binding, prefix := Prefix}) ->
+    case livery_req:binding(Binding, Req) of
+        undefined -> strip_prefix(livery_req:path(Req), Prefix);
+        Sub -> Sub
+    end.
+
+-spec strip_prefix(binary(), binary() | undefined) -> binary().
+strip_prefix(Path, undefined) ->
+    strip_leading_slash(Path);
+strip_prefix(Path, Prefix) ->
+    Size = byte_size(Prefix),
+    case Path of
+        <<Prefix:Size/binary, Rest/binary>> -> Rest;
+        _Other -> strip_leading_slash(Path)
+    end.
+
+-spec strip_leading_slash(binary()) -> binary().
+strip_leading_slash(<<"/", Rest/binary>>) -> Rest;
+strip_leading_slash(Path) -> Path.
+
+-spec resolve(string(), binary(), binary() | false) ->
+    {ok, string(), non_neg_integer(), integer()} | error.
+resolve(Root, Sub, Index) ->
+    case confine(Root, Sub) of
+        error -> error;
+        {ok, Path} -> stat(Path, Index)
+    end.
+
+-spec stat(string(), binary() | false) ->
+    {ok, string(), non_neg_integer(), integer()} | error.
+stat(Path, Index) ->
+    case file:read_link_info(Path, [{time, posix}]) of
+        {ok, #file_info{type = regular, size = Size, mtime = Mtime}} ->
+            {ok, Path, Size, Mtime};
+        {ok, #file_info{type = directory}} ->
+            stat_index(Path, Index);
+        _Other ->
+            error
+    end.
+
+-spec stat_index(string(), binary() | false) ->
+    {ok, string(), non_neg_integer(), integer()} | error.
+stat_index(_Path, false) ->
+    error;
+stat_index(Path, Index) when is_binary(Index) ->
+    stat(filename:join(Path, binary_to_list(Index)), false).
+
+%% Percent-decode, then split and reject any unsafe segment.
+-spec confine(string(), binary()) -> {ok, string()} | error.
+confine(Root, Sub) ->
+    case percent_decode(Sub) of
+        error ->
+            error;
+        {ok, Decoded} ->
+            case clean_segments(binary:split(Decoded, <<"/">>, [global]), []) of
+                {ok, Segments} -> {ok, filename:join([Root | Segments])};
+                error -> error
+            end
+    end.
+
+-spec clean_segments([binary()], [string()]) -> {ok, [string()]} | error.
+clean_segments([], Acc) ->
+    {ok, lists:reverse(Acc)};
+clean_segments([Segment | Rest], Acc) ->
+    case Segment of
+        <<>> ->
+            clean_segments(Rest, Acc);
+        <<".">> ->
+            clean_segments(Rest, Acc);
+        <<"..">> ->
+            error;
+        _ ->
+            case has_bad_byte(Segment) of
+                true -> error;
+                false -> clean_segments(Rest, [binary_to_list(Segment) | Acc])
+            end
+    end.
+
+-spec has_bad_byte(binary()) -> boolean().
+has_bad_byte(<<>>) -> false;
+has_bad_byte(<<C, _/binary>>) when C < 32; C =:= 127 -> true;
+has_bad_byte(<<_, Rest/binary>>) -> has_bad_byte(Rest).
+
+-spec percent_decode(binary()) -> {ok, binary()} | error.
+percent_decode(Bin) ->
+    percent_decode(Bin, <<>>).
+
+-spec percent_decode(binary(), binary()) -> {ok, binary()} | error.
+percent_decode(<<>>, Acc) ->
+    {ok, Acc};
+percent_decode(<<$%, H1, H2, Rest/binary>>, Acc) ->
+    case {hex(H1), hex(H2)} of
+        {{ok, A}, {ok, B}} -> percent_decode(Rest, <<Acc/binary, (A * 16 + B)>>);
+        _Bad -> error
+    end;
+percent_decode(<<$%, _/binary>>, _Acc) ->
+    error;
+percent_decode(<<C, Rest/binary>>, Acc) ->
+    percent_decode(Rest, <<Acc/binary, C>>).
+
+-spec hex(byte()) -> {ok, 0..15} | error.
+hex(C) when C >= $0, C =< $9 -> {ok, C - $0};
+hex(C) when C >= $a, C =< $f -> {ok, C - $a + 10};
+hex(C) when C >= $A, C =< $F -> {ok, C - $A + 10};
+hex(_C) -> error.
+
+%%====================================================================
+%% ETag, MIME, Range
+%%====================================================================
+
+-spec etag(non_neg_integer(), integer()) -> binary().
+etag(Size, Mtime) ->
+    S = integer_to_binary(Size),
+    M = integer_to_binary(Mtime),
+    <<"W/\"", S/binary, "-", M/binary, "\"">>.
+
+-spec mime_type(string()) -> binary().
+mime_type(Path) ->
+    Ext = string:lowercase(filename:extension(Path)),
+    maps:get(iolist_to_binary(Ext), mime_map(), <<"application/octet-stream">>).
+
+-spec mime_map() -> #{binary() => binary()}.
+mime_map() ->
+    #{
+        <<".html">> => <<"text/html; charset=utf-8">>,
+        <<".htm">> => <<"text/html; charset=utf-8">>,
+        <<".css">> => <<"text/css; charset=utf-8">>,
+        <<".js">> => <<"text/javascript; charset=utf-8">>,
+        <<".mjs">> => <<"text/javascript; charset=utf-8">>,
+        <<".json">> => <<"application/json">>,
+        <<".xml">> => <<"application/xml">>,
+        <<".txt">> => <<"text/plain; charset=utf-8">>,
+        <<".md">> => <<"text/markdown; charset=utf-8">>,
+        <<".csv">> => <<"text/csv; charset=utf-8">>,
+        <<".svg">> => <<"image/svg+xml">>,
+        <<".png">> => <<"image/png">>,
+        <<".jpg">> => <<"image/jpeg">>,
+        <<".jpeg">> => <<"image/jpeg">>,
+        <<".gif">> => <<"image/gif">>,
+        <<".webp">> => <<"image/webp">>,
+        <<".avif">> => <<"image/avif">>,
+        <<".ico">> => <<"image/x-icon">>,
+        <<".woff">> => <<"font/woff">>,
+        <<".woff2">> => <<"font/woff2">>,
+        <<".ttf">> => <<"font/ttf">>,
+        <<".otf">> => <<"font/otf">>,
+        <<".wasm">> => <<"application/wasm">>,
+        <<".pdf">> => <<"application/pdf">>,
+        <<".zip">> => <<"application/zip">>,
+        <<".gz">> => <<"application/gzip">>,
+        <<".map">> => <<"application/json">>,
+        <<".webmanifest">> => <<"application/manifest+json">>,
+        <<".mp4">> => <<"video/mp4">>,
+        <<".webm">> => <<"video/webm">>,
+        <<".mp3">> => <<"audio/mpeg">>,
+        <<".wav">> => <<"audio/wav">>
+    }.
+
+%% Parse a single `Range: bytes=A-B | A- | -N` into `{Offset, Length|eof}`;
+%% `undefined` when absent, multi-range, or malformed (emit yields 416 on
+%% an unsatisfiable but well-formed range).
+-spec parse_range(livery_req:req(), non_neg_integer()) ->
+    {non_neg_integer(), non_neg_integer() | eof} | undefined.
+parse_range(Req, Size) ->
+    case livery_req:header(<<"range">>, Req) of
+        <<"bytes=", Spec/binary>> -> range_spec(Spec, Size);
+        _Other -> undefined
+    end.
+
+-spec range_spec(binary(), non_neg_integer()) ->
+    {non_neg_integer(), non_neg_integer() | eof} | undefined.
+range_spec(Spec, Size) ->
+    case binary:split(Spec, <<"-">>) of
+        [<<>>, SuffixBin] -> suffix_range(SuffixBin, Size);
+        [StartBin, <<>>] -> open_range(StartBin);
+        [StartBin, EndBin] -> closed_range(StartBin, EndBin);
+        _Other -> undefined
+    end.
+
+-spec suffix_range(binary(), non_neg_integer()) ->
+    {non_neg_integer(), eof} | undefined.
+suffix_range(SuffixBin, Size) ->
+    case to_int(SuffixBin) of
+        {ok, N} when N > 0 -> {max(0, Size - N), eof};
+        _Other -> undefined
+    end.
+
+-spec open_range(binary()) -> {non_neg_integer(), eof} | undefined.
+open_range(StartBin) ->
+    case to_int(StartBin) of
+        {ok, Start} -> {Start, eof};
+        error -> undefined
+    end.
+
+-spec closed_range(binary(), binary()) ->
+    {non_neg_integer(), non_neg_integer()} | undefined.
+closed_range(StartBin, EndBin) ->
+    case {to_int(StartBin), to_int(EndBin)} of
+        {{ok, Start}, {ok, End}} when Start =< End -> {Start, End - Start + 1};
+        _Other -> undefined
+    end.
+
+-spec to_int(binary()) -> {ok, non_neg_integer()} | error.
+to_int(Bin) ->
+    case string:to_integer(Bin) of
+        {Int, <<>>} when is_integer(Int), Int >= 0 -> {ok, Int};
+        _Other -> error
+    end.
+
+%%====================================================================
+%% Config
+%%====================================================================
+
+-spec config(opts()) -> map().
+config(Opts) ->
+    #{
+        binding => maps:get(binding, Opts, <<"path">>),
+        prefix => maps:get(prefix, Opts, undefined),
+        index => maps:get(index, Opts, <<"index.html">>),
+        cache_control => maps:get(cache_control, Opts, undefined),
+        etag => maps:get(etag, Opts, true),
+        range => maps:get(range, Opts, true)
+    }.
+
+-spec normalize_root(file:name_all()) -> string().
+normalize_root(Root) when is_binary(Root) -> binary_to_list(Root);
+normalize_root(Root) -> Root.

--- a/test/livery_parity_SUITE.erl
+++ b/test/livery_parity_SUITE.erl
@@ -44,7 +44,8 @@
     multipart_echo/1,
     concurrency_shed/1,
     rate_limit_shed/1,
-    conditional_get/1
+    conditional_get/1,
+    static_file/1
 ]).
 
 %%====================================================================
@@ -73,7 +74,8 @@ groups() ->
         multipart_echo,
         concurrency_shed,
         rate_limit_shed,
-        conditional_get
+        conditional_get,
+        static_file
     ],
     [
         {test_adapter, [parallel], Shared ++ [response_with_trailers]},
@@ -446,6 +448,29 @@ conditional_get(Config) ->
     R2 = drive(Config, Stack, H, #{headers => [{<<"if-none-match">>, ETag}]}),
     ?assertEqual(304, status(R2)),
     ?assertEqual(<<>>, body(R2)).
+
+static_file(Config) ->
+    %% Parity requests target `/`, so serve the directory index.
+    Dir = filename:join(
+        temp_dir(),
+        "livery_parity_static_" ++ integer_to_list(erlang:unique_integer([positive]))
+    ),
+    ok = filelib:ensure_path(Dir),
+    Body = <<"<h1>static</h1>">>,
+    ok = file:write_file(filename:join(Dir, "index.html"), Body),
+    try
+        H = livery_static:handler(Dir, #{prefix => <<"/">>}),
+        R1 = drive(Config, [], H, #{}),
+        ?assertEqual(200, status(R1)),
+        ?assertEqual(Body, body(R1)),
+        ?assertEqual(<<"text/html; charset=utf-8">>, header(<<"content-type">>, R1)),
+        ETag = header(<<"etag">>, R1),
+        ?assert(is_binary(ETag)),
+        R2 = drive(Config, [], H, #{headers => [{<<"if-none-match">>, ETag}]}),
+        ?assertEqual(304, status(R2))
+    after
+        _ = file:del_dir_r(Dir)
+    end.
 
 %%====================================================================
 %% Uniform driver API: returns a `response()' tuple

--- a/test/livery_static_tests.erl
+++ b/test/livery_static_tests.erl
@@ -1,0 +1,156 @@
+-module(livery_static_tests).
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+static_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(Ctx) ->
+        [
+            {"serves a file with MIME + ETag", fun() -> serves_file(Ctx) end},
+            {"404 for a missing file", fun() -> missing(Ctx) end},
+            {"rejects literal traversal", fun() -> traversal_literal(Ctx) end},
+            {"rejects encoded traversal", fun() -> traversal_encoded(Ctx) end},
+            {"MIME by extension", fun() -> mime(Ctx) end},
+            {"conditional GET 304", fun() -> conditional(Ctx) end},
+            {"directory index", fun() -> index(Ctx) end},
+            {"index disabled", fun() -> index_disabled(Ctx) end},
+            {"405 on POST", fun() -> not_allowed(Ctx) end},
+            {"HEAD bodyless", fun() -> head(Ctx) end},
+            {"Range partial content", fun() -> range(Ctx) end},
+            {"Range suffix", fun() -> range_suffix(Ctx) end}
+        ]
+    end}.
+
+%%====================================================================
+%% Fixture
+%%====================================================================
+
+setup() ->
+    Base = filename:join(
+        temp_dir(), "livery_static_" ++ integer_to_list(erlang:unique_integer([positive]))
+    ),
+    Root = filename:join(Base, "root"),
+    ok = filelib:ensure_path(Root),
+    write(Root, "style.css", <<"body{margin:0}">>),
+    write(Root, "app.js", <<"console.log(1)">>),
+    write(Root, "logo.svg", <<"<svg/>">>),
+    write(Root, "data.bin", <<0, 1, 2, 3, 4, 5, 6, 7, 8, 9>>),
+    write(Root, "index.html", <<"<h1>home</h1>">>),
+    SecretName = "secret.txt",
+    ok = file:write_file(filename:join(Base, SecretName), <<"TOPSECRET">>),
+    #{base => Base, root => Root, secret => SecretName}.
+
+cleanup(#{base := Base}) ->
+    _ = file:del_dir_r(Base),
+    ok.
+
+write(Root, Name, Data) ->
+    ok = file:write_file(filename:join(Root, Name), Data).
+
+temp_dir() ->
+    case os:getenv("TMPDIR") of
+        false -> "/tmp";
+        Dir -> Dir
+    end.
+
+%%====================================================================
+%% Cases
+%%====================================================================
+
+serves_file(#{root := Root}) ->
+    Cap = run(handler(Root), <<"style.css">>),
+    ?assertEqual(200, status(Cap)),
+    ?assertEqual(<<"body{margin:0}">>, body(Cap)),
+    ?assertEqual(<<"text/css; charset=utf-8">>, hdr(<<"content-type">>, Cap)),
+    ?assertMatch(<<"W/\"", _/binary>>, hdr(<<"etag">>, Cap)).
+
+missing(#{root := Root}) ->
+    Cap = run(handler(Root), <<"nope.css">>),
+    ?assertEqual(404, status(Cap)).
+
+traversal_literal(#{root := Root, secret := Secret}) ->
+    Cap = run(handler(Root), <<"../", (list_to_binary(Secret))/binary>>),
+    ?assertEqual(404, status(Cap)),
+    ?assertNotEqual(<<"TOPSECRET">>, body(Cap)).
+
+traversal_encoded(#{root := Root, secret := Secret}) ->
+    Cap = run(handler(Root), <<"..%2f", (list_to_binary(Secret))/binary>>),
+    ?assertEqual(404, status(Cap)),
+    ?assertNotEqual(<<"TOPSECRET">>, body(Cap)).
+
+mime(#{root := Root}) ->
+    H = handler(Root),
+    ?assertEqual(
+        <<"text/javascript; charset=utf-8">>,
+        hdr(<<"content-type">>, run(H, <<"app.js">>))
+    ),
+    ?assertEqual(<<"image/svg+xml">>, hdr(<<"content-type">>, run(H, <<"logo.svg">>))),
+    ?assertEqual(
+        <<"application/octet-stream">>,
+        hdr(<<"content-type">>, run(H, <<"data.bin">>))
+    ).
+
+conditional(#{root := Root}) ->
+    H = handler(Root),
+    First = run(H, <<"style.css">>),
+    ETag = hdr(<<"etag">>, First),
+    Cap = run(H, <<"style.css">>, <<"GET">>, [{<<"if-none-match">>, ETag}]),
+    ?assertEqual(304, status(Cap)),
+    ?assertEqual(<<>>, body(Cap)).
+
+index(#{root := Root}) ->
+    Cap = run(handler(Root), <<>>),
+    ?assertEqual(200, status(Cap)),
+    ?assertEqual(<<"<h1>home</h1>">>, body(Cap)),
+    ?assertEqual(<<"text/html; charset=utf-8">>, hdr(<<"content-type">>, Cap)).
+
+index_disabled(#{root := Root}) ->
+    Cap = run(livery_static:handler(Root, #{index => false}), <<>>),
+    ?assertEqual(404, status(Cap)).
+
+not_allowed(#{root := Root}) ->
+    Cap = run(handler(Root), <<"style.css">>, <<"POST">>, []),
+    ?assertEqual(405, status(Cap)),
+    ?assertEqual(<<"GET, HEAD">>, hdr(<<"allow">>, Cap)).
+
+head(#{root := Root}) ->
+    Cap = run(handler(Root), <<"style.css">>, <<"HEAD">>, []),
+    ?assertEqual(200, status(Cap)),
+    ?assertEqual(<<"14">>, hdr(<<"content-length">>, Cap)),
+    ?assertEqual(<<>>, body(Cap)).
+
+range(#{root := Root}) ->
+    Cap = run(handler(Root), <<"style.css">>, <<"GET">>, [
+        {<<"range">>, <<"bytes=0-3">>}
+    ]),
+    ?assertEqual(206, status(Cap)),
+    ?assertEqual(<<"body">>, body(Cap)),
+    ?assert(is_binary(hdr(<<"content-range">>, Cap))).
+
+range_suffix(#{root := Root}) ->
+    Cap = run(handler(Root), <<"style.css">>, <<"GET">>, [
+        {<<"range">>, <<"bytes=-2">>}
+    ]),
+    ?assertEqual(206, status(Cap)),
+    ?assertEqual(<<"0}">>, body(Cap)).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+handler(Root) ->
+    livery_static:handler(Root).
+
+run(Handler, PathBinding) ->
+    run(Handler, PathBinding, <<"GET">>, []).
+
+run(Handler, PathBinding, Method, Headers) ->
+    livery_test_adapter:run([], Handler, #{
+        method => Method,
+        bindings => #{<<"path">> => PathBinding},
+        headers => Headers
+    }).
+
+status(Cap) -> livery_test_adapter:status(Cap).
+body(Cap) -> livery_test_adapter:body(Cap).
+hdr(Name, Cap) -> livery_test_adapter:header(Name, Cap).


### PR DESCRIPTION
## Summary
- `livery_static:handler/1,2`: serves files from a root directory, mounted on a router wildcard route (`/assets/*path`) or via a configured `prefix`. GET/HEAD only (405 + Allow otherwise).
- Security: the sub-path is percent-decoded THEN confined - any `..` segment, absolute path, control byte, or bad escape is rejected with 404 - and only regular files are served (directories/symlinks/missing -> 404), so a request can never traverse out of the root.
- MIME by extension (text types get charset=utf-8, default application/octet-stream); weak ETag (`W/"size-mtime"`) + conditional GET 304 (reuses `livery_etag:if_none_match/2`); `Range` -> 206/416; directory `index` (default index.html); configurable `cache_control`/`etag`/`range`/`index`.
- Tests: EUnit incl. literal + encoded traversal (a secret outside the root is never served), MIME, conditional, index, HEAD, Range; plus a `static_file` parity case (200 + ETag, then 304) across test_adapter/h1/h2/h3.

Resolves backlog item #9.