### PR TITLE
Reduce per-request overhead, add IPv6 listen options, bump wire deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: erlef/setup-beam@v1
+        env:
+          # setup-beam cannot map the arm runner's ImageOS
+          # (ubuntu24-arm64); set it explicitly per matrix OS.
+          ImageOS: ${{ fromJSON('{"ubuntu-24.04":"ubuntu24","ubuntu-24.04-arm":"ubuntu24","macos-14":"macos14","macos-15":"macos15"}')[matrix.os] }}
         with:
           otp-version: ${{ matrix.otp }}
           rebar3-version: '3.25.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,7 @@ jobs:
           path: |
             _build
             ~/.cache/rebar3
-          key: build-ubuntu-24.04-otp-28-${{ hashFiles('rebar.lock') }}
-          restore-keys: build-ubuntu-24.04-otp-28-
+          key: build-ubuntu-24.04-otp-28-${{ hashFiles('rebar.config') }}
       - run: rebar3 lint
 
   xref:
@@ -55,8 +54,7 @@ jobs:
           path: |
             _build
             ~/.cache/rebar3
-          key: build-ubuntu-24.04-otp-28-${{ hashFiles('rebar.lock') }}
-          restore-keys: build-ubuntu-24.04-otp-28-
+          key: build-ubuntu-24.04-otp-28-${{ hashFiles('rebar.config') }}
       - run: rebar3 xref
 
   dialyzer:
@@ -76,7 +74,7 @@ jobs:
             _build/*_plt
             _build/*/rebar3_*_plt
             ~/.cache/rebar3
-          key: plt-otp-28-${{ hashFiles('rebar.lock') }}
+          key: plt-otp-28-${{ hashFiles('rebar.config') }}
           restore-keys: plt-otp-28-
       - run: rebar3 dialyzer
 
@@ -104,8 +102,7 @@ jobs:
           path: |
             _build
             ~/.cache/rebar3
-          key: build-${{ matrix.os }}-otp-${{ matrix.otp }}-${{ hashFiles('rebar.lock') }}
-          restore-keys: build-${{ matrix.os }}-otp-${{ matrix.otp }}-
+          key: build-${{ matrix.os }}-otp-${{ matrix.otp }}-${{ hashFiles('rebar.config') }}
       - run: rebar3 compile
 
   eunit:
@@ -130,8 +127,7 @@ jobs:
           path: |
             _build
             ~/.cache/rebar3
-          key: build-${{ matrix.os }}-otp-28-${{ hashFiles('rebar.lock') }}
-          restore-keys: build-${{ matrix.os }}-otp-28-
+          key: build-${{ matrix.os }}-otp-28-${{ hashFiles('rebar.config') }}
       - run: rebar3 eunit
 
   ct:
@@ -156,6 +152,5 @@ jobs:
           path: |
             _build
             ~/.cache/rebar3
-          key: build-${{ matrix.os }}-otp-28-${{ hashFiles('rebar.lock') }}
-          restore-keys: build-${{ matrix.os }}-otp-28-
+          key: build-${{ matrix.os }}-otp-28-${{ hashFiles('rebar.config') }}
       - run: rebar3 ct

--- a/bench/bench_cowboy_h.erl
+++ b/bench/bench_cowboy_h.erl
@@ -1,0 +1,16 @@
+%% @doc Cowboy reference handler for the livery_bench comparison.
+%% Mirrors livery_bench:ref_handler/0 byte-for-byte: a 200 with
+%% content-type application/json and body {"ok":true}.
+-module(bench_cowboy_h).
+-behaviour(cowboy_handler).
+
+-export([init/2]).
+
+init(Req0, State) ->
+    Req = cowboy_req:reply(
+        200,
+        #{<<"content-type">> => <<"application/json">>},
+        <<"{\"ok\":true}">>,
+        Req0
+    ),
+    {ok, Req, State}.

--- a/bench/livery_bench.erl
+++ b/bench/livery_bench.erl
@@ -23,7 +23,8 @@ pass it to `compare/2` to gate future runs.
 """.
 
 -export([run/0, run/1, run_all/0, run_all/1, compare/2, report/1]).
--export([profile/2, sweep/3]).
+-export([profile/2, sweep/3, compare_servers/0, compare_servers/1]).
+-export([compare_servers_to_file/2]).
 
 -define(RAW_REQUEST, <<"GET / HTTP/1.1\r\nHost: bench\r\n\r\n">>).
 
@@ -36,22 +37,24 @@ run() ->
 %% `warmup_ms', `port'.
 run(Opts) ->
     Protocol = maps:get(protocol, Opts, h1),
+    Server = maps:get(server, Opts, livery),
     Conns = maps:get(connections, Opts, 50),
     Duration = maps:get(duration_ms, Opts, 3000),
     Warmup = maps:get(warmup_ms, Opts, 500),
     {ok, _} = application:ensure_all_started(livery),
-    {ok, _} = ensure_started(Protocol),
-    {ok, Listener} = start_listener(Protocol, Opts),
+    {ok, _} = ensure_started(Server, Protocol),
+    {ok, Listener} = start_listener(Server, Protocol, Opts),
     try
-        Port = listener_port(Protocol, Listener),
+        Port = listener_port(Server, Protocol, Listener),
         %% warmup, discarded
         _ = drive(Protocol, Port, Conns, Warmup),
         {Lats, Count, Reconns} = drive(Protocol, Port, Conns, Duration),
-        Metrics = metrics(Protocol, Lats, Count, Reconns, Duration, Conns),
+        Metrics0 = metrics(Protocol, Lats, Count, Reconns, Duration, Conns),
+        Metrics = Metrics0#{server => Server},
         report(Metrics),
         Metrics
     after
-        stop_listener(Protocol, Listener)
+        stop_listener(Server, Protocol, Listener)
     end.
 
 %% @doc Profile one protocol with fprof over `NReqs' sequential
@@ -61,10 +64,10 @@ run(Opts) ->
 %% Returns the report path.
 profile(Protocol, NReqs) ->
     {ok, _} = application:ensure_all_started(livery),
-    {ok, _} = ensure_started(Protocol),
-    {ok, Listener} = start_listener(Protocol, #{}),
+    {ok, _} = ensure_started(livery, Protocol),
+    {ok, Listener} = start_listener(livery, Protocol, #{}),
     try
-        Port = listener_port(Protocol, Listener),
+        Port = listener_port(livery, Protocol, Listener),
         {ok, Handle} = connect(Protocol, Port),
         Dest = "/tmp/livery_" ++ atom_to_list(Protocol) ++ ".fprof",
         fprof:trace([start, {procs, all}]),
@@ -75,7 +78,7 @@ profile(Protocol, NReqs) ->
         close(Protocol, Handle),
         {ok, Dest}
     after
-        stop_listener(Protocol, Listener)
+        stop_listener(livery, Protocol, Listener)
     end.
 
 %% @doc Concurrency sweep: run `Protocol' at each connection count in
@@ -104,6 +107,61 @@ run_all() ->
 run_all(Opts) ->
     [{P, run(Opts#{protocol => P})} || P <- [h1, h2, h3]].
 
+%% @doc Compare Livery against Cowboy on HTTP/1.1 and HTTP/2 (h2c)
+%% with the same load driver and an identical JSON handler. Prints a
+%% side-by-side table and returns the raw metrics maps.
+compare_servers() ->
+    compare_servers(#{}).
+
+%% @doc Non-interactive entry point for `rebar3 ... --eval'. Runs the
+%% comparison, writes the result (or any crash) to `File', and halts.
+compare_servers_to_file(File, Opts) ->
+    {ok, _} = application:ensure_all_started(livery),
+    Out =
+        try compare_servers(Opts) of
+            R -> io_lib:format("~p~n", [R])
+        catch
+            C:E:S -> io_lib:format("CRASH ~p:~p~n~p~n", [C, E, S])
+        end,
+    ok = file:write_file(File, Out),
+    ok.
+
+compare_servers(Opts) ->
+    Runs = [
+        {Server, Protocol}
+     || Protocol <- [h1, h2], Server <- [livery, cowboy]
+    ],
+    Results = [
+        {Server, Protocol, run(Opts#{server => Server, protocol => Protocol})}
+     || {Server, Protocol} <- Runs
+    ],
+    report_comparison(Results),
+    Results.
+
+report_comparison(Results) ->
+    io:format(
+        "~n=== livery vs cowboy ===~n"
+        "~-8s ~-8s ~12s ~10s ~10s ~10s~n",
+        ["server", "proto", "req/s", "p50 ms", "p90 ms", "p99 ms"]
+    ),
+    lists:foreach(
+        fun({Server, Protocol, M}) ->
+            io:format(
+                "~-8s ~-8s ~12w ~10.3f ~10.3f ~10.3f~n",
+                [
+                    atom_to_list(Server),
+                    atom_to_list(Protocol),
+                    round(maps:get(throughput_rps, M)),
+                    maps:get(p50_us, M) / 1000,
+                    maps:get(p90_us, M) / 1000,
+                    maps:get(p99_us, M) / 1000
+                ]
+            )
+        end,
+        Results
+    ),
+    io:nl().
+
 %% @doc Compare a current run against a baseline. Fails when p99
 %% regresses by more than 10%.
 compare(Baseline, Current) ->
@@ -124,7 +182,7 @@ compare(Baseline, Current) ->
 %% @doc Print a metrics map.
 report(M) ->
     io:format(
-        "~n=== livery_bench (~p) ===~n"
+        "~n=== livery_bench (~p / ~p) ===~n"
         "connections : ~p~n"
         "duration    : ~p ms~n"
         "requests    : ~p (~p reconnects)~n"
@@ -134,6 +192,7 @@ report(M) ->
         "latency p99 : ~.3f ms~n"
         "latency max : ~.3f ms~n~n",
         [
+            maps:get(server, M, livery),
             maps:get(protocol, M),
             maps:get(connections, M),
             maps:get(duration_ms, M),
@@ -151,27 +210,28 @@ report(M) ->
 %% Listener lifecycle per protocol
 %%====================================================================
 
-ensure_started(h1) -> application:ensure_all_started(h1);
-ensure_started(h2) -> application:ensure_all_started(h2);
-ensure_started(h3) -> application:ensure_all_started(quic).
+ensure_started(livery, h1) -> application:ensure_all_started(h1);
+ensure_started(livery, h2) -> application:ensure_all_started(h2);
+ensure_started(livery, h3) -> application:ensure_all_started(quic);
+ensure_started(cowboy, _Protocol) -> application:ensure_all_started(cowboy).
 
 ref_handler() ->
     fun(_Req) -> livery_resp:json(200, <<"{\"ok\":true}">>) end.
 
-start_listener(h1, Opts) ->
+start_listener(livery, h1, Opts) ->
     livery_h1:start(#{
         port => maps:get(port, Opts, 0),
         stack => [],
         handler => ref_handler()
     });
-start_listener(h2, Opts) ->
+start_listener(livery, h2, Opts) ->
     livery_h2:start(#{
         port => maps:get(port, Opts, 0),
         transport => tcp,
         stack => [],
         handler => ref_handler()
     });
-start_listener(h3, Opts) ->
+start_listener(livery, h3, Opts) ->
     {Cert, Key} = load_certs(),
     livery_h3:start(#{
         port => maps:get(port, Opts, 0),
@@ -180,19 +240,43 @@ start_listener(h3, Opts) ->
         stack => [],
         handler => ref_handler(),
         pool_size => maps:get(pool_size, Opts, 1)
-    }).
+    });
+%% Cowboy serves the same handler over a cleartext listener. The clear
+%% listener speaks HTTP/1.1 and h2c (prior knowledge), so one listener
+%% covers the h1 and h2 clients; restrict `protocols' so each run
+%% exercises exactly the protocol under test.
+start_listener(cowboy, Protocol, Opts) when Protocol =:= h1; Protocol =:= h2 ->
+    Ref = cowboy_ref(Protocol),
+    Dispatch = cowboy_router:compile([{'_', [{"/", bench_cowboy_h, []}]}]),
+    Protocols =
+        case Protocol of
+            h1 -> [http];
+            h2 -> [http2]
+        end,
+    {ok, _} = cowboy:start_clear(
+        Ref,
+        [{port, maps:get(port, Opts, 0)}],
+        #{env => #{dispatch => Dispatch}, protocols => Protocols}
+    ),
+    {ok, Ref}.
 
-listener_port(h1, L) ->
+listener_port(livery, h1, L) ->
     h1:server_port(L);
-listener_port(h2, L) ->
+listener_port(livery, h2, L) ->
     h2:server_port(L);
-listener_port(h3, L) ->
+listener_port(livery, h3, L) ->
     {ok, P} = quic:get_server_port(L),
-    P.
+    P;
+listener_port(cowboy, _Protocol, Ref) ->
+    ranch:get_port(Ref).
 
-stop_listener(h1, L) -> livery_h1:stop(L);
-stop_listener(h2, L) -> livery_h2:stop(L);
-stop_listener(h3, L) -> livery_h3:stop(L).
+stop_listener(livery, h1, L) -> livery_h1:stop(L);
+stop_listener(livery, h2, L) -> livery_h2:stop(L);
+stop_listener(livery, h3, L) -> livery_h3:stop(L);
+stop_listener(cowboy, _Protocol, Ref) -> cowboy:stop_listener(Ref).
+
+cowboy_ref(h1) -> bench_cowboy_h1;
+cowboy_ref(h2) -> bench_cowboy_h2.
 
 %% Reuse the vendored self-signed test certs for the H3 listener.
 load_certs() ->

--- a/docs/concepts/adapters.md
+++ b/docs/concepts/adapters.md
@@ -75,8 +75,16 @@ concrete adapter module the request arrived on
 `trailers` and `extended_connect` are protocol-specific. `datagrams`
 and `capsules` apply to WebTransport on H3.
 
+## Listen address
+
+Every adapter takes the same `ip => inet:ip_address()` and
+`inet6 => boolean()` listen options, translated to the underlying wire
+library by `livery_inet:socket_addr_opts/1`. See
+[Bind to an address or IPv6](../guides/bind-listen-address.md).
+
 ## See also
 
+- Guide: [Bind to an address or IPv6](../guides/bind-listen-address.md)
 - Reference: `livery_adapter`
 - Reference: `livery_test_adapter`
 - Concept: [Architecture](architecture.md)

--- a/docs/guides/bind-listen-address.md
+++ b/docs/guides/bind-listen-address.md
@@ -1,0 +1,89 @@
+# How to bind to a specific address or IPv6
+
+## Problem
+
+By default a listener binds the IPv4 wildcard, accepting connections
+on every interface. You want to pin it to one address, or serve over
+IPv6.
+
+## Solution
+
+Every listener accepts two options, on `start_service/1`,
+`start_listener/2`, and each adapter's `start/1`:
+
+- `ip => inet:ip_address()` — the bind address. An IPv6 8-tuple
+  selects the IPv6 family automatically.
+- `inet6 => true` — bind the IPv6 wildcard (`::`) when you do not
+  want to name a specific address.
+
+They work the same across all three protocols (HTTP/1.1, HTTP/2,
+and HTTP/3 over QUIC).
+
+### IPv6 on every protocol
+
+```erlang
+{ok, Pid} = livery:start_service(#{
+    http  => #{port => 8080, inet6 => true},
+    https => #{port => 8443, inet6 => true, cert => Cert, key => Key},
+    http3 => #{port => 8443, inet6 => true, cert => Cert, key => Key},
+    router => Router
+}).
+```
+
+### A specific address
+
+```erlang
+%% IPv4 loopback only
+{ok, _} = livery:start_listener(livery_h1, #{
+    port => 8080,
+    ip => {127, 0, 0, 1},
+    stack => Stack,
+    handler => Handler
+}).
+
+%% A specific IPv6 address (family inferred from the 8-tuple)
+{ok, _} = livery:start_listener(livery_h3, #{
+    port => 8443,
+    ip => {0, 0, 0, 0, 0, 0, 0, 1},
+    cert => Cert, key => Key,
+    stack => Stack, handler => Handler
+}).
+```
+
+## Dual-stack vs IPv6-only
+
+Binding `inet6` gives you whatever the OS default for v6 sockets is.
+On most systems that is dual-stack (the socket also accepts IPv4 via
+v4-mapped addresses); some default to v6-only. To be explicit, pass
+the underlying socket option through the adapter's lower-level opts:
+
+- HTTP/1.1 and HTTP/2: `ssl_opts => [{ipv6_v6only, true}]` (TLS) or
+  rely on the TCP listener's `inet6` family for cleartext.
+- HTTP/3: `quic_opts => #{extra_socket_opts => [{ipv6_v6only, true}]}`.
+
+To serve both families predictably, start one listener per family on
+the same port.
+
+## WebSockets and WebTransport
+
+There is nothing extra to configure. WebSockets (HTTP Upgrade on
+HTTP/1.1, extended CONNECT on HTTP/2 and HTTP/3) and WebTransport
+upgrade in place on the adapter's existing stream, so they inherit the
+listener's bind address and family. Bind the listener to IPv6 and a
+`wss://[::1]/...` client connects over IPv6.
+
+## Notes
+
+- `ip` and `inet6` are translated to the wire libraries the same way
+  everywhere by `livery_inet:socket_addr_opts/1`: an IPv6 `ip` tuple
+  or `inet6 => true` selects the `inet6` family, and `ip` sets the
+  bind address.
+- For HTTP/3 the options fold into the QUIC listener's
+  `extra_socket_opts`; any `extra_socket_opts` you set yourself are
+  preserved.
+- `livery_service:which_listeners/1` reports the bound ports.
+
+## See also
+
+- Concept: [Adapters](../concepts/adapters.md)
+- Reference: `livery`, `livery_service`

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -87,4 +87,5 @@ will emit one entry via `logger:log/2`, and any inbound body over
 
 - Learn the model: [Tutorials](tutorials/your-first-service.md).
 - Solve a specific task: [How-to guides](README.md#how-to-guides).
+- Bind a specific address or serve over IPv6: [Bind to an address or IPv6](guides/bind-listen-address.md).
 - Migrate an existing service: [Migrate from Cowboy](guides/migrate-from-cowboy.md).

--- a/rebar.config
+++ b/rebar.config
@@ -8,10 +8,10 @@
     {mimerl, "1.5.0"},
     {h1, "0.3.0", {pkg, erlang_h1}},
     {h2, "0.8.0"},
-    {quic, "1.6.2"},
+    {quic, "1.6.3"},
     {ws, "0.3.0", {pkg, erlang_ws}},
     {instrument, "1.1.3"},
-    {webtransport, "0.3.0"},
+    {webtransport, "0.3.1"},
     {hackney, "4.1.0"},
     {barrel_mcp, "2.1.0"}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -6,9 +6,9 @@
 
 {deps, [
     {mimerl, "1.5.0"},
-    {h1, "0.2.3", {pkg, erlang_h1}},
-    {h2, "0.6.1"},
-    {quic, "1.4.5"},
+    {h1, "0.3.0", {pkg, erlang_h1}},
+    {h2, "0.7.0"},
+    {quic, "1.6.1"},
     {ws, "0.3.0", {pkg, erlang_ws}},
     {instrument, "1.1.3"},
     {webtransport, "0.2.6"},
@@ -96,6 +96,9 @@
         {"docs/tutorials/testing-handlers.md", #{title => <<"Test your handlers">>}},
 
         {"docs/guides/mount-a-router.md", #{title => <<"Mount a router on a service">>}},
+        {"docs/guides/bind-listen-address.md", #{
+            title => <<"Bind to an address or IPv6">>
+        }},
         {"docs/guides/parse-json-bodies.md", #{title => <<"Parse a JSON body">>}},
         {"docs/guides/read-query-strings.md", #{title => <<"Read query strings">>}},
         {"docs/guides/parse-form-bodies.md", #{title => <<"Parse form bodies">>}},
@@ -164,6 +167,7 @@
         ]},
         {<<"How-to guides">>, [
             <<"docs/guides/mount-a-router.md">>,
+            <<"docs/guides/bind-listen-address.md">>,
             <<"docs/guides/parse-json-bodies.md">>,
             <<"docs/guides/read-query-strings.md">>,
             <<"docs/guides/parse-form-bodies.md">>,

--- a/rebar.config
+++ b/rebar.config
@@ -7,11 +7,11 @@
 {deps, [
     {mimerl, "1.5.0"},
     {h1, "0.3.0", {pkg, erlang_h1}},
-    {h2, "0.7.0"},
-    {quic, "1.6.1"},
+    {h2, "0.8.0"},
+    {quic, "1.6.2"},
     {ws, "0.3.0", {pkg, erlang_ws}},
     {instrument, "1.1.3"},
-    {webtransport, "0.2.6"},
+    {webtransport, "0.3.0"},
     {hackney, "4.1.0"},
     {barrel_mcp, "2.1.0"}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -41,7 +41,14 @@
     ]},
     {bench, [
         {extra_src_dirs, [{"bench", [{recursive, false}]}]},
-        {erl_opts, [debug_info, nowarn_missing_spec, nowarn_deprecated_catch]}
+        {erl_opts, [debug_info, nowarn_missing_spec, nowarn_deprecated_catch]},
+        %% cowboy (+ cowlib/ranch) for the livery-vs-cowboy comparison;
+        %% same pins as the test profile. See rebar.config test deps.
+        {deps, [
+            {cowlib, "2.16.1"},
+            {ranch, "1.8.1"},
+            {cowboy, {git, "https://github.com/ninenines/cowboy.git", {tag, "2.15.0"}}}
+        ]}
     ]}
 ]}.
 

--- a/src/livery.erl
+++ b/src/livery.erl
@@ -230,15 +230,16 @@ emit_body(Adapter, Stream, Status, Hs, {full, IoData}, Trailers) ->
                 Other -> Other
             end;
         _ ->
-            case Adapter:send_headers(Stream, Status, Hs, #{end_stream => false}) of
-                ok ->
-                    EndStream = not HasTrailers,
-                    case Adapter:send_data(Stream, IoData, #{end_stream => EndStream}) of
-                        ok -> emit_trailers(Adapter, Stream, Trailers);
-                        Other -> Other
-                    end;
-                Other ->
-                    Other
+            CanCoalesce =
+                not HasTrailers andalso
+                    erlang:function_exported(Adapter, send_full, 5),
+            case CanCoalesce of
+                true ->
+                    %% Coalesce headers + body into one adapter call (and
+                    %% one socket write) when the adapter supports it.
+                    Adapter:send_full(Stream, Status, Hs, IoData, #{end_stream => true});
+                false ->
+                    emit_full_granular(Adapter, Stream, Status, Hs, IoData, Trailers)
             end
     end;
 emit_body(Adapter, Stream, Status, Hs, {chunked, Producer}, Trailers) ->
@@ -331,6 +332,21 @@ emit_body(Adapter, Stream, _Status, _Hs, {upgrade, _Kind, _State}, _Trailers) ->
     %% Upgrades are handled at the adapter level (livery_ws, livery_wt).
     Adapter:reset(Stream, upgrade_not_handled_at_emit),
     {error, not_implemented}.
+
+%% Granular full-body emit: separate headers then body, closing the
+%% stream after the body unless trailers follow. Used when the adapter
+%% does not export the coalesced `send_full/5'.
+emit_full_granular(Adapter, Stream, Status, Hs, IoData, Trailers) ->
+    case Adapter:send_headers(Stream, Status, Hs, #{end_stream => false}) of
+        ok ->
+            EndStream = Trailers =:= undefined,
+            case Adapter:send_data(Stream, IoData, #{end_stream => EndStream}) of
+                ok -> emit_trailers(Adapter, Stream, Trailers);
+                Other -> Other
+            end;
+        Other ->
+            Other
+    end.
 
 emit_trailers(_Adapter, _Stream, undefined) ->
     ok;

--- a/src/livery_adapter.erl
+++ b/src/livery_adapter.erl
@@ -97,3 +97,19 @@ here.
 -callback peer_info(stream()) -> peer_info().
 
 -callback capabilities(listener()) -> capabilities().
+
+%% Optional: emit a complete response (status, headers and body) in one
+%% call so the adapter can coalesce it into a single write instead of a
+%% separate `send_headers' + `send_data'. `emit/3' uses it for a `full'
+%% body with no trailers when the adapter exports it, and otherwise
+%% falls back to the granular callbacks.
+-callback send_full(
+    stream(),
+    100..599,
+    [{binary(), binary()}],
+    iodata(),
+    send_opts()
+) ->
+    send_result().
+
+-optional_callbacks([send_full/5]).

--- a/src/livery_drain.erl
+++ b/src/livery_drain.erl
@@ -10,10 +10,10 @@ stops the service. Returns `ok` once fully drained or
 running (the service is stopped either way).
 
 In-flight requests are counted node-wide via the global
-`livery_req_sup` — every request, on every protocol, runs in a
-`livery_req_proc` child of it. A single-service node drains
-exactly its own requests; on a multi-service node `drain/2` waits
-for all of them.
+`livery_req_sup` in-flight counter — every request, on every
+protocol, runs in a `livery_req_proc` worker it tracks. A
+single-service node drains exactly its own requests; on a
+multi-service node `drain/2` waits for all of them.
 
 Stopping acceptance closes the listen socket (no new connections);
 it does not send GOAWAY on existing keep-alive connections.
@@ -79,12 +79,7 @@ await(Opts) ->
 -doc "Number of requests currently in flight (0 if the app is down).".
 -spec in_flight() -> non_neg_integer().
 in_flight() ->
-    try
-        Counts = supervisor:count_children(livery_req_sup),
-        proplists:get_value(active, Counts, 0)
-    catch
-        _:_ -> 0
-    end.
+    livery_req_sup:in_flight().
 
 %%====================================================================
 %% Internals

--- a/src/livery_h1.erl
+++ b/src/livery_h1.erl
@@ -52,6 +52,10 @@ adapter callbacks (`send_headers/4`, `send_data/3`,
 
 -type listen_opts() :: #{
     port => inet:port_number(),
+    %% Bind address. An IPv6 8-tuple selects the inet6 family.
+    ip => inet:ip_address(),
+    %% Bind the IPv6 wildcard (`::') when no explicit `ip' is given.
+    inet6 => boolean(),
     transport => tcp | ssl,
     cert => binary() | string(),
     key => binary() | string(),
@@ -223,6 +227,8 @@ build_h1_opts(Opts, Stack, Handler) ->
     },
     copy_keys(
         [
+            ip,
+            inet6,
             cert,
             key,
             cacerts,

--- a/src/livery_h2.erl
+++ b/src/livery_h2.erl
@@ -55,6 +55,10 @@ in `capabilities/1`.
 
 -type listen_opts() :: #{
     port => inet:port_number(),
+    %% Bind address. An IPv6 8-tuple selects the inet6 family.
+    ip => inet:ip_address(),
+    %% Bind the IPv6 wildcard (`::') when no explicit `ip' is given.
+    inet6 => boolean(),
     transport => tcp | ssl,
     cert => binary() | string(),
     key => binary() | string(),
@@ -232,6 +236,8 @@ build_h2_opts(Opts, Stack, Handler) ->
     },
     copy_keys(
         [
+            ip,
+            inet6,
             cert,
             key,
             cacerts,

--- a/src/livery_h2.erl
+++ b/src/livery_h2.erl
@@ -42,6 +42,7 @@ in `capabilities/1`.
     stop/1,
     send_headers/4,
     send_data/3,
+    send_full/5,
     send_trailers/2,
     reset/2,
     peer_info/1,
@@ -126,6 +127,20 @@ send_headers({Conn, StreamId}, Status, Headers, Opts) ->
 send_data({Conn, StreamId}, IoData, Opts) ->
     EndStream = maps:get(end_stream, Opts, false),
     h2:send_data(Conn, StreamId, iolist_to_binary(IoData), EndStream).
+
+%% Coalesced full response: HEADERS + DATA in one h2 call (and one
+%% socket write). h2:respond/5 falls back to the granular path itself
+%% when it cannot coalesce (oversized headers/body).
+-spec send_full(
+    stream(),
+    100..599,
+    [{binary(), binary()}],
+    iodata(),
+    livery_adapter:send_opts()
+) ->
+    livery_adapter:send_result().
+send_full({Conn, StreamId}, Status, Headers, IoData, _Opts) ->
+    h2:respond(Conn, StreamId, Status, Headers, iolist_to_binary(IoData)).
 
 -spec send_trailers(stream(), [{binary(), binary()}]) ->
     livery_adapter:send_result().

--- a/src/livery_h3.erl
+++ b/src/livery_h3.erl
@@ -50,6 +50,10 @@ adapter callbacks, which call into `quic_h3:send_response/4`,
 -type listen_opts() :: #{
     name => atom(),
     port => inet:port_number(),
+    %% Bind address. An IPv6 8-tuple selects the inet6 family.
+    ip => inet:ip_address(),
+    %% Bind the IPv6 wildcard (`::') when no explicit `ip' is given.
+    inet6 => boolean(),
     cert := binary(),
     key := term(),
     settings => map(),
@@ -251,12 +255,12 @@ build_h3_opts(Opts, Stack, Handler) ->
     Base = #{
         cert => maps:get(cert, Opts),
         key => maps:get(key, Opts),
+        quic_opts => quic_opts(Opts),
         handler => make_handler_fun(Stack, Handler, MaxBody)
     },
     copy_keys(
         [
             settings,
-            quic_opts,
             stream_type_handler,
             h3_datagram_enabled,
             connection_handler,
@@ -268,6 +272,20 @@ build_h3_opts(Opts, Stack, Handler) ->
         Opts,
         Base
     ).
+
+%% Fold the `ip'/`inet6' bind options into `quic_opts.extra_socket_opts'.
+%% An IPv6 `ip' tuple (or `inet6 => true') selects the inet6 family;
+%% caller-supplied `extra_socket_opts' are preserved.
+-spec quic_opts(listen_opts()) -> map().
+quic_opts(Opts) ->
+    QuicOpts = maps:get(quic_opts, Opts, #{}),
+    case livery_inet:socket_addr_opts(Opts) of
+        [] ->
+            QuicOpts;
+        Addr ->
+            Extra = maps:get(extra_socket_opts, QuicOpts, []),
+            QuicOpts#{extra_socket_opts => Addr ++ Extra}
+    end.
 
 -spec copy_keys([atom()], map(), map()) -> map().
 copy_keys([], _Src, Dst) ->

--- a/src/livery_inet.erl
+++ b/src/livery_inet.erl
@@ -1,0 +1,32 @@
+%% @doc Shared listen-address option translation.
+%%
+%% Every adapter accepts the same `ip'/`inet6' listen options; this
+%% module turns them into the `[inet6 | {ip, Addr}]' socket option list
+%% the wire libraries expect.
+-module(livery_inet).
+
+-export([socket_addr_opts/1]).
+
+-doc """
+Build inet listen options from the `ip'/`inet6' keys of a listen-opts map.
+
+An IPv6 `ip' tuple (an 8-tuple) or `inet6 => true' selects the `inet6'
+family; `ip' sets the bind address. Returns a list suitable for the
+`gen_tcp'/`ssl' listen options or quic's `extra_socket_opts'. Returns
+`[]' when neither key is set, so callers fall back to default binding.
+""".
+-spec socket_addr_opts(map()) -> [inet6 | {ip, inet:ip_address()}].
+socket_addr_opts(Opts) ->
+    IP = maps:get(ip, Opts, undefined),
+    Family =
+        case {IP, maps:get(inet6, Opts, false)} of
+            {{_, _, _, _, _, _, _, _}, _} -> [inet6];
+            {_, true} -> [inet6];
+            _ -> []
+        end,
+    Addr =
+        case IP of
+            undefined -> [];
+            _ -> [{ip, IP}]
+        end,
+    Family ++ Addr.

--- a/src/livery_req_proc.erl
+++ b/src/livery_req_proc.erl
@@ -18,7 +18,8 @@ messages, which the body reader already drains via the mailbox.
 
 -export([
     start_link/1,
-    init/2
+    init/2,
+    run/1
 ]).
 
 -export_type([args/0]).
@@ -38,14 +39,29 @@ start_link(Args) ->
 
 -doc false.
 -spec init(pid(), args()) -> no_return().
-init(Parent, #{
+init(Parent, Args) ->
+    proc_lib:init_ack(Parent, {ok, self()}),
+    dispatch(Args),
+    exit(normal).
+
+-doc """
+Run a request to completion in the calling-spawned process. Used by
+`livery_req_sup:start_request/1`, which spawns the worker directly
+(no `init_ack` handshake) and monitors it for the in-flight count.
+""".
+-spec run(args()) -> no_return().
+run(Args) ->
+    dispatch(Args),
+    exit(normal).
+
+-spec dispatch(args()) -> ok.
+dispatch(#{
     adapter := Adapter,
     stream := Stream,
     req := Req0,
     stack := Stack,
     handler := Handler
 }) ->
-    proc_lib:init_ack(Parent, {ok, self()}),
     Req = ensure_started_at(Req0),
     try
         Resp = livery:dispatch(Stack, Handler, Req),
@@ -54,7 +70,7 @@ init(Parent, #{
         Class:Reason:Stack0 ->
             handle_crash(Adapter, Stream, Class, Reason, Stack0)
     end,
-    exit(normal).
+    ok.
 
 -spec ensure_started_at(livery_req:req()) -> livery_req:req().
 ensure_started_at(#livery_req{started_at = undefined} = Req) ->

--- a/src/livery_req_sup.erl
+++ b/src/livery_req_sup.erl
@@ -1,62 +1,115 @@
 -module(livery_req_sup).
 -moduledoc """
-Simple-one-for-one supervisor for `livery_req_proc` children.
+Per-request worker registry and concurrency cap.
 
-Adapters call `start_request/1` on every inbound request. Children
-are temporary: a crashed request does not restart, the adapter
-sees the reset and serves the next stream.
+Adapters call `start_request/1` on every inbound request. The worker
+is spawned directly in the calling process (so spawning is not
+serialized through one process), then this `gen_server` is told to
+monitor it. Workers are temporary: a crashed request does not
+restart, the adapter sees the reset and serves the next stream.
 
-The supervisor caps concurrent in-flight requests: `start_request/1`
-checks the live child count against `max_concurrent_requests`
-(application environment, default 10000) and returns `{error, overload}`
-past the cap, which the adapter answers with `503`. This bounds process
-and memory growth under a connection/request flood. (OTP supervisors
-have no built-in child ceiling, so the check is explicit; the count is
-accurate even when a worker is `kill`ed.) Operators should additionally
-bound the node with `+P`/`+Q` in `vm.args` (a library cannot impose those
+In-flight requests are tracked in a lock-free `counters` array, not
+by enumerating processes: `start_request/1` reads the count to
+enforce `max_concurrent_requests` (application environment, default
+10000) and answers `{error, overload}` past the cap, which the
+adapter turns into a `503`. The count is incremented when a worker
+is admitted and decremented when this server sees the worker's
+`DOWN`, so a worker that is `kill`ed (which skips any in-process
+cleanup) is still accounted for. This bounds process and memory
+growth under a request flood. Operators should additionally bound
+the node with `+P`/`+Q` in `vm.args` (a library cannot impose those
 downstream); see `config/vm.args.example`.
+
+The cap is a soft bound: the read-then-increment is not atomic, so a
+concurrent burst may admit a few past the cap, the same as the
+previous supervisor-count-based check.
 """.
--behaviour(supervisor).
+-behaviour(gen_server).
 
 -export([
     start_link/0,
-    start_request/1
+    start_request/1,
+    in_flight/0
 ]).
--export([init/1]).
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2
+]).
+
+%% persistent_term key for the in-flight `counters' reference. Read on
+%% the request hot path, so it lives in persistent_term (lock-free,
+%% no copy) rather than this server's state.
+-define(COUNTER_KEY, {?MODULE, inflight}).
+
+-record(state, {counter :: counters:counters_ref()}).
+-type state() :: #state{}.
 
 -spec start_link() -> {ok, pid()} | {error, term()}.
 start_link() ->
-    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 -doc """
-Spawn a new `livery_req_proc` under this supervisor, unless the live
-child count is at the `max_concurrent_requests` cap, in which case
-return `{error, overload}` so the adapter can shed load with a `503`.
+Spawn a new `livery_req_proc` worker, unless the in-flight count is at
+the `max_concurrent_requests` cap, in which case return
+`{error, overload}` so the adapter can shed load with a `503`.
 """.
 -spec start_request(livery_req_proc:args()) ->
     {ok, pid()} | {error, term()}.
 start_request(Args) ->
+    Ref = persistent_term:get(?COUNTER_KEY),
     Max = application:get_env(livery, max_concurrent_requests, 10000),
-    Counts = supervisor:count_children(?MODULE),
-    case proplists:get_value(active, Counts) >= Max of
-        true -> {error, overload};
-        false -> supervisor:start_child(?MODULE, [Args])
+    case counters:get(Ref, 1) >= Max of
+        true ->
+            {error, overload};
+        false ->
+            counters:add(Ref, 1, 1),
+            Pid = proc_lib:spawn(livery_req_proc, run, [Args]),
+            gen_server:cast(?MODULE, {monitor, Pid}),
+            {ok, Pid}
     end.
 
--spec init([]) ->
-    {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
+-doc "Number of requests currently in flight (0 if the app is down).".
+-spec in_flight() -> non_neg_integer().
+in_flight() ->
+    try counters:get(persistent_term:get(?COUNTER_KEY), 1) of
+        N when N > 0 -> N;
+        _ -> 0
+    catch
+        _:_ -> 0
+    end.
+
+%%====================================================================
+%% gen_server
+%%====================================================================
+
+-spec init([]) -> {ok, state()}.
 init([]) ->
-    SupFlags = #{
-        strategy => simple_one_for_one,
-        intensity => 100,
-        period => 1
-    },
-    ChildSpec = #{
-        id => livery_req_proc,
-        start => {livery_req_proc, start_link, []},
-        restart => temporary,
-        shutdown => 5000,
-        type => worker,
-        modules => [livery_req_proc]
-    },
-    {ok, {SupFlags, [ChildSpec]}}.
+    Ref = counters:new(1, [write_concurrency]),
+    persistent_term:put(?COUNTER_KEY, Ref),
+    {ok, #state{counter = Ref}}.
+
+-spec handle_call(term(), {pid(), term()}, state()) -> {reply, ok, state()}.
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+%% Monitor an admitted worker so its exit (including an external kill)
+%% decrements the in-flight count.
+-spec handle_cast({monitor, pid()}, state()) -> {noreply, state()}.
+handle_cast({monitor, Pid}, State) ->
+    _ = erlang:monitor(process, Pid),
+    {noreply, State};
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+-spec handle_info(term(), state()) -> {noreply, state()}.
+handle_info({'DOWN', _Ref, process, _Pid, _Reason}, #state{counter = Ref} = State) ->
+    %% One DOWN per admitted worker; balance the admission increment.
+    case counters:get(Ref, 1) > 0 of
+        true -> counters:sub(Ref, 1, 1);
+        false -> ok
+    end,
+    {noreply, State};
+handle_info(_Info, State) ->
+    {noreply, State}.

--- a/src/livery_service.erl
+++ b/src/livery_service.erl
@@ -67,6 +67,10 @@ in-flight requests finish, use `livery:drain/1,2`.
 
 -type listener_opts() :: #{
     port => inet:port_number(),
+    %% Bind address. An IPv6 8-tuple selects the inet6 family.
+    ip => inet:ip_address(),
+    %% Bind the IPv6 wildcard (`::') when no explicit `ip' is given.
+    inet6 => boolean(),
     cert => binary() | string(),
     key => binary() | string() | term(),
     cacerts => [binary()],

--- a/src/livery_sup.erl
+++ b/src/livery_sup.erl
@@ -2,8 +2,8 @@
 -moduledoc """
 Top-level Livery supervisor.
 
-Supervises `livery_req_sup`, the simple-one-for-one parent of
-per-request workers, and `livery_ratelimit_store`, the owner of the
+Supervises `livery_req_sup`, the per-request worker registry and
+concurrency cap, and `livery_ratelimit_store`, the owner of the
 rate-limiter ETS table. Listeners are owned by their wire libraries
 (`h1`/`h2`/`quic`); `livery_service` starts and stops them per
 service rather than under this supervisor.
@@ -24,8 +24,8 @@ init([]) ->
         id => livery_req_sup,
         start => {livery_req_sup, start_link, []},
         restart => permanent,
-        shutdown => infinity,
-        type => supervisor,
+        shutdown => 5000,
+        type => worker,
         modules => [livery_req_sup]
     },
     RateLimitStore = #{

--- a/test/livery_drain_tests.erl
+++ b/test/livery_drain_tests.erl
@@ -37,11 +37,11 @@ in_flight_zero_when_idle() ->
     ?assertEqual(0, livery_drain:in_flight()).
 
 in_flight_counts_live_workers() ->
-    {Tab, S1} = blocked_worker(),
-    {Tab2, S2} = blocked_worker(),
+    {Tab, S1, P1} = blocked_worker(),
+    {Tab2, S2, P2} = blocked_worker(),
     ?assertEqual(2, livery_drain:in_flight()),
-    release(S1),
-    release(S2),
+    release(P1, S1),
+    release(P2, S2),
     wait_idle(1000),
     livery_test_adapter:stop(Tab),
     livery_test_adapter:stop(Tab2).
@@ -54,14 +54,14 @@ await_ok_when_idle() ->
     ?assertEqual(ok, livery_drain:await(#{timeout => 100})).
 
 await_times_out_then_succeeds() ->
-    {Tab, Sync} = blocked_worker(),
+    {Tab, Sync, Pid} = blocked_worker(),
     %% Worker is parked, so a short window times out.
     ?assertEqual(
         {error, timeout},
         livery_drain:await(#{timeout => 150, poll_interval => 20})
     ),
     %% Release it; await now drains to zero.
-    release(Sync),
+    release(Pid, Sync),
     ?assertEqual(ok, livery_drain:await(#{timeout => 1000, poll_interval => 20})),
     livery_test_adapter:stop(Tab).
 
@@ -69,8 +69,8 @@ await_times_out_then_succeeds() ->
 %% Helpers: a livery_req_proc worker whose handler blocks until told
 %%====================================================================
 
-%% Start one request worker under livery_req_sup whose handler waits
-%% for a `{release, Sync}' message. Returns {TestAdapterTab, Sync}.
+%% Start one request worker via livery_req_sup whose handler waits
+%% for a `{release, Sync}' message. Returns {TestAdapterTab, Sync, Pid}.
 blocked_worker() ->
     Tab = livery_test_adapter:start(),
     Stream = livery_test_adapter:new_stream(Tab),
@@ -84,7 +84,7 @@ blocked_worker() ->
         livery_resp:text(200, <<"done">>)
     end,
     Req = livery_req:new(#{method => <<"GET">>, path => <<"/">>}),
-    {ok, _Pid} = livery_req_sup:start_request(#{
+    {ok, Pid} = livery_req_sup:start_request(#{
         adapter => livery_test_adapter,
         stream => Stream,
         req => Req,
@@ -95,17 +95,11 @@ blocked_worker() ->
         {worker_ready, Sync} -> ok
     after 1000 -> error(worker_never_started)
     end,
-    {Tab, Sync}.
+    {Tab, Sync, Pid}.
 
-release(Sync) ->
-    %% The worker is blocked in its handler; find it and release.
-    %% We broadcast to all req_proc children (only the blocked ones
-    %% are listening for {release, Sync}).
-    [
-        Pid ! {release, Sync}
-     || {_, Pid, _, _} <- supervisor:which_children(livery_req_sup),
-        is_pid(Pid)
-    ],
+release(Pid, Sync) ->
+    %% The worker is blocked in its handler; release it directly.
+    Pid ! {release, Sync},
     ok.
 
 wait_idle(Timeout) ->

--- a/test/livery_parity_SUITE.erl
+++ b/test/livery_parity_SUITE.erl
@@ -47,7 +47,8 @@
     conditional_get/1,
     static_file/1,
     health_live/1,
-    metrics_export/1
+    metrics_export/1,
+    ipv6_loopback/1
 ]).
 
 %%====================================================================
@@ -55,7 +56,7 @@
 %%====================================================================
 
 all() ->
-    [{group, test_adapter}, {group, h1}, {group, h2}, {group, h3}].
+    [ipv6_loopback, {group, test_adapter}, {group, h1}, {group, h2}, {group, h3}].
 
 groups() ->
     Shared = [
@@ -504,6 +505,102 @@ metrics_export(Config) ->
 drive(Config, Stack, Handler, Spec) ->
     Driver = ?config(driver, Config),
     Driver(Stack, Handler, Spec).
+
+%% Bind each adapter on the IPv6 loopback and round-trip a request,
+%% proving the `ip'/`inet6' listen option reaches all three wire libs.
+%% Skips on a host without an IPv6 loopback (e.g. CI with IPv6 disabled).
+-define(V6_LOOPBACK, {0, 0, 0, 0, 0, 0, 0, 1}).
+
+ipv6_loopback(Config) ->
+    case ipv6_loopback_available() of
+        false ->
+            {skip, no_ipv6_loopback};
+        true ->
+            ok = ipv6_h1(),
+            ok = ipv6_h2(),
+            ok = ipv6_h3(?config(cert, Config), ?config(key, Config))
+    end.
+
+ipv6_loopback_available() ->
+    case gen_tcp:listen(0, [inet6, {ip, ?V6_LOOPBACK}]) of
+        {ok, S} ->
+            ok = gen_tcp:close(S),
+            true;
+        {error, _} ->
+            false
+    end.
+
+ipv6_h1() ->
+    Handler = fun(_R) -> livery_resp:text(200, <<"v6">>) end,
+    {ok, L} = livery_h1:start(#{
+        port => 0, ip => ?V6_LOOPBACK, stack => [], handler => Handler
+    }),
+    try
+        Port = h1:server_port(L),
+        Url = iolist_to_binary([
+            <<"http://[::1]:">>, integer_to_binary(Port), <<"/">>
+        ]),
+        {ok, 200, _, Body} = hackney:request(
+            get, Url, [], <<>>, [with_body, {recv_timeout, 5000}, {connect_options, [inet6]}]
+        ),
+        ?assertEqual(<<"v6">>, Body),
+        ok
+    after
+        livery_h1:stop(L)
+    end.
+
+ipv6_h2() ->
+    Handler = fun(_R) -> livery_resp:text(200, <<"v6">>) end,
+    {ok, L} = livery_h2:start(#{
+        port => 0, transport => tcp, ip => ?V6_LOOPBACK, stack => [], handler => Handler
+    }),
+    try
+        Port = h2:server_port(L),
+        {ok, Conn} = h2:connect(?V6_LOOPBACK, Port, #{transport => tcp}),
+        try
+            {ok, StreamId} = h2:request(Conn, <<"GET">>, <<"/">>, [{<<"host">>, <<"::1">>}]),
+            Resp = collect_h2(Conn, StreamId, undefined, [], [], undefined),
+            ?assertEqual(200, Resp#response.status),
+            ?assertEqual(<<"v6">>, Resp#response.body),
+            ok
+        after
+            h2:close(Conn)
+        end
+    after
+        livery_h2:stop(L)
+    end.
+
+ipv6_h3(Cert, Key) ->
+    Handler = fun(_R) -> livery_resp:text(200, <<"v6">>) end,
+    {ok, L} = livery_h3:start(#{
+        port => 0, ip => ?V6_LOOPBACK, cert => Cert, key => Key, stack => [], handler => Handler
+    }),
+    try
+        {ok, Port} = quic:get_server_port(L),
+        {ok, Conn} = quic_h3:connect(
+            <<"::1">>, Port, #{verify => verify_none, sync => true}
+        ),
+        try
+            {ok, StreamId} = quic_h3:request(
+                Conn,
+                [
+                    {<<":method">>, <<"GET">>},
+                    {<<":path">>, <<"/">>},
+                    {<<":scheme">>, <<"https">>},
+                    {<<":authority">>, <<"[::1]">>}
+                ],
+                #{end_stream => true}
+            ),
+            Resp = collect_h3(Conn, StreamId, undefined, [], [], undefined),
+            ?assertEqual(200, Resp#response.status),
+            ?assertEqual(<<"v6">>, Resp#response.body),
+            ok
+        after
+            catch quic_h3:close(Conn)
+        end
+    after
+        livery_h3:stop(L)
+    end.
 
 status(#response{status = S}) -> S.
 body(#response{body = B}) -> B.

--- a/test/livery_ws_SUITE.erl
+++ b/test/livery_ws_SUITE.erl
@@ -26,7 +26,8 @@
     h1_rejects_request_without_upgrade_headers/1,
     h2_echo_text_frame/1,
     h2_rejects_plain_get/1,
-    h3_echo_text_frame/1
+    h3_echo_text_frame/1,
+    h1_echo_text_frame_ipv6/1
 ]).
 
 %%====================================================================
@@ -42,6 +43,7 @@ suite() ->
 all() ->
     [
         h1_echo_text_frame,
+        h1_echo_text_frame_ipv6,
         h1_rejects_request_without_upgrade_headers,
         h2_echo_text_frame,
         h2_rejects_plain_get,
@@ -84,6 +86,24 @@ init_per_testcase(TC, Config) when
         {port, h2:server_port(Listener)}
         | Config
     ];
+init_per_testcase(h1_echo_text_frame_ipv6, Config) ->
+    case ipv6_loopback_available() of
+        false ->
+            {skip, no_ipv6_loopback};
+        true ->
+            {ok, Listener} = livery_h1:start(#{
+                port => 0,
+                ip => {0, 0, 0, 0, 0, 0, 0, 1},
+                stack => [],
+                handler => fun ws_handler/1
+            }),
+            [
+                {adapter, h1},
+                {listener, Listener},
+                {port, h1:server_port(Listener)}
+                | Config
+            ]
+    end;
 init_per_testcase(h3_echo_text_frame, Config) ->
     {ok, Listener} = livery_h3:start(#{
         port => 0,
@@ -120,6 +140,15 @@ end_per_testcase(_TC, Config) ->
 ws_handler(R) ->
     livery_ws:upgrade(R, livery_ws_echo_handler, #{}).
 
+ipv6_loopback_available() ->
+    case gen_tcp:listen(0, [inet6, {ip, {0, 0, 0, 0, 0, 0, 0, 1}}]) of
+        {ok, S} ->
+            ok = gen_tcp:close(S),
+            true;
+        {error, _} ->
+            false
+    end.
+
 %%====================================================================
 %% H1
 %%====================================================================
@@ -131,6 +160,22 @@ h1_echo_text_frame(Config) ->
         integer_to_binary(Port),
         <<"/">>
     ]),
+    ws_echo_roundtrip(Url).
+
+%% Same echo round-trip over an IPv6-bound listener (`ip => ::1'),
+%% proving the listen-address options carry through to the WS upgrade.
+%% The listener is bound v6 in init_per_testcase, which skips the case
+%% on a host without an IPv6 loopback.
+h1_echo_text_frame_ipv6(Config) ->
+    Port = ?config(port, Config),
+    Url = iolist_to_binary([
+        <<"ws://[::1]:">>,
+        integer_to_binary(Port),
+        <<"/">>
+    ]),
+    ws_echo_roundtrip(Url).
+
+ws_echo_roundtrip(Url) ->
     Self = self(),
     {ok, Sess} = ws_client:connect(Url, #{
         handler => livery_ws_client_capture,


### PR DESCRIPTION
Three related changes to the request path and wire deps.

## Spawn request workers off the supervisor hot path
`start_request/1` made two synchronous calls to the single global `livery_req_sup` per request (`count_children` for the cap, `start_child` to spawn), serializing every request through one process. Replaced with a lock-free `counters` cap check and a direct `proc_lib:spawn` in the caller. `livery_req_sup` is now a `gen_server` that monitors each worker and decrements the in-flight count on `DOWN`, which stays correct even when a worker is killed. Adds a livery-vs-cowboy mode to the bench harness.

## ip/inet6 listen options
Uniform `ip` and `inet6` options across the H1, H2, and H3 adapters and `start_service`, translated by `livery_inet:socket_addr_opts/1`. WebSockets inherit the listener bind address. New how-to guide.

## Bump wire deps and coalesce H2 full responses
quic 1.6.2, h2 0.8.0, webtransport 0.3.0 (all hex). New optional `send_full/5` adapter callback uses `h2:respond/5` to send a full response in one coalesced write; other adapters fall back to the granular path. h2 0.8.0 also fixes a connection collapse under concurrent load.

## Loopback bench (100 conns, 5s, vs cowboy)
- H1: ~65k to ~80k req/s, p50 roughly halved; ahead of cowboy (~75k).
- H2: ~45k to ~71k req/s, reconnect churn to zero; at parity with cowboy (~73k).