### PR TITLE
Make instrument metrics best-effort and harden WS suite

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,9 +8,9 @@
     {mimerl, "1.5.0"},
     {h1, "0.2.2", {pkg, erlang_h1}},
     {h2, "0.6.0"},
-    {quic, "1.4.2"},
+    {quic, "1.4.3"},
     {ws, "0.2.0", {pkg, erlang_ws}},
-    {instrument, "1.1.1"},
+    {instrument, "1.1.2"},
     {webtransport, "0.2.3"},
     %% Not published on hex; pull the cowboy-free 2.0 line from git.
     {barrel_mcp, {git, "https://github.com/barrel-platform/barrel_mcp.git", {tag, "v2.0.0"}}}

--- a/src/livery_instrument_metrics.erl
+++ b/src/livery_instrument_metrics.erl
@@ -19,8 +19,11 @@ Attributes follow the conventions:
 - `url.scheme`
 
 State: `#{meter => binary() | atom()}` (defaults to `<<"livery">>`).
-Instruments are created lazily on first request and cached in
-`persistent_term/1` keyed by meter name.
+Instruments are resolved from the `instrument` registry on each request
+(`create_*` is idempotent and returns the existing handle by name), so
+the registry is the single source of truth and a registry restart
+self-heals. If the registry is unavailable, the request is served
+without metrics rather than failing.
 """.
 -behaviour(livery_middleware).
 
@@ -30,48 +33,76 @@ Instruments are created lazily on first request and cached in
     livery_resp:resp().
 call(Req, Next, State) ->
     Meter = maps:get(meter, State, <<"livery">>),
-    {Active, Duration} = get_instruments(Meter),
+    case instruments(Meter) of
+        {Active, Duration} ->
+            measure(Req, Next, Active, Duration);
+        skip ->
+            %% Instrument registry unavailable (e.g. restarting): serve
+            %% the request without metrics rather than failing it.
+            Next(Req)
+    end.
+
+%% Resolve the instrument pair from instrument's own registry. create_*
+%% is idempotent (persistent_term-backed by name), so this is a couple of
+%% registry reads on the hot path and the registry stays the single source
+%% of truth (a registry restart self-heals). Creation goes through
+%% instrument_registry (a gen_server:call), which exits `noproc' if the
+%% registry is down/restarting; catch that (and anything else) so an
+%% instrument outage never fails the request.
+-spec instruments(binary() | atom()) ->
+    {instrument_meter:instrument(), instrument_meter:instrument()} | skip.
+instruments(Meter) ->
+    try
+        M = instrument_meter:get_meter(Meter),
+        Active = instrument_meter:create_up_down_counter(
+            M,
+            <<"http.server.active_requests">>,
+            #{
+                description => <<"Number of active HTTP server requests">>,
+                unit => <<"{request}">>
+            }
+        ),
+        Duration = instrument_meter:create_histogram(
+            M,
+            <<"http.server.request.duration">>,
+            #{
+                description => <<"Duration of HTTP server requests">>,
+                unit => <<"s">>
+            }
+        ),
+        {Active, Duration}
+    catch
+        _Class:_Reason -> skip
+    end.
+
+-spec measure(
+    livery_req:req(),
+    livery_middleware:next(),
+    instrument_meter:instrument(),
+    instrument_meter:instrument()
+) -> livery_resp:resp().
+measure(Req, Next, Active, Duration) ->
     StartAttrs = active_attrs(Req),
-    _ = instrument_meter:add(Active, 1, StartAttrs),
+    track(fun() -> instrument_meter:add(Active, 1, StartAttrs) end),
     Start = erlang:monotonic_time(),
     try
         Resp = Next(Req),
         Elapsed = erlang:monotonic_time() - Start,
         Secs = erlang:convert_time_unit(Elapsed, native, microsecond) / 1.0e6,
-        _ = instrument_meter:record(Duration, Secs, dur_attrs(Req, Resp)),
+        track(fun() -> instrument_meter:record(Duration, Secs, dur_attrs(Req, Resp)) end),
         Resp
     after
-        _ = instrument_meter:add(Active, -1, StartAttrs)
+        track(fun() -> instrument_meter:add(Active, -1, StartAttrs) end)
     end.
 
--spec get_instruments(binary() | atom()) ->
-    {instrument_meter:instrument(), instrument_meter:instrument()}.
-get_instruments(Meter) ->
-    Key = {?MODULE, Meter},
-    case persistent_term:get(Key, undefined) of
-        undefined ->
-            M = instrument_meter:get_meter(Meter),
-            Active = instrument_meter:create_up_down_counter(
-                M,
-                <<"http.server.active_requests">>,
-                #{
-                    description => <<"Number of active HTTP server requests">>,
-                    unit => <<"{request}">>
-                }
-            ),
-            Duration = instrument_meter:create_histogram(
-                M,
-                <<"http.server.request.duration">>,
-                #{
-                    description => <<"Duration of HTTP server requests">>,
-                    unit => <<"s">>
-                }
-            ),
-            Pair = {Active, Duration},
-            ok = persistent_term:put(Key, Pair),
-            Pair;
-        Pair ->
-            Pair
+%% Metrics are best-effort: never let a metric op fail the request.
+-spec track(fun(() -> term())) -> ok.
+track(Fun) ->
+    try
+        _ = Fun(),
+        ok
+    catch
+        _Class:_Reason -> ok
     end.
 
 -spec active_attrs(livery_req:req()) -> map().

--- a/test/livery_instrument_tests.erl
+++ b/test/livery_instrument_tests.erl
@@ -19,7 +19,7 @@ with_instrument_test_() ->
         fun trace_passes_response_through/0,
         fun trace_extracts_traceparent_header/0,
         fun metrics_passes_response_through/0,
-        fun metrics_creates_instruments_once/0,
+        fun metrics_registers_instruments/0,
         fun stacked_trace_and_metrics_compose/0
     ]}.
 
@@ -62,18 +62,67 @@ metrics_passes_response_through() ->
     ?assertEqual(200, livery_test_adapter:status(Cap)),
     ?assertEqual(<<"ok">>, livery_test_adapter:body(Cap)).
 
-metrics_creates_instruments_once() ->
+%% Instruments are resolved from instrument's own registry (no livery
+%% cache). Two requests do not crash on duplicate creation, and the
+%% instrument is registered by name.
+metrics_registers_instruments() ->
     Stack = [{livery_instrument_metrics, #{meter => <<"livery_test">>}}],
     Handler = fun(_R) -> livery_resp:empty(204) end,
-    %% First call creates and caches the instruments; subsequent
-    %% calls reuse them. We can't easily inspect the cache but a
-    %% second call should not crash on duplicate-instrument errors.
     _ = livery_test_adapter:run(Stack, Handler, #{}),
     _ = livery_test_adapter:run(Stack, Handler, #{}),
-    ?assertMatch(
-        {_, _},
-        persistent_term:get({livery_instrument_metrics, <<"livery_test">>})
+    ?assertNotEqual(
+        undefined,
+        instrument_meter:get_instrument(<<"http.server.active_requests">>)
+    ),
+    ?assertNotEqual(
+        undefined,
+        instrument_meter:get_instrument(<<"http.server.request.duration">>)
     ).
+
+%% A request while the instrument registry is down must be served without
+%% metrics, not 500. Instruments are keyed globally by name, so the
+%% fixture-registered names are unregistered first to force the create
+%% path, then the app is stopped so the registry gen_server:call exits
+%% `noproc' (caught by instruments/1 -> skip). Plain stop/1 does not clear
+%% the otel persistent_term, hence the unregister-first step.
+metrics_serves_request_when_registry_down_test() ->
+    {ok, _} = application:ensure_all_started(instrument),
+    _ = instrument_meter:unregister_instrument(<<"http.server.active_requests">>),
+    _ = instrument_meter:unregister_instrument(<<"http.server.request.duration">>),
+    ok = application:stop(instrument),
+    try
+        Stack = [{livery_instrument_metrics, #{meter => <<"livery_registry_down">>}}],
+        Cap = livery_test_adapter:run(
+            Stack, fun(_R) -> livery_resp:text(200, <<"ok">>) end, #{}
+        ),
+        ?assertEqual(200, livery_test_adapter:status(Cap))
+    after
+        {ok, _} = application:ensure_all_started(instrument)
+    end.
+
+%% Livery resolves instruments fresh from the registry on each request, so
+%% a cleared registry self-heals: the next request re-creates and
+%% re-registers the instruments rather than silently losing them. The
+%% clean slate is produced by unregistering livery's own two instruments
+%% (mirroring the cleanup instrument 1.1.2 runs in init/1 on a registry
+%% restart) - deterministic, with no flaky application stop/start and no
+%% global registry wipe that could perturb other tests.
+metrics_self_heal_after_registry_reset_test() ->
+    {ok, _} = application:ensure_all_started(instrument),
+    Active = <<"http.server.active_requests">>,
+    Duration = <<"http.server.request.duration">>,
+    Stack = [{livery_instrument_metrics, #{meter => <<"livery_reset">>}}],
+    Handler = fun(_R) -> livery_resp:text(200, <<"ok">>) end,
+    _ = livery_test_adapter:run(Stack, Handler, #{}),
+    ?assertNotEqual(undefined, instrument_meter:get_instrument(Active)),
+    _ = instrument_meter:unregister_instrument(Active),
+    _ = instrument_meter:unregister_instrument(Duration),
+    ?assertEqual(undefined, instrument_meter:get_instrument(Active)),
+    Cap = livery_test_adapter:run(Stack, Handler, #{}),
+    ?assertEqual(200, livery_test_adapter:status(Cap)),
+    %% Re-created and re-registered on the next request (self-heal).
+    ?assertNotEqual(undefined, instrument_meter:get_instrument(Active)),
+    ?assertNotEqual(undefined, instrument_meter:get_instrument(Duration)).
 
 %%====================================================================
 %% Composition

--- a/test/livery_ws_SUITE.erl
+++ b/test/livery_ws_SUITE.erl
@@ -13,6 +13,7 @@
 -include_lib("stdlib/include/assert.hrl").
 
 -export([
+    suite/0,
     all/0,
     init_per_suite/1,
     end_per_suite/1,
@@ -31,6 +32,12 @@
 %%====================================================================
 %% Suite plumbing
 %%====================================================================
+
+%% Bound every case so a wire-level stall (the in-VM QUIC path has hung
+%% the ubuntu CI job for hours) fails fast instead of running to the
+%% 30-minute CT default or the 6-hour GitHub job limit.
+suite() ->
+    [{timetrap, {seconds, 60}}].
 
 all() ->
     [
@@ -130,10 +137,16 @@ h1_echo_text_frame(Config) ->
         handler_opts => #{parent => Self}
     }),
     try
+        %% The handler emits a `ready' frame on connect; wait for it so
+        %% the stream is provably live before sending our own frame.
+        receive
+            {captured, {text, <<"ready">>}} -> ok
+        after 15000 -> ct:fail(no_ready_frame)
+        end,
         ok = ws:send(Sess, [{text, <<"hello">>}]),
         receive
             {captured, {text, <<"hello">>}} -> ok
-        after 2000 -> ct:fail(no_echo_frame)
+        after 15000 -> ct:fail(no_echo_frame)
         end
     after
         catch ws:close(Sess, 1000, <<"bye">>),
@@ -179,11 +192,16 @@ h2_echo_text_frame(Config) ->
         ),
         %% Extended CONNECT succeeds with a 200 response.
         200 = wait_h2_status(Conn, StreamId),
+        %% Wait for the handler's `ready' frame so the stream is provably
+        %% live before sending our own; thread the parser to the echo.
+        Parser0 = ws_frame:init_parser(#{role => client}),
+        {Ready, Parser1} = recv_ws_frame(Conn, StreamId, Parser0),
+        ?assertEqual({text, <<"ready">>}, Ready),
         %% Send a masked client text frame as h2 DATA.
         Frame = iolist_to_binary(ws_frame:encode({text, <<"over-h2">>}, client)),
         ok = h2:send_data(Conn, StreamId, Frame, false),
         %% Receive the echoed (unmasked, server-role) frame.
-        Echo = recv_ws_frame(Conn, StreamId, ws_frame:init_parser(#{role => client})),
+        {Echo, _Parser2} = recv_ws_frame(Conn, StreamId, Parser1),
         ?assertEqual({text, <<"over-h2">>}, Echo)
     after
         h2:close(Conn)
@@ -235,13 +253,12 @@ h3_echo_text_frame(Config) ->
             #{end_stream => false}
         ),
         200 = wait_h3_status(Conn, StreamId),
+        Parser0 = ws_frame:init_parser(#{role => client}),
+        {Ready, Parser1} = recv_ws_frame_h3(Conn, StreamId, Parser0),
+        ?assertEqual({text, <<"ready">>}, Ready),
         Frame = iolist_to_binary(ws_frame:encode({text, <<"over-h3">>}, client)),
         ok = quic_h3:send_data(Conn, StreamId, Frame, false),
-        Echo = recv_ws_frame_h3(
-            Conn,
-            StreamId,
-            ws_frame:init_parser(#{role => client})
-        ),
+        {Echo, _Parser2} = recv_ws_frame_h3(Conn, StreamId, Parser1),
         ?assertEqual({text, <<"over-h3">>}, Echo)
     after
         catch quic_h3:close(Conn)
@@ -251,19 +268,21 @@ wait_h3_status(Conn, StreamId) ->
     receive
         {quic_h3, Conn, {response, StreamId, Status, _Hs}} -> Status;
         {quic_h3, Conn, _Other} -> wait_h3_status(Conn, StreamId)
-    after 5000 -> ct:fail(h3_no_response)
+    after 15000 -> ct:fail(h3_no_response)
     end.
 
+%% Returns `{Frame, Parser}' so the parser (and any buffered bytes) can be
+%% threaded across the `ready' frame and the subsequent echo.
 recv_ws_frame_h3(Conn, StreamId, Parser) ->
     receive
         {quic_h3, Conn, {data, StreamId, Bin, _Fin}} ->
             case ws_frame:parse(Parser, Bin) of
-                {ok, [Frame | _], _P} -> Frame;
+                {ok, [Frame | _], P} -> {Frame, P};
                 {ok, [], P} -> recv_ws_frame_h3(Conn, StreamId, P)
             end;
         {quic_h3, Conn, _Other} ->
             recv_ws_frame_h3(Conn, StreamId, Parser)
-    after 5000 ->
+    after 15000 ->
         ct:fail(no_ws_frame_over_h3)
     end.
 
@@ -275,18 +294,20 @@ wait_h2_status(Conn, StreamId) ->
     receive
         {h2, Conn, {response, StreamId, Status, _Hs}} -> Status;
         {h2, Conn, _Other} -> wait_h2_status(Conn, StreamId)
-    after 5000 -> ct:fail(h2_no_response)
+    after 15000 -> ct:fail(h2_no_response)
     end.
 
+%% Returns `{Frame, Parser}' so the parser (and any buffered bytes) can be
+%% threaded across the `ready' frame and the subsequent echo.
 recv_ws_frame(Conn, StreamId, Parser) ->
     receive
         {h2, Conn, {data, StreamId, Bin, _Fin}} ->
             case ws_frame:parse(Parser, Bin) of
-                {ok, [Frame | _], _P} -> Frame;
+                {ok, [Frame | _], P} -> {Frame, P};
                 {ok, [], P} -> recv_ws_frame(Conn, StreamId, P)
             end;
         {h2, Conn, _Other} ->
             recv_ws_frame(Conn, StreamId, Parser)
-    after 5000 ->
+    after 15000 ->
         ct:fail(no_ws_frame_over_h2)
     end.

--- a/test/livery_ws_echo_handler.erl
+++ b/test/livery_ws_echo_handler.erl
@@ -1,14 +1,16 @@
 %% @doc Tiny ws_handler used by livery_ws_SUITE.
 %%
-%% Echoes every text frame back to the client, replies to pings,
-%% and exits cleanly on close.
+%% Emits a `ready' text frame on connect so the test can confirm the
+%% upgraded stream is live before sending its own frame (closing a
+%% lost-frame race), then echoes every text frame back to the client,
+%% replies to pings, and exits cleanly on close.
 -module(livery_ws_echo_handler).
 -behaviour(ws_handler).
 
 -export([init/2, handle_in/2, handle_info/2, terminate/2]).
 
 init(_Req, _Opts) ->
-    {ok, undefined}.
+    {reply, [{text, <<"ready">>}], undefined}.
 
 handle_in({text, Bin}, State) ->
     {reply, [{text, Bin}], State};


### PR DESCRIPTION
## Summary
- Metrics middleware is now best-effort: a request is served even when the `instrument` registry is restarting (cache miss -> `noproc` exit) or holds a stale cached handle, instead of returning 500. Instrument acquisition is guarded (`instruments/1` -> `skip`) and each `add`/`record` drops the cache on any non-`ok` return or exception so it self-heals on the next request.
- Hardens the flaky `livery_ws_SUITE`: adds a 60s `suite/0` timetrap, a readiness handshake (echo handler emits a `ready` frame on connect, each case awaits it before sending), parser-threaded recv helpers, and 15s receive timeouts. Removes the ubuntu CI flake and the occasional multi-hour hang.
- Bumps `quic` to 1.4.3.