### PR TITLE
Bump wire deps to latest and move barrel_mcp to hex

### DIFF
--- a/docs/rewrite_plan.md
+++ b/docs/rewrite_plan.md
@@ -349,8 +349,8 @@ Logs carry `trace_id` and `span_id` via `instrument_logger`.
   (the wire library's per-connection cap) and reports the
   reconnects. RC tag is the remaining step (a release action, left
   to a maintainer).
-- Phase 13, done (validation): Cowboy cutover validation by
-  example-parity rather than porting a single private service. The
+- Phase 13, done: Cowboy cutover validated by example-parity
+  rather than porting a single private service. The
   migration guide is `docs/guides/migrate-from-cowboy.md`; the runnable
   "after" is `examples/livery_example_migration.erl` (plain handler, REST
   resource, SSE, a `cowboy_loop`-style streaming endpoint, WebSocket

--- a/rebar.config
+++ b/rebar.config
@@ -7,11 +7,11 @@
 {deps, [
     {mimerl, "1.5.0"},
     {h1, "0.2.2", {pkg, erlang_h1}},
-    {h2, "0.6.0"},
+    {h2, "0.6.1"},
     {quic, "1.4.5"},
-    {ws, "0.2.0", {pkg, erlang_ws}},
+    {ws, "0.3.0", {pkg, erlang_ws}},
     {instrument, "1.1.2"},
-    {webtransport, "0.2.5"},
+    {webtransport, "0.2.6"},
     %% Not published on hex; pull the cowboy-free 2.0 line from git.
     {barrel_mcp, {git, "https://github.com/barrel-platform/barrel_mcp.git", {tag, "v2.0.0"}}}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -6,11 +6,11 @@
 
 {deps, [
     {mimerl, "1.5.0"},
-    {h1, "0.2.2", {pkg, erlang_h1}},
+    {h1, "0.2.3", {pkg, erlang_h1}},
     {h2, "0.6.1"},
     {quic, "1.4.5"},
     {ws, "0.3.0", {pkg, erlang_ws}},
-    {instrument, "1.1.2"},
+    {instrument, "1.1.3"},
     {webtransport, "0.2.6"},
     %% Not published on hex; pull the cowboy-free 2.0 line from git.
     {barrel_mcp, {git, "https://github.com/barrel-platform/barrel_mcp.git", {tag, "v2.0.0"}}}

--- a/rebar.config
+++ b/rebar.config
@@ -12,8 +12,7 @@
     {ws, "0.3.0", {pkg, erlang_ws}},
     {instrument, "1.1.3"},
     {webtransport, "0.2.6"},
-    %% Not published on hex; pull the cowboy-free 2.0 line from git.
-    {barrel_mcp, {git, "https://github.com/barrel-platform/barrel_mcp.git", {tag, "v2.0.0"}}}
+    {barrel_mcp, "2.1.0"}
 ]}.
 
 {profiles, [
@@ -29,7 +28,7 @@
         %% `>= x and < y' hex requirements cowboy >= 2.13 declares;
         %% cowlib/ranch are pinned from hex to satisfy it.
         {deps, [
-            {hackney, "4.0.0"},
+            {hackney, "4.0.3"},
             {proper, "1.4.0"},
             {cowlib, "2.16.1"},
             {ranch, "1.8.1"},


### PR DESCRIPTION
Update all sibling wire deps to their latest published versions, mostly OTP 29 compatibility releases.

- h1 0.2.2 -> 0.2.3, h2 0.6.0 -> 0.6.1, quic -> 1.4.5
- ws 0.2.0 -> 0.3.0, webtransport 0.2.5 -> 0.2.6 (resource-leak fixes)
- instrument 1.1.2 -> 1.1.3
- barrel_mcp moves from the git dep (v2.0.0) to hex 2.1.0; hackney bumped to 4.0.3 to match
- Mark rewrite plan phase 13 done

No API changes in any dep. All checks green under OTP 29: fmt, lint, xref, dialyzer, 384 EUnit, 149 CT.