### PR TITLE
Add health/readiness and Prometheus metrics endpoints

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -5,7 +5,7 @@ sibling library that owns the change.
 
 ## Framework-gap backlog (from the audit)
 
-Modern web/AI framework gaps, in priority order. Steps 1-8 are done.
+Modern web/AI framework gaps, in priority order. All 10 items are done.
 
 1. Cancel on client disconnect. DONE: `livery_req:on_disconnect/2`
    plus the `{livery_disconnect, _, _}` message, delivered across
@@ -47,7 +47,11 @@ Modern web/AI framework gaps, in priority order. Steps 1-8 are done.
    (`handler/1,2` mounted on a `*path` wildcard route; MIME by extension,
    weak ETag + conditional GET, Range, directory index, strict path
    confinement). See `docs/guides/serve-static-files.md`.
-10. Health/readiness endpoints + Prometheus `/metrics`.
+10. Health/readiness endpoints + Prometheus `/metrics`. DONE:
+    `livery_health` (`live/0`, `ready/1` with named checks) and
+    `livery_metrics` (`handler/0` rendering the `instrument` registry via
+    `instrument_prometheus`). See `docs/guides/health-checks.md` and
+    `docs/guides/export-metrics.md`.
 
 ## Benchmarking: H3 needs an external client
 

--- a/docs/guides/export-metrics.md
+++ b/docs/guides/export-metrics.md
@@ -1,0 +1,41 @@
+# How to export Prometheus metrics
+
+## Problem
+
+You want Prometheus to scrape your service's metrics at `/metrics`.
+
+## Solution
+
+Livery records HTTP server metrics through the `livery_instrument_metrics`
+middleware and exposes them with the `livery_metrics` handler. Add the
+middleware to the stack and mount the handler:
+
+```erlang
+R1 = livery_router:add('GET', <<"/metrics">>, livery_metrics:handler(), #{}, R0),
+livery:start_service(#{
+    router => R1,
+    middleware => [{livery_instrument_metrics, #{}}]
+}).
+```
+
+`GET /metrics` returns the registered metrics in Prometheus text format
+with `Content-Type: text/plain; version=0.0.4; charset=utf-8`.
+
+## What is exported
+
+`livery_instrument_metrics` records the OpenTelemetry HTTP server
+metrics:
+
+- `http.server.active_requests` (gauge) - concurrent in-flight requests.
+- `http.server.request.duration` (histogram, seconds) - request latency
+  with `_bucket`/`_sum`/`_count` series.
+
+Any other metric your app registers via the `instrument` library is
+exported too - `livery_metrics:handler()` simply renders the whole
+`instrument` registry. (Metric names are exposed verbatim, so the dots
+in the OpenTelemetry names are preserved.)
+
+## See also
+
+- Reference: `livery_metrics`, `livery_instrument_metrics`
+- Recipe: [Add health and readiness checks](health-checks.md)

--- a/docs/guides/health-checks.md
+++ b/docs/guides/health-checks.md
@@ -1,0 +1,47 @@
+# How to add health and readiness checks
+
+## Problem
+
+An orchestrator (Kubernetes, a load balancer) needs liveness and
+readiness probes: is the process up, and is it ready to take traffic?
+
+## Solution
+
+Mount the `livery_health` handlers on routes:
+
+```erlang
+R0 = livery_router:new(),
+R1 = livery_router:add('GET', <<"/healthz">>, livery_health:live(), #{}, R0),
+R2 = livery_router:add(
+    'GET', <<"/readyz">>,
+    livery_health:ready([
+        {<<"db">>, fun() -> my_db:ping() end},
+        {<<"cache">>, fun() -> my_cache:ping() end}
+    ]),
+    #{}, R1
+).
+```
+
+## Liveness
+
+`livery_health:live()` always answers `200 {"status":"ok"}`. Use it for
+the liveness probe - it only signals that the process is running.
+
+## Readiness
+
+`livery_health:ready(Checks)` runs each `{Name, Fun}` check. A check
+passes when its `Fun()` returns `ok`; any other return or a raised
+exception counts as a failure.
+
+- All pass -> `200 {"status":"ok"}`.
+- Any fail -> `503 {"status":"unavailable","failed":["db"]}` listing the
+  failed names.
+
+`ready([])` is always ready. Checks run synchronously in the request
+process, so keep them fast (wrap slow dependencies with your own
+timeout).
+
+## See also
+
+- Reference: `livery_health`
+- Recipe: [Export Prometheus metrics](export-metrics.md)

--- a/rebar.config
+++ b/rebar.config
@@ -111,6 +111,8 @@
         {"docs/guides/serve-mcp-tools.md", #{title => <<"Serve MCP tools">>}},
         {"docs/guides/serve-webtransport.md", #{title => <<"Serve WebTransport">>}},
         {"docs/guides/graceful-shutdown.md", #{title => <<"Shut down gracefully">>}},
+        {"docs/guides/health-checks.md", #{title => <<"Health and readiness checks">>}},
+        {"docs/guides/export-metrics.md", #{title => <<"Export Prometheus metrics">>}},
         {"docs/guides/test-handlers.md", #{title => <<"Test handlers without a socket">>}},
         {"docs/guides/migrate-from-cowboy.md", #{title => <<"Migrate from Cowboy">>}},
 
@@ -174,6 +176,8 @@
             <<"docs/guides/serve-mcp-tools.md">>,
             <<"docs/guides/serve-webtransport.md">>,
             <<"docs/guides/graceful-shutdown.md">>,
+            <<"docs/guides/health-checks.md">>,
+            <<"docs/guides/export-metrics.md">>,
             <<"docs/guides/test-handlers.md">>,
             <<"docs/guides/migrate-from-cowboy.md">>
         ]},
@@ -227,6 +231,12 @@
             livery_auth_jwks
         ]},
         {<<"MCP">>, [livery_mcp]},
+        {<<"Health and metrics">>, [
+            livery_health,
+            livery_metrics,
+            livery_instrument_metrics,
+            livery_instrument_trace
+        ]},
         {<<"WebSocket and WebTransport">>, [livery_ws, livery_wt]},
         {<<"Adapters">>, [livery_adapter, livery_test_adapter]},
         {<<"Body reader">>, [livery_body]},

--- a/src/livery_health.erl
+++ b/src/livery_health.erl
@@ -1,0 +1,66 @@
+-module(livery_health).
+-moduledoc """
+Health and readiness handlers.
+
+`live/0` is a liveness probe - it always answers `200` `{"status":"ok"}`
+(the process is up). `ready/1` is a readiness probe - it runs a list of
+named checks and answers `200` when all pass, or `503` listing the
+failed checks. Mount them on routes:
+
+```erlang
+R1 = livery_router:add('GET', <<"/healthz">>, livery_health:live(), #{}, R0),
+R2 = livery_router:add(
+    '_GET', <<"/readyz">>,
+    livery_health:ready([{<<"db">>, fun () -> my_db:ping() end}]),
+    #{}, R1
+).
+```
+
+A check is `{Name, fun(() -> ok | {error, term()})}`; any non-`ok`
+return or a raised exception counts as failed. Checks run synchronously
+in the request process, so keep them fast.
+""".
+
+-export([live/0, ready/1]).
+
+-export_type([check/0]).
+
+-type check() :: {binary(), fun(() -> ok | {error, term()})}.
+
+-doc "Liveness handler: always `200` `{\"status\":\"ok\"}`.".
+-spec live() -> livery_middleware:handler().
+live() ->
+    fun(_Req) -> ok_response() end.
+
+-doc "Readiness handler: `200` when every check passes, else `503`.".
+-spec ready([check()]) -> livery_middleware:handler().
+ready(Checks) ->
+    fun(_Req) -> readiness(Checks) end.
+
+-spec readiness([check()]) -> livery_resp:resp().
+readiness(Checks) ->
+    case [Name || {Name, Fun} <- Checks, not passes(Fun)] of
+        [] ->
+            ok_response();
+        Failed ->
+            livery_resp:json(
+                503,
+                json:encode(#{
+                    <<"status">> => <<"unavailable">>,
+                    <<"failed">> => Failed
+                })
+            )
+    end.
+
+-spec passes(fun(() -> ok | {error, term()})) -> boolean().
+passes(Fun) ->
+    try Fun() of
+        ok -> true;
+        _Other -> false
+    catch
+        _Class:_Reason -> false
+    end.
+
+-spec ok_response() -> livery_resp:resp().
+ok_response() ->
+    livery_resp:json(200, json:encode(#{<<"status">> => <<"ok">>})).

--- a/src/livery_metrics.erl
+++ b/src/livery_metrics.erl
@@ -1,0 +1,31 @@
+-module(livery_metrics).
+-moduledoc """
+Prometheus `/metrics` handler.
+
+Returns a handler that renders the `instrument` registry in Prometheus
+text exposition format. Livery's `livery_instrument_metrics` middleware
+already records HTTP server metrics into that registry; mount this on a
+route to expose them:
+
+```erlang
+R1 = livery_router:add('GET', <<"/metrics">>, livery_metrics:handler(), #{}, R0).
+```
+
+The body and `Content-Type`
+(`text/plain; version=0.0.4; charset=utf-8`) come from
+`instrument_prometheus`. Requires the `instrument` application to be
+running (it is, as a Livery dependency).
+""".
+
+-export([handler/0]).
+
+-doc "Handler that exposes registered metrics in Prometheus format.".
+-spec handler() -> livery_middleware:handler().
+handler() ->
+    fun(_Req) ->
+        livery_resp:text(
+            200,
+            [{<<"content-type">>, instrument_prometheus:content_type()}],
+            instrument_prometheus:format()
+        )
+    end.

--- a/test/livery_health_tests.erl
+++ b/test/livery_health_tests.erl
@@ -1,0 +1,48 @@
+-module(livery_health_tests).
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+live_test() ->
+    Cap = run(livery_health:live()),
+    ?assertEqual(200, status(Cap)),
+    ?assertEqual(<<"{\"status\":\"ok\"}">>, body(Cap)).
+
+ready_empty_test() ->
+    Cap = run(livery_health:ready([])),
+    ?assertEqual(200, status(Cap)).
+
+ready_all_pass_test() ->
+    Checks = [{<<"a">>, fun() -> ok end}, {<<"b">>, fun() -> ok end}],
+    Cap = run(livery_health:ready(Checks)),
+    ?assertEqual(200, status(Cap)).
+
+ready_one_fails_test() ->
+    Checks = [
+        {<<"a">>, fun() -> ok end},
+        {<<"db">>, fun() -> {error, down} end}
+    ],
+    Cap = run(livery_health:ready(Checks)),
+    ?assertEqual(503, status(Cap)),
+    Decoded = json:decode(body(Cap)),
+    ?assertEqual(<<"unavailable">>, maps:get(<<"status">>, Decoded)),
+    ?assertEqual([<<"db">>], maps:get(<<"failed">>, Decoded)).
+
+ready_check_raises_test() ->
+    Cap = run(livery_health:ready([{<<"boom">>, fun() -> error(boom) end}])),
+    ?assertEqual(503, status(Cap)),
+    ?assertEqual([<<"boom">>], maps:get(<<"failed">>, json:decode(body(Cap)))).
+
+ready_non_ok_return_test() ->
+    Cap = run(livery_health:ready([{<<"x">>, fun() -> not_ok end}])),
+    ?assertEqual(503, status(Cap)).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+run(Handler) ->
+    livery_test_adapter:run([], Handler, #{method => <<"GET">>}).
+
+status(Cap) -> livery_test_adapter:status(Cap).
+body(Cap) -> livery_test_adapter:body(Cap).

--- a/test/livery_metrics_tests.erl
+++ b/test/livery_metrics_tests.erl
@@ -1,0 +1,51 @@
+-module(livery_metrics_tests).
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% The instrument registry needs the application running.
+metrics_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        {"200 with Prometheus content-type", fun content_type/0},
+        {"records and exports a metric", fun records/0}
+    ]}.
+
+setup() ->
+    %% The metrics handler and the instrument middleware only need the
+    %% `instrument' app (the registry). Avoid starting/stopping the full
+    %% `livery' app so this module does not perturb other test modules.
+    {ok, _} = application:ensure_all_started(instrument),
+    ok.
+
+cleanup(_) ->
+    ok.
+
+content_type() ->
+    Cap = livery_test_adapter:run(
+        [], livery_metrics:handler(), #{method => <<"GET">>}
+    ),
+    ?assertEqual(200, livery_test_adapter:status(Cap)),
+    ?assertEqual(
+        <<"text/plain; version=0.0.4; charset=utf-8">>,
+        livery_test_adapter:header(<<"content-type">>, Cap)
+    ).
+
+records() ->
+    %% Register a uniquely-named metric directly (instrument keys
+    %% instruments by name globally, so reusing the http.server.* names
+    %% here would collide with livery_instrument_tests). This proves the
+    %% endpoint renders the registry without touching shared names.
+    Meter = instrument_meter:get_meter(<<"livery_metrics_test">>),
+    Counter = instrument_meter:create_counter(
+        Meter, <<"livery_metrics_test_hits">>, #{description => <<"test counter">>}
+    ),
+    _ = instrument_meter:add(Counter, 1, #{}),
+    Cap = livery_test_adapter:run(
+        [], livery_metrics:handler(), #{method => <<"GET">>}
+    ),
+    Body = livery_test_adapter:body(Cap),
+    ?assertNotEqual(nomatch, binary:match(Body, <<"# HELP">>)),
+    ?assertNotEqual(nomatch, binary:match(Body, <<"# TYPE">>)),
+    ?assertNotEqual(
+        nomatch, binary:match(Body, <<"livery_metrics_test_hits">>)
+    ).

--- a/test/livery_parity_SUITE.erl
+++ b/test/livery_parity_SUITE.erl
@@ -45,7 +45,9 @@
     concurrency_shed/1,
     rate_limit_shed/1,
     conditional_get/1,
-    static_file/1
+    static_file/1,
+    health_live/1,
+    metrics_export/1
 ]).
 
 %%====================================================================
@@ -75,7 +77,9 @@ groups() ->
         concurrency_shed,
         rate_limit_shed,
         conditional_get,
-        static_file
+        static_file,
+        health_live,
+        metrics_export
     ],
     [
         {test_adapter, [parallel], Shared ++ [response_with_trailers]},
@@ -471,6 +475,20 @@ static_file(Config) ->
     after
         _ = file:del_dir_r(Dir)
     end.
+
+health_live(Config) ->
+    Resp = drive(Config, [], livery_health:live(), #{}),
+    ?assertEqual(200, status(Resp)),
+    ?assertEqual(<<"{\"status\":\"ok\"}">>, body(Resp)).
+
+metrics_export(Config) ->
+    %% init_per_suite starts livery, so the instrument registry is up.
+    Resp = drive(Config, [], livery_metrics:handler(), #{}),
+    ?assertEqual(200, status(Resp)),
+    ?assertMatch(
+        <<"text/plain; version=0.0.4", _/binary>>,
+        header(<<"content-type">>, Resp)
+    ).
 
 %%====================================================================
 %% Uniform driver API: returns a `response()' tuple


### PR DESCRIPTION
## Summary
- `livery_health`: `live/0` is a liveness handler (always `200 {"status":"ok"}`); `ready/1` runs a list of `{Name, fun(() -> ok | {error, _})}` checks and answers `200` when all pass or `503 {"status":"unavailable","failed":[...]}` (a non-`ok` return or a raised exception counts as failed; `ready([])` is always ready).
- `livery_metrics:handler/0`: renders the `instrument` registry (the HTTP metrics `livery_instrument_metrics` already records, plus any the app registers) in Prometheus text format with `Content-Type: text/plain; version=0.0.4; charset=utf-8`, via `instrument_prometheus`.
- Both are plain handlers the caller mounts on routes (`/healthz`, `/readyz`, `/metrics`).
- Tests: EUnit for health (live/ready/empty/fail/raise) and metrics (content-type, registry render), plus `health_live` and `metrics_export` parity cases across test_adapter/h1/h2/h3. Guides added.

Resolves backlog item #10 - completing all 10 audit items.