### PR TITLE
Make the concept docs concrete and warm

### DIFF
--- a/docs/concepts/adapters.md
+++ b/docs/concepts/adapters.md
@@ -1,9 +1,28 @@
 # Adapters
 
-An adapter glues a wire library to Livery's request/response model.
-Each adapter implements the `livery_adapter` behaviour.
+An adapter is the thin translator between a wire library and Livery's
+request/response model. It is the only part of Livery that knows there is
+a socket. Everything above it (the router, the middleware, your handlers)
+works in terms of request and response values, and the adapter turns
+those into the bytes a particular protocol expects.
 
-## Behaviour
+Because the adapter owns so little, the same handler runs unchanged over
+HTTP/1.1, HTTP/2, and HTTP/3, and over an in-memory test harness with no
+socket at all.
+
+## When you would write one
+
+Almost never: the four shipped adapters cover HTTP/1.1, HTTP/2, HTTP/3,
+and in-memory testing. **You write an adapter when** you want Livery's
+handler model over a transport it does not speak yet, for example a
+different HTTP implementation, an RPC over a message bus, or a bespoke
+test harness. If you find yourself reaching for one to add buffering,
+routing, or protocol logic, that work belongs upstream in the wire
+library or downstream in a middleware instead.
+
+## The behaviour
+
+An adapter implements the `livery_adapter` behaviour:
 
 ```erlang
 -callback start(Name, ListenSpec, Opts) -> {ok, Listener}.
@@ -17,7 +36,9 @@ Each adapter implements the `livery_adapter` behaviour.
 ```
 
 `SendOpts` is `#{end_stream => boolean(), flush => boolean()}`.
-`SendResult` is `ok | {error, closed | flow | term()}`.
+`SendResult` is `ok | {error, closed | flow | term()}`. There is an
+optional `send_full/5` an adapter may export to coalesce headers and body
+into one write; `livery:emit/3` uses it when present.
 
 ## Adapters that ship
 
@@ -28,35 +49,52 @@ Each adapter implements the `livery_adapter` behaviour.
 | `livery_h2` | HTTP/2 | `h2` |
 | `livery_h3` | HTTP/3 | `quic` (`quic_h3` subsystem) |
 
-The test adapter exists so handlers can be exercised in EUnit and
-the parity SUITE can run a single source of truth across every
-adapter.
+The test adapter is the one to read first: it is the smallest complete
+implementation, and the parity SUITE drives one handler set through every
+adapter to prove they behave the same.
 
 ## What an adapter is not
 
-- Not a state machine. Framing, header compression, flow control,
-  and TLS belong to the wire library.
-- Not a buffer. The body reader buffers, not the adapter.
-- Not a router. Routing happens in middleware after the request
-  reaches `livery_req_proc`.
+- **Not a state machine.** Framing, header compression, flow control, and
+  TLS belong to the wire library.
+- **Not a buffer.** The body reader buffers; the adapter does not.
+- **Not a router.** Routing happens in middleware, after the request
+  reaches the worker.
 
-If you find yourself writing complex logic inside an adapter, the
-piece probably belongs in `h1`/`h2`/`quic` upstream or in a
-middleware downstream.
+## How an adapter is wired
 
-## Adding a new adapter
+On a new request the adapter builds a request value, asks
+`livery_req_sup:start_request/1` to spawn the per-request worker, and
+feeds the body in as `{livery_body, Ref, _}` messages:
 
-1. Pick a wire library or implement one.
-2. Implement the eight callbacks in a new `livery_xx` module with
-   `-behaviour(livery_adapter).`.
-3. Translate incoming engine events to `{livery_body, Ref, _}`
-   messages addressed to the per-request process.
-4. Add a group to `test/livery_parity_SUITE.erl` that drives the
-   shared handler matrix through the new adapter.
+```erlang
+{ok, Worker} = livery_req_sup:start_request(#{
+    adapter => ?MODULE, stream => Stream, req => Req,
+    stack => Stack, handler => Handler
+}),
+Worker ! {livery_body, BodyRef, {data, Chunk}},
+Worker ! {livery_body, BodyRef, eof}.
+```
+
+The worker runs the middleware and handler, then drives the response back
+out through `livery:emit/3`, which calls your `send_headers/4`,
+`send_data/3`, and `send_trailers/2`. So the adapter is two halves: turn
+inbound wire events into the body protocol, and implement the `send_*`
+callbacks for the outbound side.
+
+`examples/livery_example_adapter.erl` is a complete, readable adapter that
+does exactly this, capturing the response in ETS instead of a socket so
+the wiring is easy to follow. Section 10 of
+[Build a complete service](../tutorials/build-a-complete-service.md) walks
+it. To grow it into a real transport, keep the callbacks, replace the ETS
+sink with socket writes, translate your wire's body events into
+`{livery_body, Ref, _}` messages, then add a group to
+`test/livery_parity_SUITE.erl` so it is held to the same behaviour as the
+others.
 
 ## Capability gating
 
-A handler can branch on adapter capabilities for optional features:
+A handler can branch on what the arriving protocol supports:
 
 ```erlang
 Adapter = livery_req:adapter(Req),
@@ -68,23 +106,22 @@ case Adapter:capabilities(livery_req:stream(Req)) of
 end.
 ```
 
-`capabilities/1` is a `livery_adapter` callback; call it on the
-concrete adapter module the request arrived on
-(`livery_req:adapter/1`), not on `livery_adapter` itself.
-
-`trailers` and `extended_connect` are protocol-specific. `datagrams`
-and `capsules` apply to WebTransport on H3.
+Call `capabilities/1` on the concrete adapter module the request arrived
+on (`livery_req:adapter/1`), not on `livery_adapter`. `trailers` and
+`extended_connect` are protocol-specific; `datagrams` and `capsules`
+apply to WebTransport on H3.
 
 ## Listen address
 
 Every adapter takes the same `ip => inet:ip_address()` and
-`inet6 => boolean()` listen options, translated to the underlying wire
-library by `livery_inet:socket_addr_opts/1`. See
+`inet6 => boolean()` listen options, translated to the wire library by
+`livery_inet:socket_addr_opts/1`. See
 [Bind to an address or IPv6](../guides/bind-listen-address.md).
 
 ## See also
 
-- Guide: [Bind to an address or IPv6](../guides/bind-listen-address.md)
-- Reference: `livery_adapter`
-- Reference: `livery_test_adapter`
 - Concept: [Architecture](architecture.md)
+- Concept: [Request lifecycle](request-lifecycle.md)
+- Tutorial: [Build a complete service](../tutorials/build-a-complete-service.md)
+- Guide: [Bind to an address or IPv6](../guides/bind-listen-address.md)
+- Reference: `livery_adapter`, `livery_test_adapter`

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -1,7 +1,9 @@
 # Architecture
 
-Livery is a single OTP application that sits on top of three
-external wire libraries and exposes one developer-facing surface.
+Here is the whole shape of Livery in one picture, before we zoom in. It
+is a single OTP application that sits on top of three external wire
+libraries and exposes one developer-facing surface, so you write your
+handlers once and they serve every protocol.
 
 ```
                  ┌─────────────────────┐
@@ -60,8 +62,8 @@ No state machine, no buffering, no framing. The adapter answers
 
 ## Per-request process
 
-For each inbound request the adapter spawns a short-lived worker
-under `livery_req_sup` (simple-one-for-one). The worker:
+For each inbound request the adapter spawns a short-lived worker via
+`livery_req_sup:start_request/1`. The worker:
 
 1. Owns the body reference and receives `{livery_body, Ref, _}`
    messages from the adapter.
@@ -70,8 +72,10 @@ under `livery_req_sup` (simple-one-for-one). The worker:
    adapter's `send_*` callbacks.
 4. Exits when done.
 
-The engine process is never blocked on a slow handler. Crashes are
-mapped to `500` and the worker exits normally.
+The listener process is never blocked on a slow handler: it handed the
+request to its own worker and moved on. Crashes are mapped to `500` and
+the worker exits normally. The [request lifecycle](request-lifecycle.md)
+page follows this path step by step.
 
 ## What this enables
 
@@ -83,6 +87,7 @@ mapped to `500` and the worker exits normally.
 
 ## See also
 
-- [Adapters](adapters.md) — the behaviour in detail
-- [Request lifecycle](request-lifecycle.md) — message flow
+- [Adapters](adapters.md) - the behaviour in detail
+- [Request lifecycle](request-lifecycle.md) - message flow
+- Tutorial: [Build a complete service](../tutorials/build-a-complete-service.md)
 - Long-form: [design.md](../design.md)

--- a/docs/concepts/middleware-pipeline.md
+++ b/docs/concepts/middleware-pipeline.md
@@ -1,29 +1,46 @@
 # The middleware pipeline
 
+Middleware is the code that runs around your handlers: the cross-cutting
+work that does not belong to any one route but to many. A request id on
+every response, an access log line, a body-size cap, an auth check, a
+CORS preflight, a timeout. You write each concern once and stack it.
+
+A Livery middleware is a function over immutable values, in the
+Tower/Axum style: it receives the request and a `Next` continuation, and
+it *returns* a response. It can change the request before calling `Next`,
+change the response after, decline to call `Next` at all, or wrap the
+call. There is no shared mutable response object to write into and
+remember to forward.
+
+## When you want middleware (and when you do not)
+
+**Use middleware when** the behaviour applies to a family of routes:
+authentication, logging, rate limiting, CORS, compression, security
+headers, request ids, deadlines. **Keep it in the handler when** the
+logic is specific to one endpoint. **Put it on a route's `Meta`** when it
+applies to just a few routes (see [Routing](routing.md)).
+
 ## A modern, value-based model
 
 Livery's middleware is the **Tower/Axum** model, not the legacy
-`(req, res, next)` one. The difference is the core of the design
-(principle #4 in [design.md](../design.md): *"Axum + Tower
-ergonomics"*).
+`(req, res, next)` one (principle #4 in [design.md](../design.md):
+*"Axum + Tower ergonomics"*).
 
 **Legacy** (Express, Rack, Cowboy middlewares): a middleware gets a
-mutable request *and* response object and a `next` callback. You
-mutate the response in place and remember to call `next()`; control
-flow is implicit and the response is shared, mutable state.
+mutable request *and* response object plus a `next` callback. You mutate
+the response in place and remember to call `next()`; control flow is
+implicit and the response is shared, mutable state.
 
 ```text
-%% legacy shape — mutate-and-next
+%% legacy shape - mutate-and-next
 fun(Req, Res, Next) -> Res2 = set_header(Res, ...), Next(Req, Res2) end
 ```
 
-**Livery** (Tower-style continuation over immutable values): a
-middleware gets the request and a `Next` continuation, and *returns*
-a response. There is no mutable response object; each stage either
-returns a response, transforms one, or wraps the downstream call.
+**Livery** (continuation over immutable values): a middleware gets the
+request and a `Next` continuation, and returns a response.
 
 ```erlang
-%% Livery shape — continuation-passing, values in/out
+%% Livery shape - continuation-passing, values in/out
 call(Req, Next, State) ->
     Resp = Next(Req),                       %% run the rest of the stack
     livery_resp:with_header(<<"x-served-by">>, <<"livery">>, Resp).
@@ -32,99 +49,136 @@ call(Req, Next, State) ->
 Why it matters:
 
 - **Immutable values.** `Req` and `Resp` are plain records, never a
-  shared mutable handle — safe to pass between processes, trivial to
-  test, no "did I forget to return the response" bugs.
-- **Composition is a value.** `Next` *is* "the rest of the
-  pipeline" as a function; wrapping it in `try`/`catch`, a timeout,
-  or a span is just calling it inside your own code.
-- **Pairs with extractors.** Like Axum, typed input comes from
-  `livery_ext` (`json/1`, `query/2`, `bearer_token/1`), not from
-  mutating the request as it flows.
-
-### The alternative we did not take
-
-The other modern model is the **interceptor chain** (Pedestal,
-gRPC): the pipeline is a *data value* — a queue of
-`#{enter, leave, error}` stages you can reorder, push/pop at
-runtime, and pause/resume, with uniform error handling in a `leave`
-phase. It is more introspectable and dynamic, at the cost of more
-indirection and being less familiar to the Axum audience Livery
-targets. Livery chose the Tower onion; reach for interceptors only
-if you need to manipulate the chain mid-request.
+  shared mutable handle: safe to pass between processes, trivial to test.
+- **Composition is a value.** `Next` *is* "the rest of the pipeline" as a
+  function; wrapping it in `try`/`catch`, a timeout, or a span is just
+  calling it inside your own code.
+- **Pairs with extractors.** Typed input comes from `livery_ext`
+  (`json/1`, `query/2`, `bearer_token/1`), not from mutating the request.
 
 ## Shape
 
-A middleware stack is an ordered list. Each entry is either:
+A stack is an ordered list. Each entry is either:
 
-- `{Module, State}` where `Module` implements the
-  `livery_middleware` behaviour.
+- `{Module, State}` where `Module` implements the `livery_middleware`
+  behaviour; or
 - `fun(Req, Next) -> Resp` for one-off inline middleware.
 
-`livery:dispatch/3` runs the stack against a request and a handler.
-The first entry in the list is outermost: it sees the request first
-and the response last.
+`livery:dispatch/3` runs the stack against a request and a handler. The
+first entry is outermost: it sees the request first and the response
+last.
 
-```
+```text
 Request  ──> M1 ──> M2 ──> M3 ──> Handler ──> M3 ──> M2 ──> M1 ──> Response
               ↑                                                       ↓
               └────── short-circuit returns response without ─────────┘
                        going deeper into the pipeline
 ```
 
-## The three shapes
+## A complete middleware
 
-1. **Pass-through.** Always calls `Next`. Optionally transforms the
-   request before, the response after, or both. Examples:
-   `livery_request_id`, `livery_access_log`.
-2. **Short-circuit.** Returns a response without calling `Next`.
-   Examples: auth failures, rate limit hits, CORS preflight.
-3. **Wrapper.** Calls `Next` inside `try`/`catch`, a monitor, or a
-   spawned worker. Examples: `livery_middleware:wrap`,
-   `livery_timeout`.
-
-## Sugar constructors
+A reusable middleware is a module implementing the one callback,
+`call(Req, Next, State)`. `State` is whatever you configured the entry
+with. This one rejects requests without a known API key, and otherwise
+gets out of the way:
 
 ```erlang
-livery_middleware:before(fun(Req)  -> ... end)        %% request transform
-livery_middleware:after_response(fun(Resp) -> ... end) %% response transform
+-module(my_api_key).
+-behaviour(livery_middleware).
+
+-export([call/3]).
+
+call(Req, Next, #{keys := Keys}) ->
+    case livery_req:header(<<"x-api-key">>, Req) of
+        Key when is_binary(Key) ->
+            case lists:member(Key, Keys) of
+                true  -> Next(Req);                          %% pass through
+                false -> livery_resp:text(403, <<"forbidden">>)  %% short-circuit
+            end;
+        undefined ->
+            livery_resp:text(401, <<"missing api key">>)
+    end.
+```
+
+## Wiring it in
+
+A middleware does nothing until it is in a stack. Put it in the
+service-wide stack to cover every route:
+
+```erlang
+Stack = [
+    {livery_request_id, undefined},
+    {livery_access_log, #{}},
+    {my_api_key, #{keys => [<<"s3cret">>]}}
+].
+```
+
+Or hang it off a single route's `Meta`, so it runs only there, nested
+inside the service-wide stack:
+
+```erlang
+{<<"GET">>, <<"/admin">>, {admin, index},
+ #{middleware => [{my_api_key, #{keys => [<<"s3cret">>]}}]}}
+```
+
+## The three shapes
+
+1. **Pass-through.** Always calls `Next`; optionally transforms the
+   request before or the response after. Examples: `livery_request_id`,
+   `livery_access_log`.
+2. **Short-circuit.** Returns a response without calling `Next`.
+   Examples: auth failures, rate-limit hits, CORS preflight.
+3. **Wrapper.** Calls `Next` inside `try`/`catch`, a monitor, or a
+   spawned worker. Examples: `livery_middleware:wrap`, `livery_timeout`.
+
+## Sugar constructors, and when to use them
+
+For the common cases you do not need a whole module: lift a small
+function into a stack entry.
+
+```erlang
+livery_middleware:before(fun(Req)  -> ... end)               %% request transform
+livery_middleware:after_response(fun(Resp) -> ... end)       %% response transform
 livery_middleware:wrap(fun(Class, Reason, Stack) -> ... end) %% try/catch
 ```
 
-Each returns a stack entry that you can drop straight into the
-list.
+**Which to reach for:**
 
-## State threading
+| You need to ... | Use |
+|---|---|
+| tweak the request, always continue | `before/1` |
+| tweak the response, always continue | `after_response/1` |
+| recover from downstream crashes | `wrap/1` |
+| short-circuit, hold config, or reuse it | a `call/3` module |
 
-Middleware can store values for the handler via
-`livery_req:set_meta/3`. The handler reads them back with
-`livery_req:meta/2`. Examples: authenticated user, trace id, parsed
-form data.
+## Threading state to the handler
 
-The handler can also write to `meta` for downstream
-`after_response` transformers.
+A middleware stores values for the handler with `livery_req:set_meta/3`;
+the handler reads them with `livery_req:meta/2`. Common payloads: the
+authenticated user, a trace id, parsed form data. The handler may also
+write `meta` for a downstream `after_response`.
 
 ## Ordering rules of thumb
 
 | Position | Why |
 |---|---|
 | `livery_request_id` outermost | every response carries an id |
-| Error wrapper just below | catches everything including auth and routing |
+| error wrapper just below | catches everything, including auth and routing |
 | `livery_access_log` after wrapper | sees the final status |
 | `livery_body_limit` further in | bodies are checked once |
-| `livery_timeout` further still | deadline applies to body + handler |
+| `livery_timeout` further still | deadline covers body + handler |
 | auth before business logic | handlers can assume `meta(user, _)` is set |
 | handler last | a single function, never explicit |
 
 ## Performance
 
-The pipeline is built per request as a chain of closures: each
-`Next` is `fun(R) -> run(Rest, Handler, R) end`. Modern BEAM
-inlines these effectively; the per-request overhead is a few
-function calls plus the actual work. Avoid stacks with hundreds of
-entries; aim for under ten.
+The pipeline is built per request as a chain of closures: each `Next` is
+`fun(R) -> run(Rest, Handler, R) end`. The BEAM handles these well; the
+per-request overhead is a few calls plus the real work. Keep stacks under
+about ten entries.
 
 ## See also
 
-- Reference: `livery_middleware`
-- Reference: `livery_request_id`, `livery_body_limit`, `livery_timeout`, `livery_access_log`
 - Tutorial: [Compose a middleware stack](../tutorials/middleware-stack.md)
+- Guide: [Write a custom middleware](../guides/custom-middleware.md)
+- Reference: `livery_middleware`, `livery_request_id`, `livery_body_limit`, `livery_timeout`, `livery_access_log`

--- a/docs/concepts/request-and-response.md
+++ b/docs/concepts/request-and-response.md
@@ -1,13 +1,23 @@
 # Request and response model
 
+A handler in Livery is a plain function: it takes one request value and
+returns one response value. No mutable request object, no response handle
+you write into, no `init/2` and reply tuple. One value in, one value out.
+That is the whole model, and it is why handlers are trivial to test (you
+build a request, you check the response) and safe to pass between
+processes.
+
+```erlang
+greet(Req) ->
+    Name = livery_req:binding(<<"name">>, Req),
+    livery_resp:text(200, [<<"hello, ">>, Name]).
+```
+
 ## Requests are values
 
-A request is an immutable `#livery_req{}` record. Middleware reads
-it via `livery_req` accessors, derives a new value with setters,
-and threads it forward by calling `Next(Req1)`. There is no
-mutable handle, no `Req0/Req1` ceremony, no callback module.
-
-Fields:
+A request is an immutable `#livery_req{}` record. You read it through
+`livery_req` accessors and, in middleware, derive a new value with the
+setters and pass it on with `Next(Req1)`. The fields:
 
 | Field | Type | Source |
 |---|---|---|
@@ -15,69 +25,137 @@ Fields:
 | `method` | `binary()` | adapter |
 | `scheme` | `binary()` | adapter (`<<"http">>`/`<<"https">>`) |
 | `authority` | `binary()` | adapter (host:port) |
-| `path` | `binary()` | adapter, post-router |
+| `path` | `binary()` | adapter |
 | `raw_query` | `binary()` | adapter |
 | `bindings` | `#{binary() => binary()}` | router |
 | `headers` | `[{binary(), binary()}]` | adapter (lowercased names) |
 | `peer` | `{ip, port} \| undefined` | adapter |
 | `tls` | `map() \| undefined` | adapter |
 | `body` | `empty \| {buffered, _} \| {stream, _}` | adapter |
-| `adapter` | `module()` | adapter |
-| `stream` | adapter-specific | adapter |
-| `engine_pid` | `pid() \| undefined` | adapter |
 | `req_id` | `binary()` | middleware (e.g. `livery_request_id`) |
-| `started_at` | `integer() \| undefined` | `livery_req_proc` |
 | `meta` | `map()` | middleware |
 
-`meta` is the user-controlled extension point. Use
-`livery_req:set_meta/3` and `livery_req:meta/2,3` to thread values
-from middleware to handler without expanding the record.
+Reading the common things looks like this:
+
+```erlang
+Method = livery_req:method(Req),                       %% <<"POST">>
+Id     = livery_req:binding(<<"id">>, Req),            %% from /things/:id
+Accept = livery_req:header(<<"accept">>, Req),         %% undefined if absent
+Page   = livery_ext:query(<<"page">>, Req).            %% query string param
+```
+
+`meta` is your extension point. Use `livery_req:set_meta/3` and
+`livery_req:meta/2,3` to carry values without growing the record (see
+"Threading values" below).
+
+## Reading the body
+
+The body is one of three shapes, and the adapter chooses which:
+
+- `empty` - there is no body.
+- `{buffered, IoData}` - the adapter already has it in memory.
+- `{stream, Reader}` - pull it with `livery_body`.
+
+The socket adapters deliver `{stream, Reader}`, so read it to the end
+before decoding. Accepting `{buffered, _}` too means the same handler
+also runs under the in-memory test adapter:
+
+```erlang
+read_json(Req) ->
+    Bin =
+        case livery_req:body(Req) of
+            {stream, Reader}   -> {ok, B, _} = livery_body:read_all(Reader), B;
+            {buffered, IoData} -> iolist_to_binary(IoData);
+            empty              -> <<>>
+        end,
+    try {ok, json:decode(Bin)} catch _:_ -> {error, invalid_json} end.
+```
+
+For huge bodies you can stream rather than buffer; see
+[Streaming and backpressure](streaming-and-backpressure.md).
 
 ## Responses are values
 
-A response is an immutable `#livery_resp{}`. The handler returns
-one; `livery:emit/3` walks it into adapter callbacks.
+A response is an immutable `#livery_resp{}`. You build one with a
+`livery_resp` constructor and, if needed, adjust it with the setters. The
+constructor encodes the body variant, and `livery:emit/3` walks that
+variant into adapter calls:
 
-| Body variant | Emission |
+| Body variant | Built by | Emission |
+|---|---|---|
+| `empty` | `empty/1` | one `send_headers`, stream ended |
+| `{full, IoData}` | `json/2`, `text/2`, `html/2` | headers + body (coalesced where possible) |
+| `{chunked, Producer}` | `stream/3` | headers + repeated `send_data` |
+| `{sse, Producer}` | `sse/2,3` | as chunked, with SSE framing |
+| `{file, Path, Range}` | `file/2,3` | `sendfile` where supported |
+| `{upgrade, ws \| wt, _}` | `upgrade/2` | handed to `livery_ws`/`livery_wt` |
+
+**Which constructor, when:**
+
+| Situation | Use |
 |---|---|
-| `empty` | one `send_headers` with `end_stream` |
-| `{full, IoData}` | `send_headers` + `send_data` (+ `send_trailers`) |
-| `{chunked, Producer}` | `send_headers` + repeated `send_data` from `Emit` |
-| `{sse, Producer}` | as chunked, with SSE framing applied to each event |
-| `{file, Path, Range}` | `sendfile` on adapters that support it |
-| `{upgrade, ws \| wt, _}` | handed off to `livery_ws` / `livery_wt` |
+| JSON API reply | `livery_resp:json/2` |
+| plain text / health check | `livery_resp:text/2` |
+| an HTML page | `livery_resp:html/2` |
+| created a resource, point at it | `json/2` + `livery_resp:with_header/3` (`location`) |
+| nothing to return (204, etc.) | `livery_resp:empty/1` |
+| send the caller elsewhere | `livery_resp:redirect/2` |
+| a file on disk | `livery_resp:file/2` |
+| a live or unbounded body | `stream/3`, `sse/2`, `ndjson/2` |
 
-Headers are lowercased on construction (or on `with_header/3`,
-`append_header/3`). Lookup is case-direct after that.
+A created-resource reply, lifting the location into a variable (a binary
+with an embedded comma would otherwise read oddly):
 
-## Body shapes
+```erlang
+create(Req) ->
+    Note = save(Req),
+    Id = maps:get(<<"id">>, Note),
+    Location = <<"/notes/", Id/binary>>,
+    Resp = livery_resp:json(201, json:encode(Note)),
+    livery_resp:with_header(<<"location">>, Location, Resp).
+```
 
-Inbound body is one of:
+Headers are lowercased on construction and on `with_header/3` /
+`append_header/3`, so later lookups are case-direct.
 
-- `empty` — no body.
-- `{buffered, IoData}` — the adapter has the whole body in memory.
-- `{stream, Reader}` — call `livery_body:read/2` to drain.
+## Threading values from middleware to handler
 
-The H1/H2/H3 adapters choose buffered or streaming based on a
-per-route config. The test adapter always sets whatever the test
-spec passed in.
+When a middleware computes something the handler needs (the
+authenticated user, a parsed body, a trace id), it stores it in `meta`
+and the handler reads it back. Nothing mutates; each stage passes a new
+request forward.
+
+```erlang
+%% in a middleware's call/3
+authenticate(Req, Next) ->
+    User = lookup_user(Req),
+    Next(livery_req:set_meta(user, User, Req)).
+
+%% in the handler
+profile(Req) ->
+    User = livery_req:meta(user, Req),
+    livery_resp:json(200, json:encode(User)).
+```
 
 ## Extractors
 
-`livery_ext` is a thin layer over the request accessors that
-returns typed values or `{error, Reason}`:
+`livery_ext` is a thin typed layer over the accessors. It returns a value
+or `{error, Reason}`, so you can pattern-match the good case:
 
 | Extractor | Returns |
 |---|---|
 | `livery_ext:json/1` | `{ok, Term} \| {error, _}` |
 | `livery_ext:form/1` | `{ok, [{Key, Value}]} \| {error, _}` |
-| `livery_ext:path_param/2` | `binary() \| undefined` |
 | `livery_ext:query/2` | `binary() \| undefined` |
 | `livery_ext:header/2` | `binary() \| undefined` |
 | `livery_ext:bearer_token/1` | `binary() \| undefined` |
 
+`livery_ext:json/1` works on a buffered body; for a streamed body read it
+with `livery_body` first, as shown above.
+
 ## See also
 
-- Reference: `livery_req`
-- Reference: `livery_resp`
-- Reference: `livery_ext`
+- Tutorial: [Your first service](../tutorials/your-first-service.md)
+- Tutorial: [Build a complete service](../tutorials/build-a-complete-service.md)
+- Guide: [Parse a JSON body](../guides/parse-json-bodies.md)
+- Reference: `livery_req`, `livery_resp`, `livery_ext`

--- a/docs/concepts/request-lifecycle.md
+++ b/docs/concepts/request-lifecycle.md
@@ -1,98 +1,129 @@
 # Request lifecycle
 
-What happens between "a request hits the listener" and "the
-response is on the wire".
+This page follows one request from the moment it lands on a listener to
+the moment its response is on the wire. Knowing this path explains the
+two things that surprise people coming from other frameworks: why a
+handler may block freely, and why a handler crash never takes the server
+down.
+
+The short version: **every request gets its own process.** The adapter
+spawns a worker, the worker runs your middleware and handler, and it
+writes the response back through the adapter. The listener process is
+never the one running your code, so a slow or crashing handler cannot
+stall or sink it.
 
 ## Sequence
 
 ```
-client                  adapter                req_proc            handler
+client                  adapter                 worker              handler
   │                        │                       │                  │
   │── headers + body ───→ │                       │                  │
-  │                        │                       │                  │
-  │                        │── start_link ────────→│                  │
+  │                        │── start_request ─────→│  (proc_lib:spawn)│
   │                        │   (adapter, stream,   │                  │
   │                        │    req, stack, fun)   │                  │
-  │                        │                       │                  │
   │── body chunk ───────→ │                       │                  │
   │                        │── {livery_body, ...} →│                  │
   │                        │                       │── dispatch ─────→│
   │                        │                       │   middleware →   │
   │                        │                       │   handler        │
   │                        │                       │←── #livery_resp{}│
-  │                        │                       │                  │
   │                        │←── send_headers ──────│ via livery:emit  │
   │                        │←── send_data ─────────│                  │
   │                        │←── send_trailers ─────│                  │
   │←── response ──────────│                       │                  │
-  │                        │                       │                  │
   │                        │                       │── exit normal ───│
 ```
 
 ## Steps in detail
 
-1. The wire library decodes a request and invokes the adapter's
-   inbound callback with method, path, headers, and a stream
-   handle.
-2. The adapter constructs an initial `#livery_req{}` and calls
-   `livery_req_sup:start_request/1` with the stream, request, stack,
-   and handler.
-3. The supervisor starts a `livery_req_proc` worker. The worker
-   receives subsequent body chunks as `{livery_body, Ref, _}`
+1. The wire library decodes a request and calls the adapter's inbound
+   callback with the method, path, headers, and a stream handle.
+2. The adapter builds an initial request value and calls
+   `livery_req_sup:start_request/1` with the adapter, stream, request,
+   middleware stack, and handler.
+3. `start_request/1` admits the request against the concurrency cap and,
+   if there is room, spawns a `livery_req_proc` worker directly with
+   `proc_lib:spawn` (not a supervised child; see the note below). The
+   worker receives the body, chunk by chunk, as `{livery_body, Ref, _}`
    messages.
-4. The worker runs `livery:dispatch/3`: middleware stack first,
-   then handler.
-5. The handler returns a `#livery_resp{}`.
-6. The worker walks the body variant via `livery:emit/3` into the
-   adapter callbacks. Headers, body bytes, trailers.
-7. The worker exits normally. A crash inside dispatch is mapped to
-   `500` and the worker still exits normally.
+4. The worker runs `livery:dispatch/3`: the middleware stack, then the
+   handler.
+5. The handler returns a `#livery_resp{}` value.
+6. The worker walks that response with `livery:emit/3`, which calls the
+   adapter's `send_headers`, `send_data`, and `send_trailers` in turn.
+7. The worker exits normally. If anything in step 4 to 6 crashed, the
+   worker maps it to a `500` (when nothing was sent yet) and still exits
+   normally, so the failure stays contained.
+
+The worker doing the dispatch is `livery_req_proc`; the entry point is
+`run/1`. The whole of it:
+
+```erlang
+dispatch(Adapter, Stream, Stack, Handler, Req) ->
+    Resp = livery:dispatch(Stack, Handler, Req),
+    livery:emit(Adapter, Stream, Resp).
+```
 
 ## Body messages
 
 The body protocol on the worker's mailbox:
 
-```
+```text
 {livery_body, Ref, {data, IoData}}
 {livery_body, Ref, {trailers, [{Name, Value}]}}
 {livery_body, Ref, eof}
 {livery_body, Ref, {reset, Reason}}
 ```
 
-`livery_body:read/2` drains them. Other messages in the mailbox
-are left alone, so the worker can also receive its own
-application messages (for streaming responses driven by external
-publishers).
+You do not match these by hand. The request carries a reader, and
+`livery_body:read/2` (one chunk) or `livery_body:read_all/1` (the whole
+body) drains them for you. Messages with other tags are left untouched,
+which is exactly why a streaming handler can `receive` its own
+application messages in the same loop. See
+[Streaming and backpressure](streaming-and-backpressure.md).
 
-## Streaming response
+## Why you can block in a handler
 
-When the body variant is `{chunked, Producer}` or `{sse, Producer}`,
-the producer fun runs inside the worker. It is free to `receive`
-and may hibernate during idle stretches.
+Because the handler owns its process, you may call `receive`, sleep, wait
+on a `gen_server`, or loop for as long as the request lives, without a
+yield or a callback in sight. This is what makes the streaming producer
+in the previous page a plain recursive function. The listener keeps
+accepting new connections the whole time; it handed your request to its
+own worker and moved on.
 
 ## Cancellation
 
-A client disconnect is signaled by the wire library to the adapter
-as a stream reset. The per-stream translator calls `livery_disconnect`
-to notify the request worker: it sends a `{livery_disconnect, Ref,
-Reason}` message (matchable via `livery_req:disconnect_tag/0`) so a
-handler blocked in a `receive` wakes, and it runs any callbacks the
-handler registered with `livery_req:on_disconnect/2`. Alternatively
-the worker observes `{error, closed}` from the next `send_data` and
-breaks out of its producer loop.
+When the client resets the stream or drops the connection, the wire
+library tells the adapter, and the adapter's per-stream translator
+notifies the worker. Two things happen: the worker is sent a
+`{livery_disconnect, Ref, Reason}` message (match it with
+`livery_req:disconnect_tag/0`) so a handler parked in a `receive` wakes
+up, and any callbacks registered with `livery_req:on_disconnect/2` run. A
+handler that is mid-`send_data` instead sees `{error, closed}` from the
+next write. Either signal is your cue to stop and clean up.
 
 ## Graceful shutdown
 
-Because every request runs as a `livery_req_proc` child of the one
-`livery_req_sup`, the in-flight count is just that supervisor's
-active children. `livery_drain` uses this: it stops the listeners
-from accepting new connections, waits for the active children to
-reach zero (within a window), then stops the service. See
-[How to shut down gracefully](../guides/graceful-shutdown.md).
+`livery_req_sup` keeps a lock-free count of in-flight requests in a
+`counters` array: it bumps the count when a worker is admitted and drops
+it when the worker exits (it monitors each one, so even a killed worker
+is accounted for). `livery_drain:in_flight/0` reads that count.
+
+Draining uses it: stop the listeners from accepting new connections, wait
+for the in-flight count to reach zero within a window, then stop the
+service. See [Shut down gracefully](../guides/graceful-shutdown.md).
+
+> **Note:** earlier versions ran each worker as a supervised child and
+> counted in-flight requests as the supervisor's active children. That
+> single supervisor became a serialization point on the hot path, so the
+> worker is now spawned directly and the count lives in a `counters` ref.
+> The externally visible behaviour (drain, the `500`-on-crash mapping) is
+> unchanged.
 
 ## See also
 
 - Concept: [Architecture](architecture.md)
 - Concept: [Streaming and backpressure](streaming-and-backpressure.md)
-- Recipe: [Shut down gracefully](../guides/graceful-shutdown.md)
+- Guide: [Shut down gracefully](../guides/graceful-shutdown.md)
+- Tutorial: [Build a complete service](../tutorials/build-a-complete-service.md)
 - Reference: `livery_req_proc`, `livery_drain`

--- a/docs/concepts/routing.md
+++ b/docs/concepts/routing.md
@@ -1,20 +1,34 @@
 # Routing
 
+A router maps a method and a path to a handler. You give Livery a flat
+list of routes, it compiles them into a radix trie once, and from then
+on each request is matched to its handler in time proportional to the
+path depth, not the number of routes.
+
+## When you want a router
+
+**Use a router when** you have more than a couple of endpoints, path
+parameters (`/things/:id`), or different methods on the same path. **Skip
+it when** the service is a single catch-all (a health probe, a webhook
+sink, a proxy); there you can give `start_service/1` a plain `handler`
+function instead of a `router`. Most services want the router.
+
 ## Shape
 
-`livery_router` is a radix-trie router compiled from a flat list
-of `{Method, Path, Handler}` triples:
+`livery_router:compile/1` takes `{Method, Path, Handler}` triples (with
+an optional fourth `Meta` element):
 
 ```erlang
 Router = livery_router:compile([
-    {<<"GET">>,  <<"/">>,           {hello, index}},
-    {<<"GET">>,  <<"/hi/:name">>,   {hello, greet}},
+    {<<"GET">>,  <<"/">>,            {hello, index}},
+    {<<"GET">>,  <<"/hi/:name">>,    {hello, greet}},
     {<<"GET">>,  <<"/files/*rest">>, {files, serve}},
-    {<<"POST">>, <<"/items">>,      {items, create}}
+    {<<"POST">>, <<"/items">>,       {items, create}}
 ]).
 ```
 
-`match/3` returns one of:
+A handler is `{Module, Function}` or a `fun((Req) -> Resp)`. `match/3`
+returns one of:
 
 ```erlang
 {ok, {hello, greet}, #{<<"name">> => <<"alice">>}, _Meta} =
@@ -27,23 +41,29 @@ Router = livery_router:compile([
     livery_router:match(<<"GET">>, <<"/items">>, Router).
 ```
 
-The captured path bindings end up on the request as
-`livery_req:bindings/1`.
+## From route to handler
 
-## Dispatching through a router
-
-You rarely call `match/3` directly. `livery:router_handler/1`
-turns a compiled router into a request handler — it matches, sets
-the path bindings, invokes the route handler, and produces `404`
-for an unknown path or `405` (with an `Allow` header) for a known
-path on the wrong method:
+The captured path parameters land on the request as *bindings*, and the
+handler reads them by name. The route `{<<"GET">>, <<"/hi/:name">>,
+{hello, greet}}` points at this function:
 
 ```erlang
-Handler = livery:router_handler(Router),
+greet(Req) ->
+    Name = livery_req:binding(<<"name">>, Req),
+    livery_resp:text(200, [<<"hello, ">>, Name]).
+```
+
+You rarely call `match/3` yourself. `livery:router_handler/1` turns a
+compiled router into a request handler: it matches, sets the bindings,
+invokes the route handler, and produces `404` for an unknown path or
+`405` (with an `Allow` header) for a known path on the wrong method.
+
+```erlang
+Handler = livery:router_handler(Router).
 %% Handler :: fun((livery_req:req()) -> livery_resp:resp())
 ```
 
-Give the router straight to the service and it does this for you:
+Give the router straight to the service and it wires that for you:
 
 ```erlang
 livery:start_service(#{
@@ -52,10 +72,9 @@ livery:start_service(#{
 }).
 ```
 
-`start_service/1` takes exactly one of `router` or `handler` (a
-single catch-all). `router_handler/2` accepts `not_found` and
-`method_not_allowed` funs to override the default `404`/`405`
-responses.
+`start_service/1` takes exactly one of `router` or `handler`.
+`livery:router_handler/2` accepts `not_found` and `method_not_allowed`
+funs to override the default `404`/`405`.
 
 ## Segment kinds
 
@@ -65,46 +84,37 @@ responses.
 | `/users/:id` | one segment, captured | `#{<<"id">> => Seg}` |
 | `/files/*rest` | one or more trailing segments | `#{<<"rest">> => Joined}` |
 
-Static segments are matched first, then `:param` segments, then
-`*wildcard`. The trie keeps lookup proportional to path depth, not
-route count.
+Static segments match first, then `:param`, then `*wildcard`.
 
-## Method matching
+**Use a `:param`** for a resource identifier (`/things/:id`). **Use a
+`*wildcard`** when the tail is itself a path: serving static files under
+a prefix, or mounting a sub-application. For example
+`{<<"GET">>, <<"/assets/*path">>, {my_static, serve}}` hands the joined
+remainder to a handler that reads `livery_req:binding(<<"path">>, Req)`
+and serves a confined file (see [Serve static files](../guides/serve-static-files.md)).
 
-When a path matches a node but no route is registered for the
-requested method, `match/3` returns
-`{error, {method_not_allowed, Methods}}` where `Methods` is the
-list of methods that *are* registered for that path.
-`livery:router_handler/1` turns that into a `405` response with an
-`Allow` header. A path that matches nothing returns
-`{error, not_found}` → `404`.
+## Per-route middleware and metadata
 
-## Route metadata
-
-Route tuples accept an optional fourth element, a `Meta` map
-(`{Method, Path, Handler, Meta}`): operation id, summary, request
-schema, response schemas, tags. `match/3` returns it as the
-fourth element, and `livery_openapi:build/1` emits an OpenAPI 3.1
-document from the same route table.
-
-`Meta` may also carry a `middleware` key — a `livery_middleware`
-stack that `livery:router_handler/1` runs for that route only,
-inside any service-level stack:
+The optional fourth element is a `Meta` map: an operation id, summary,
+schemas, tags (which `livery_openapi:build/1` turns into an OpenAPI 3.1
+document), and a `middleware` key. That key is a stack
+`livery:router_handler/1` runs for that route only, nested inside any
+service-level stack:
 
 ```erlang
 {<<"GET">>, <<"/admin">>, {admin, index},
- #{middleware => [{my_auth, #{role => admin}}]}}
+ #{middleware => [{my_api_key, #{keys => [<<"s3cret">>]}}]}}
 ```
 
 ## Performance
 
-The radix trie does no allocation on lookup besides the bindings
-map. Empty bindings reuse a single shared `#{}`. Matching a path
-of N segments is O(N) regardless of total route count, with a
-constant factor low enough that the router is not a hot path in
-production benchmarks.
+The trie allocates nothing on a lookup besides the bindings map, and
+empty bindings reuse one shared `#{}`. Matching an N-segment path is O(N)
+regardless of route count, so the router is not a hot path in benchmarks.
 
 ## See also
 
-- Reference: `livery_router`
 - Tutorial: [Your first service](../tutorials/your-first-service.md)
+- Tutorial: [Build a complete service](../tutorials/build-a-complete-service.md)
+- Concept: [The middleware pipeline](middleware-pipeline.md)
+- Reference: `livery_router`

--- a/docs/concepts/streaming-and-backpressure.md
+++ b/docs/concepts/streaming-and-backpressure.md
@@ -1,107 +1,209 @@
 # Streaming and backpressure
 
-Livery streams bytes both ways and applies backpressure rather than
-unbounded buffering when either side stalls.
+Most responses are one short burst: a handler builds a value and Livery
+writes it. Streaming is for the other kind, where the body arrives, or
+leaves, in pieces over time. This page explains how you stream in both
+directions, where the producing function lives, and what happens when
+one side cannot keep up.
 
-## Inbound streaming
+The thing to hold onto: **a request runs in its own process** (the
+per-request worker). So the function that produces a stream is free to
+block, to `receive`, to wait on a database or another process. Nothing
+else shares that process, so there is no callback to register and no
+event loop to yield to. You write a normal Erlang loop.
 
-Inbound body arrives at the per-request process as messages:
+## When to stream, and which one
 
+Reach for streaming when the whole body should not, or cannot, sit in
+memory at once, or when you want bytes to reach the client as they are
+produced rather than at the end.
+
+| You want to ... | Use | Content type |
+|---|---|---|
+| send a normal, complete body | `livery_resp:json/2`, `text/2`, `html/2` | as set |
+| push live updates to a browser | `livery_resp:sse/2` | `text/event-stream` |
+| stream records to a tool or service | `livery_resp:ndjson/2` | `application/x-ndjson` |
+| stream arbitrary bytes (a big export) | `livery_resp:stream/3` | as set |
+| send a file from disk | `livery_resp:file/2` | as set |
+
+**Use `sse/2` when** the client is a browser `EventSource` or you want
+named events with automatic reconnect semantics: dashboards, progress
+bars, notifications, LLM tokens. **Use `ndjson/2` when** the consumer is
+a CLI or another service reading one JSON object per line. **Use
+`stream/3` when** you just need to push opaque chunks (a CSV report
+generated row by row, a proxied payload). **Prefer `file/2`** over
+reading a file yourself; adapters that can will use `sendfile`.
+
+## Outbound: where the producer lives
+
+`livery_resp:stream/3`, `sse/2`, and `ndjson/2` all take a *producer*: a
+function Livery hands an `Emit` callback to. You call `Emit` once per
+chunk; Livery frames it and writes it. The producer runs inside the
+per-request worker, so you can write it as a plain recursive function.
+
+The following is an excerpt from `examples/livery_example_stream.erl`. The
+handler is a one-liner; the real work is `tick/3`, a named top-level
+function, so it is easy to read and to test:
+
+```erlang
+clock(_Req) ->
+    livery_resp:sse(200, fun(Emit) -> tick(Emit, 10, 1000) end).
+
+tick(_Emit, 0, _Interval) ->
+    ok;
+tick(Emit, Remaining, Interval) ->
+    receive
+        {livery_disconnect, _Ref, _Reason} ->
+            ok
+    after Interval ->
+        Now = integer_to_binary(erlang:system_time(second)),
+        case Emit(#{event => <<"tick">>, data => Now}) of
+            ok         -> tick(Emit, Remaining - 1, Interval);
+            {error, _} -> ok
+        end
+    end.
 ```
+
+`Emit` returns the adapter's send result, and you act on it:
+
+- `ok` - the chunk went out; keep going.
+- `{error, closed}` - the peer is gone. Stop and clean up.
+- `{error, flow}` - temporary backpressure (see below); back off and retry.
+- `{error, _Other}` - an adapter-specific failure; stop.
+
+For `sse/2` you emit a map (`#{event => _, id => _, data => _}` or just
+`data`); for `stream/3` and `ndjson/2` you emit `iodata` (ndjson encodes
+and newline-frames each term for you).
+
+## Outbound, receive-driven: the long-lived stream
+
+The clock above paces itself with `after`. The more common shape is a
+stream fed by *another* process: an LLM emitting tokens, a pub/sub topic,
+a job reporting progress. The producer `receive`s those messages and
+forwards them, and it also matches the disconnect message so it can stop
+the upstream work when the client leaves. This is Livery's answer to
+Cowboy's `cowboy_loop`.
+
+```erlang
+chat(Req) ->
+    {ok, InferRef} = my_llm:start(prompt(Req)),   %% streams {token, InferRef, T}
+    livery_resp:sse(200, fun(Emit) -> relay(Emit, InferRef) end).
+
+relay(Emit, InferRef) ->
+    receive
+        {token, InferRef, T} ->
+            case Emit(#{data => T}) of
+                ok         -> relay(Emit, InferRef);
+                {error, _} -> my_llm:cancel(InferRef)   %% client gone: stop work
+            end;
+        {done, InferRef} ->
+            ok;
+        {livery_disconnect, _Ref, _Reason} ->
+            my_llm:cancel(InferRef)
+    end.
+```
+
+The disconnect message tag is `livery_req:disconnect_tag/0`
+(`livery_disconnect`). You do not register anything to get it; the worker
+is sent `{livery_disconnect, Ref, Reason}` when the client resets the
+stream. If your handler is not sitting in a `receive`, register a
+callback instead with `livery_req:on_disconnect/2`. See
+[Cancel on client disconnect](../guides/cancel-on-disconnect.md).
+
+## Inbound: reading a streamed request body
+
+A large upload arrives the same way, as messages on the worker's mailbox:
+
+```text
 {livery_body, Ref, {data, IoData}}
-{livery_body, Ref, {trailers, [...]}}
+{livery_body, Ref, {trailers, [{Name, Value}]}}
 {livery_body, Ref, eof}
 {livery_body, Ref, {reset, Reason}}
 ```
 
-`livery_body:read/2` drains one message per call. `read_all/2`
-loops until `eof` or `reset`.
-
-Backpressure on the inbound side is per-protocol:
-
-- **H1**: limit the wire library's read size; the kernel TCP window
-  closes naturally when the application stops reading.
-- **H2**: WINDOW_UPDATE frames. The wire library issues them in
-  response to `livery_body:signal_demand/2`.
-- **H3**: QUIC flow control credits. Same demand hook.
-
-`livery_body:signal_demand(R, N)` is a no-op for adapters without a
-demand mechanism, and a window update for the others.
-
-## Outbound streaming
-
-The producer fun inside `livery_resp:stream/3` (or `:sse/2`) runs
-in the per-request process. It drives `Emit(IoData)` one chunk at
-a time. Each `Emit` returns the adapter's `send_data` result:
-
-- `ok` — proceed.
-- `{error, closed}` — peer disconnected. Stop and clean up.
-- `{error, flow}` — temporary backpressure; retry after a wait.
-- `{error, _Other}` — adapter-specific error.
-
-The producer can `receive` between emits, sleep, or block on a
-mailbox message. Nothing else in the process competes for control.
-
-## Backpressure on the outbound side
-
-The wire library cooperates with the adapter to apply
-backpressure when the client cannot keep up:
-
-- **H1**: `gen_tcp` `{active, false}` plus `send/2` blocks on a
-  full kernel buffer.
-- **H2**: stream-level WINDOW_UPDATE; `send_data` returns
-  `{error, flow}` when there is no credit.
-- **H3**: same, on QUIC stream credits.
-
-The recommended pattern is to drive `Emit` to completion and react
-on error returns:
+You rarely match those yourself. The request carries a reader, and
+`livery_body` drains it for you. To buffer the whole body (with a size
+cap), use `read_all`:
 
 ```erlang
-fun(Emit) -> stream_loop(Source, Emit) end.
+upload(Req) ->
+    {stream, Reader} = livery_req:body(Req),
+    {ok, Bin, _Reader1} = livery_body:read_all(Reader),
+    livery_resp:text(201, integer_to_binary(byte_size(Bin))).
+```
 
-stream_loop(Source, Emit) ->
-    case next(Source) of
-        {ok, Chunk, Source1} ->
-            case Emit(Chunk) of
-                ok          -> stream_loop(Source1, Emit);
-                {error, _}  -> cleanup(Source1)
-            end;
-        done -> ok
+To process the body without ever holding all of it, loop with
+`livery_body:read/2` (it returns one chunk per call) until `eof`, folding
+as you go, for example hashing or counting:
+
+```erlang
+count_bytes(Reader, Acc) ->
+    case livery_body:read(Reader, 5000) of
+        {ok, Data, Reader1} -> count_bytes(Reader1, Acc + iolist_size(Data));
+        {done, _Reader1}    -> Acc;
+        {error, Reason, _}  -> {error, Reason}
     end.
 ```
 
-## Disconnect detection
+See [Read a streaming request body](../guides/read-streaming-body.md).
 
-A client disconnect surfaces as:
+## Backpressure
 
-- An error return from `Emit` (above), or
-- A `{livery_body, Ref, {reset, _}}` message in the worker mailbox.
+Backpressure is the framework refusing to buffer without bound when one
+side stalls, so a slow client cannot make the server run out of memory.
+It is handled per protocol, and you mostly feel it through return values.
 
-Either way, the producer is the one responsible for stopping. The
-worker process terminates when the producer returns, regardless of
-whether the disconnect was clean.
+**Outbound.** When the client's window is full, `send_data` does not
+buffer forever:
+
+- **H1**: the kernel socket buffer fills and the write blocks.
+- **H2**: a full stream window makes `Emit` return `{error, flow}`.
+- **H3**: the same, on QUIC stream credits.
+
+So the rule from the producer's side is simple: drive `Emit` and react to
+its result. `ok` means proceed, `{error, flow}` means wait a moment and
+retry, `{error, closed}` means give up.
+
+**Inbound.** To pull more body under flow control, call
+`livery_body:signal_demand/2`. It is a no-op on adapters with no demand
+mechanism (H1) and a window update on the others, so the same handler
+code is correct everywhere.
+
+## Failure modes
+
+- **Client disconnects mid-stream.** You learn either way: `Emit` returns
+  `{error, closed}`, or a `{livery_disconnect, _, _}` message arrives.
+  Stop and release upstream resources. The worker then exits.
+- **The producer crashes.** Headers are usually already on the wire, so
+  the crash cannot become a `500`; the stream resets instead. Do cleanup
+  inside the loop (on the error and disconnect branches) rather than
+  relying on a wrapper turning it into a response.
+- **The body exceeds the limit.** With `livery_body_limit` in the stack,
+  an over-limit body is rejected with `413` before your handler runs.
 
 ## Hibernation
 
-Long-lived idle streams (slow LLM tokens, infrequent updates)
-should hibernate to reduce memory footprint:
+A stream that is idle for long stretches (slow tokens, infrequent
+updates) should hibernate so it costs almost no memory while it waits.
+The worker is an ordinary BEAM process, so `erlang:hibernate/3` works:
 
 ```erlang
-stream_loop(Source, Emit) ->
+relay(Emit, Source) ->
     receive
         {Source, Event} ->
-            Emit(format(Event)),
-            stream_loop(Source, Emit)
+            _ = Emit(#{data => format(Event)}),
+            relay(Emit, Source)
     after 30_000 ->
-        erlang:hibernate(?MODULE, stream_loop, [Source, Emit])
+        erlang:hibernate(?MODULE, relay, [Emit, Source])
     end.
 ```
 
-The per-request process is a regular BEAM process, so
-`erlang:hibernate/3` works as usual.
-
 ## See also
 
-- Reference: `livery_body`
-- Reference: `livery_resp`
-- Tutorial: [Stream a response](../tutorials/streaming-responses.md)
+- Guide: [Return a streaming response](../guides/stream-chunked.md)
+- Guide: [Return Server-Sent Events](../guides/server-sent-events.md)
+- Guide: [Read a streaming request body](../guides/read-streaming-body.md)
+- Guide: [Cancel on client disconnect](../guides/cancel-on-disconnect.md)
+- Example: `examples/livery_example_stream.erl`
+- Tutorial: [Build a complete service](../tutorials/build-a-complete-service.md)
+- Reference: `livery_resp`, `livery_body`

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,7 +17,7 @@ Then start one from a shell (`rebar3 as examples shell`):
 REST + path params + SSE + NDJSON + an OpenAPI document, served over
 HTTP/1.1 on one port. `livery:start_service/1` takes a single
 handler, so the example drives `livery_router` from inside that
-handler — a useful pattern until route mounting lands in the
+handler - a useful pattern until route mounting lands in the
 service runtime.
 
 ```
@@ -58,6 +58,17 @@ section of the same tutorial. It implements the `livery_adapter`
 behaviour and runs the real per-request worker, but captures the
 response in ETS instead of writing to a socket, so the wiring is easy to
 read. `test/livery_example_adapter_tests.erl` drives it end to end.
+
+## `livery_example_stream`
+
+The receive-driven streaming companion to the [Streaming and
+backpressure](../docs/concepts/streaming-and-backpressure.md) concept
+doc. A `/clock` endpoint returns Server-Sent Events, one per second, from
+a named `tick/3` producer that loops on `receive` and stops on client
+disconnect. Start it with `livery_example_stream:start(8080)` and watch
+with `curl -N http://127.0.0.1:8080/clock`.
+`test/livery_example_stream_tests.erl` drives the producer with a tiny
+interval.
 
 ## Notes
 

--- a/examples/livery_example_stream.erl
+++ b/examples/livery_example_stream.erl
@@ -1,0 +1,78 @@
+%% @doc A streaming service you can watch tick.
+%%
+%% This is the companion code for the "Streaming and backpressure"
+%% concept doc. It answers the question that doc exists to answer: where
+%% does the producer function live, and what does it look like? Here it
+%% is a real top-level function, `tick/3`, that runs inside the
+%% per-request worker, loops on `receive`, and pushes one Server-Sent
+%% Event per interval until it has sent enough, the client disconnects,
+%% or a send fails.
+%%
+%% Try it:
+%%
+%%     rebar3 as examples shell
+%%     {ok, Pid} = livery_example_stream:start(8080).
+%%     curl -N http://127.0.0.1:8080/clock
+%%     livery_example_stream:stop(Pid).
+%%
+%% `curl -N` disables buffering so you see each `event: tick` arrive once
+%% a second. Press Ctrl-C and the loop notices the disconnect and stops.
+-module(livery_example_stream).
+
+%% service lifecycle
+-export([start/0, start/1, stop/1, router/0, handler/0]).
+%% route handler
+-export([clock/1]).
+%% the producer loop, exported so it reads as a real, named function and
+%% so tests can drive it with a small count and interval
+-export([tick/3]).
+
+start() -> start(8080).
+
+%% @doc Start the streaming service on `Port' over plain HTTP/1.1.
+start(Port) ->
+    livery:start_service(#{
+        http => #{port => Port},
+        router => router()
+    }).
+
+%% @doc Stop the service.
+stop(Pid) ->
+    livery:stop_service(Pid).
+
+%% @doc A ready-to-use router-dispatch handler.
+handler() ->
+    livery:router_handler(router()).
+
+router() ->
+    livery_router:compile([
+        {<<"GET">>, <<"/clock">>, {?MODULE, clock}}
+    ]).
+
+%% The handler does almost nothing: it returns an SSE response whose
+%% producer is `tick/3'. Ten ticks, one per second. The producer fun is
+%% tiny on purpose; the real work lives in the named function it calls.
+clock(_Req) ->
+    livery_resp:sse(200, fun(Emit) -> tick(Emit, 10, 1000) end).
+
+%% @doc The producer loop. It runs in the per-request worker, so it is
+%% free to block in `receive'. Each pass either sends the next event, or
+%% stops because the client went away or the count ran out. Three exits:
+%%
+%%   - the count reaches zero: a clean, finite stream;
+%%   - `{livery_disconnect, _, _}': the client closed, so stop the work;
+%%   - `Emit' returns `{error, _}': the send failed, same conclusion.
+-spec tick(fun((map()) -> ok | {error, term()}), non_neg_integer(), pos_integer()) -> ok.
+tick(_Emit, 0, _Interval) ->
+    ok;
+tick(Emit, Remaining, Interval) ->
+    receive
+        {livery_disconnect, _Ref, _Reason} ->
+            ok
+    after Interval ->
+        Now = integer_to_binary(erlang:system_time(second)),
+        case Emit(#{event => <<"tick">>, data => Now}) of
+            ok -> tick(Emit, Remaining - 1, Interval);
+            {error, _} -> ok
+        end
+    end.

--- a/test/livery_example_stream_tests.erl
+++ b/test/livery_example_stream_tests.erl
@@ -1,0 +1,29 @@
+%% @doc Drives the streaming example's producer through the in-memory
+%% adapter, so the concept doc's receive-loop pattern stays correct.
+-module(livery_example_stream_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% A small count and a tiny interval keep the test fast: the producer
+%% runs synchronously inside livery_test_adapter:run/3.
+emits_n_sse_frames_test() ->
+    Handler = fun(_Req) ->
+        livery_resp:sse(200, fun(Emit) -> livery_example_stream:tick(Emit, 3, 5) end)
+    end,
+    Cap = livery_test_adapter:run([], Handler, #{method => <<"GET">>}),
+    ?assertEqual(200, livery_test_adapter:status(Cap)),
+    Body = livery_test_adapter:body(Cap),
+    ?assertEqual(3, count_substr(Body, <<"event: tick">>)).
+
+%% Zero ticks: the loop returns immediately, no frames.
+emits_nothing_when_count_zero_test() ->
+    Handler = fun(_Req) ->
+        livery_resp:sse(200, fun(Emit) -> livery_example_stream:tick(Emit, 0, 5) end)
+    end,
+    Cap = livery_test_adapter:run([], Handler, #{method => <<"GET">>}),
+    ?assertEqual(<<>>, livery_test_adapter:body(Cap)).
+
+count_substr(Haystack, Needle) ->
+    case binary:matches(Haystack, Needle) of
+        nomatch -> 0;
+        Matches -> length(Matches)
+    end.


### PR DESCRIPTION
Rewrites the seven `docs/concepts/` docs to be concrete, practical, and warm, modeled on the Microsoft Orleans conceptual docs: each opens with a plain-language definition and mental model, says when to use the thing and for what with real scenarios, shows runnable code and where the function lives, resolves choices with "use X when" tables, documents failure modes, and links out to the guides and tutorial.

## Highlights
- **streaming-and-backpressure**: replaces the invented `Source`/`next/1` loop with a real named producer and a receive-driven (LLM/pub-sub) stream, a "which streaming primitive, when" table, inbound `read_all`/`read/2` examples, and a failure-modes section. This was the main gap (the "stream message, where does the function go" complaint).
- **request-lifecycle** and **architecture**: fixed stale facts. The per-request worker is spawned directly via `livery_req_sup:start_request/1` (not a supervised child), and in-flight is a lock-free `counters` ref read by `livery_drain:in_flight/0`.
- **request-and-response / middleware / routing / adapters**: added runnable snippets (a full `call/3` middleware module, body/binding reads, route→handler wiring, an adapter handoff), when-to-use guidance, and comparison tables.
- New `examples/livery_example_stream.erl` (a receive-driven SSE `/clock`) plus a test, as the companion to the streaming doc.

## Verification
`livery_docs_SUITE` (compiles every module snippet and arity-checks every `livery_*` call) passes, along with fmt, compile, examples-compile, lint, xref, dialyzer, eunit (401), and ex_doc. Verified the clock stream over a real socket with `curl -N`. No em-dash in the changed files.