### PR TITLE
Read query strings over H1 (h1 0.4.0)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 
 {deps, [
     {mimerl, "1.5.0"},
-    {h1, "0.3.0", {pkg, erlang_h1}},
+    {h1, "0.4.0", {pkg, erlang_h1}},
     {h2, "0.8.0"},
     {quic, "1.6.3"},
     {ws, "0.3.0", {pkg, erlang_ws}},

--- a/test/livery_h1_SUITE.erl
+++ b/test/livery_h1_SUITE.erl
@@ -21,6 +21,7 @@
     json_response/1,
     empty_response/1,
     binding_via_routed_handler/1,
+    read_query_string/1,
     streaming_chunked_response/1,
     sse_response/1,
     echo_buffered_body/1,
@@ -39,6 +40,7 @@ all() ->
         json_response,
         empty_response,
         binding_via_routed_handler,
+        read_query_string,
         streaming_chunked_response,
         sse_response,
         echo_buffered_body,
@@ -107,6 +109,12 @@ binding_via_routed_handler(Config) ->
     %% No router yet; emulate by reading the path inside the handler.
     {ok, 200, _, Body} = get(Config, <<"/hi/alice">>),
     ?assertEqual(<<"hello, alice">>, Body).
+
+%% The query string survives the H1 transport: livery_ext:query/2 reads
+%% the values (URL-decoded) the handler asked for.
+read_query_string(Config) ->
+    {ok, 200, _, Body} = get(Config, <<"/search?q=hello%20world&page=2">>),
+    ?assertEqual(<<"hello world|2">>, Body).
 
 streaming_chunked_response(Config) ->
     {ok, 200, _, Body} = get(Config, <<"/">>),
@@ -185,6 +193,12 @@ handler_for(binding_via_routed_handler) ->
             _ ->
                 livery_resp:text(404, <<>>)
         end
+    end;
+handler_for(read_query_string) ->
+    fun(R) ->
+        Q = livery_ext:query(<<"q">>, R),
+        Page = livery_ext:query(<<"page">>, R),
+        livery_resp:text(200, [Q, <<"|">>, Page])
     end;
 handler_for(streaming_chunked_response) ->
     Producer = fun(Emit) ->


### PR DESCRIPTION
`h1` 0.4.0 delivers the full origin-form request target (path plus query) in its `request` event. Previously the query string was dropped, so `livery_ext:query/2` always returned `undefined` over H1.

This bumps the `h1` dependency to 0.4.0 and adds a `livery_h1_SUITE` parity test that issues `GET /search?q=hello%20world&page=2` over a real H1 listener and asserts `livery_ext:query/2` returns the decoded values. The read-query-strings guide is now accurate over H1.