### PR TITLE
Warm the how-to guides' tone

### DIFF
--- a/docs/guides/add-deadlines.md
+++ b/docs/guides/add-deadlines.md
@@ -2,8 +2,10 @@
 
 ## Problem
 
-A handler should return within a bounded time; if it does not, the
-client receives `504` instead of a hung response.
+Some handler reaches out to a slow database, a flaky upstream, or a
+queue that occasionally stalls. You do not want a single request to
+hang forever and tie up a client. You want a clear rule: return in
+time, or the caller gets a `504` and moves on.
 
 ## Solution
 
@@ -15,17 +17,17 @@ Stack = [
 ```
 
 `livery_timeout` runs the rest of the pipeline in a monitored
-worker process. If the worker does not return within `after_ms`,
-the process is killed and `504` is emitted. Handler crashes are
-mapped to `500`.
+worker process. If the worker does not answer within `after_ms`,
+Livery kills it and emits a `504`. And if your handler crashes on
+its own, that becomes a `500`.
 
 ## Caveat: streaming request bodies
 
-The deadline runs in a spawned, monitored worker, but body messages
-from the adapter target the original request process
-(`livery_req_proc`). Handlers that read body chunks via
-`livery_body:read/2` will not see them under this middleware.
-Workarounds:
+There is a catch worth knowing. The deadline runs in a spawned,
+monitored worker, but body messages from the adapter still target
+the original request process (`livery_req_proc`). So a handler that
+reads body chunks with `livery_body:read/2` will never see them
+under this middleware. Two ways around it:
 
 - Place a body-buffering middleware in front of `livery_timeout`.
 - Apply the middleware only to routes whose handlers do not stream
@@ -33,8 +35,9 @@ Workarounds:
 
 ## Per-route deadlines
 
-Stack the middleware multiple times with different keys, or mount
-separate stacks per route group:
+Not every route deserves the same patience. Stack the middleware
+several times with different keys, or mount a separate stack per
+route group:
 
 ```erlang
 FastApi    = [{livery_timeout, #{after_ms => 1_000}} | Common],
@@ -43,9 +46,9 @@ LongPolls  = [{livery_timeout, #{after_ms => 60_000}} | Common].
 
 ## Skipping for long-lived streams
 
-SSE and chunked streaming handlers are open-ended by design. Do
-not place `livery_timeout` in front of them. If you need an idle
-timer for streams, implement it inside the producer with `receive
+SSE and chunked streaming handlers are open-ended on purpose, so
+do not put `livery_timeout` in front of them. If you want an idle
+timer for a stream, build it right into the producer with `receive
 ... after Ms`.
 
 ## See also

--- a/docs/guides/bearer-tokens.md
+++ b/docs/guides/bearer-tokens.md
@@ -2,8 +2,10 @@
 
 ## Problem
 
-Your handler or auth middleware needs the bearer token from the
-`Authorization` header.
+A client sends you a token in the `Authorization` header, and you
+need to pull it out cleanly before you can verify it. The header has
+a scheme prefix, the casing varies between clients, and you would
+rather not parse it by hand in every handler.
 
 ## Solution
 
@@ -44,13 +46,14 @@ call(Req, Next, _State) ->
 verify(_Token) -> {ok, #{}}.
 ```
 
-Place it in the stack after `livery_request_id` and
-`livery_access_log` so the audit log records the failed attempt.
+Put it in the stack after `livery_request_id` and
+`livery_access_log`, so a failed attempt still lands in your audit
+log.
 
 ## Non-bearer schemes
 
-`livery_ext:bearer_token/1` only matches the bearer scheme. For
-Basic auth, read the header directly and decode:
+`livery_ext:bearer_token/1` only matches the bearer scheme. If you
+need Basic auth instead, read the header yourself and decode it:
 
 ```erlang
 case livery_req:header(<<"authorization">>, Req) of
@@ -59,7 +62,8 @@ case livery_req:header(<<"authorization">>, Req) of
 end.
 ```
 
-OIDC, JWKS rotation, and JWT verification ship as `livery_auth`.
+And when you need the real machinery - OIDC, JWKS rotation, JWT
+verification - it all ships as `livery_auth`.
 
 ## See also
 

--- a/docs/guides/cancel-on-disconnect.md
+++ b/docs/guides/cancel-on-disconnect.md
@@ -2,9 +2,10 @@
 
 ## Problem
 
-A request triggers expensive work (an LLM inference, a long query).
-If the client disconnects mid-request, you want to stop that work
-instead of finishing it for nobody.
+A request kicks off expensive work: an LLM inference, a long query,
+a heavy report. Then the client gives up and disconnects halfway
+through. You would rather stop that work right away than keep
+burning resources to produce an answer nobody will read.
 
 ## Solution
 

--- a/docs/guides/cap-body-size.md
+++ b/docs/guides/cap-body-size.md
@@ -2,8 +2,9 @@
 
 ## Problem
 
-You want to reject oversized request bodies with a `413` before
-they reach the handler.
+Someone, by accident or on purpose, sends you a giant request body.
+You would like to turn it away with a `413` early, before it ever
+reaches your handler and ties up memory.
 
 ## Solution
 
@@ -16,17 +17,16 @@ Stack = [
 ].
 ```
 
-A buffered body whose size exceeds `max` short-circuits with
-`livery_resp:text(413, <<"payload too large">>)`. The handler is
-not invoked.
+Any buffered body larger than `max` short-circuits with
+`livery_resp:text(413, <<"payload too large">>)`, and your handler
+never runs.
 
 ## Buffered only
 
-`livery_body_limit` inspects `{buffered, IoData}` bodies and uses
-`iolist_size/1`. Streaming bodies (`{stream, _}`) pass through
-unchecked; count bytes in the handler as you drain the reader.
-
-For streaming intake, count bytes manually in the handler:
+One thing to keep in mind: `livery_body_limit` only inspects
+`{buffered, IoData}` bodies, measured with `iolist_size/1`.
+Streaming bodies (`{stream, _}`) pass straight through unchecked, so
+for those you count bytes yourself as you drain the reader:
 
 ```erlang
 consume(R, Acc) when Acc > Max -> too_large();
@@ -39,7 +39,9 @@ consume(R, Acc) ->
 
 ## Different limits per route
 
-Mount the middleware separately per route group when limits differ:
+An upload endpoint and a JSON API rarely want the same ceiling.
+Mount the middleware separately per route group when the limits
+differ:
 
 ```erlang
 UploadStack  = [{livery_body_limit, #{max => 50_000_000}} | Common],

--- a/docs/guides/compress-responses.md
+++ b/docs/guides/compress-responses.md
@@ -2,8 +2,10 @@
 
 ## Problem
 
-You want responses gzip/deflate-compressed when the client supports it,
-without touching every handler.
+Your responses are bigger than they need to be on the wire, and you
+would like them gzipped or deflated whenever the client can handle
+it. The catch: you do not want to reach into every handler to make
+that happen.
 
 ## Solution
 
@@ -17,18 +19,20 @@ Stack = [
 ```
 
 It reads the request `Accept-Encoding`, picks a codec the client
-accepts, compresses the response body, and sets `Content-Encoding` plus
-`Vary: Accept-Encoding`. A client that sends no `Accept-Encoding` (or
-none the server has) gets the response uncompressed, so any HTTP client
-works: those that advertise gzip decode it transparently, the rest get
+accepts, compresses the body, and sets `Content-Encoding` along with
+`Vary: Accept-Encoding`. A client that sends no `Accept-Encoding`, or
+asks only for codings you do not have, simply gets the response
+uncompressed. So every HTTP client keeps working: the ones that
+advertise gzip decode it transparently, and the rest receive
 identity.
 
 ## What gets compressed
 
-Eligible responses are `{full, _}` bodies at least `min_size` bytes and
-`{chunked, _}` streams, with a compressible `Content-Type` and no
-existing `Content-Encoding`. SSE, file, empty, and upgrade responses
-pass through untouched.
+Livery is selective on purpose. It compresses `{full, _}` bodies of
+at least `min_size` bytes and `{chunked, _}` streams, as long as the
+`Content-Type` is compressible and there is no `Content-Encoding`
+already. SSE, file, empty, and upgrade responses pass through
+untouched.
 
 ```erlang
 {livery_compress, #{
@@ -42,10 +46,11 @@ pass through untouched.
 
 ## Negotiation and server preference
 
-A coding is acceptable when its `Accept-Encoding` q-value is greater
-than zero (`q=0` rejects). Among acceptable codings the SERVER decides
-which to use, in the order of the codec list; client q-weights are only
-an accept/reject filter. Control the order with `codecs`:
+A coding is acceptable when its `Accept-Encoding` q-value is above
+zero (`q=0` is a refusal). Among the codings the client accepts, the
+SERVER picks which one to use, following the order of the codec list;
+the client q-weights act only as an accept-or-reject filter, not a
+ranking. You control the order with `codecs`:
 
 ```erlang
 {livery_compress, #{codecs => [livery_codec_gzip]}}   %% gzip only
@@ -53,13 +58,14 @@ an accept/reject filter. Control the order with `codecs`:
 
 ## Adding more codecs
 
-`livery_compress` negotiates over `livery_codec:registered()`, which is
-`[livery_codec_gzip, livery_codec_deflate]` plus any codec a separate
-app registered. A codec app implements the `livery_codec` behaviour and
-calls `livery_codec:register(Module)` at its own start; it is then
-negotiated automatically (e.g. a future `livery_brotli` advertising
-`br`). The built-ins are always present and cannot be displaced by
-registration.
+`livery_compress` negotiates over `livery_codec:registered()`, which
+is `[livery_codec_gzip, livery_codec_deflate]` plus any codec a
+separate app has registered. To add one, write a module that
+implements the `livery_codec` behaviour and call
+`livery_codec:register(Module)` when your app starts; from then on it
+joins the negotiation automatically (think of a future
+`livery_brotli` advertising `br`). The built-ins are always there and
+registration can never displace them.
 
 ## See also
 

--- a/docs/guides/custom-middleware.md
+++ b/docs/guides/custom-middleware.md
@@ -2,13 +2,15 @@
 
 ## Problem
 
-You need behaviour that runs before or after every handler in a
-stack: auth, CORS, rate limiting, feature flags, request mutation.
+You have logic that belongs around your handlers rather than inside
+them: checking auth, adding CORS headers, rate limiting, flipping a
+feature flag, tweaking the request before it lands. Middleware is
+where that lives, and writing your own is straightforward.
 
 ## Solution
 
-Implement the `livery_middleware` behaviour. One callback:
-`call(Req, Next, State) -> Resp`.
+Implement the `livery_middleware` behaviour. There is just one
+callback to write: `call(Req, Next, State) -> Resp`.
 
 ```erlang
 -module(my_cors).
@@ -35,7 +37,8 @@ Wire it into a stack as `{my_cors, #{origins => [...]}}`.
 
 ## Sugar helpers
 
-For simple shapes, use the constructors instead of a full module:
+When the job is small, you do not need a whole module. Reach for the
+constructors instead:
 
 ```erlang
 %% Mutate the request, then continue.
@@ -57,17 +60,19 @@ end).
 
 ## Three shapes a middleware can take
 
-1. **Pass-through.** Transform request or response. Always call
-   `Next`. Example: `livery_request_id`, `livery_access_log`.
-2. **Short-circuit.** Skip `Next` and return a response directly.
-   Example: auth failures, rate limit hits.
-3. **Wrapper.** Run `Next` inside `try`/`catch` or a monitor.
-   Example: `livery_middleware:wrap`, `livery_timeout`.
+Almost everything you write falls into one of these:
+
+1. **Pass-through.** Transform the request or the response, and
+   always call `Next`. See `livery_request_id`, `livery_access_log`.
+2. **Short-circuit.** Skip `Next` and answer directly. This is how
+   auth failures and rate limit hits work.
+3. **Wrapper.** Run `Next` inside a `try`/`catch` or a monitor. See
+   `livery_middleware:wrap`, `livery_timeout`.
 
 ## Storing state on the request
 
-Use `livery_req:set_meta/3` to thread values from middleware to
-handler:
+To pass a value from your middleware down to the handler, stash it on
+the request with `livery_req:set_meta/3`:
 
 ```erlang
 call(Req, Next, _State) ->
@@ -79,9 +84,9 @@ The handler reads it back with `livery_req:meta(user, Req)`.
 
 ## Ordering
 
-The first entry in the stack list is outermost. Put auth before
-business logic. Put request id and error wrappers at the very top
-so every response carries them.
+The first entry in the stack is the outermost one. So put auth ahead
+of your business logic, and keep request id and error wrappers right
+at the top, where they wrap every response.
 
 ## Testing
 

--- a/docs/guides/empty-and-redirects.md
+++ b/docs/guides/empty-and-redirects.md
@@ -7,8 +7,10 @@ livery_resp:empty(204).   %% No Content
 livery_resp:empty(304).   %% Not Modified
 ```
 
-`empty/1` sends headers with `end_stream` set; no body bytes are
-emitted on the wire.
+`empty/1` sends the headers with `end_stream` set, and not a single
+body byte goes out on the wire. Handy whenever the status says
+everything: a `204` after a successful delete, a `304` for a cache
+hit.
 
 ## Redirect
 
@@ -17,8 +19,8 @@ livery_resp:redirect(302, <<"/login">>).
 livery_resp:redirect(308, <<"https://example.com/api/v2/items">>).
 ```
 
-The builder sets the `Location` header and an empty body. Pass
-additional headers as a third argument:
+The builder fills in the `Location` header and leaves the body
+empty. Need extra headers? Pass them as a third argument:
 
 ```erlang
 livery_resp:redirect(303, <<"/items/42">>,

--- a/docs/guides/enable-cors.md
+++ b/docs/guides/enable-cors.md
@@ -2,9 +2,11 @@
 
 ## Problem
 
-A browser app on another origin needs to call your API, so the
-responses must carry Cross-Origin Resource Sharing headers and
-preflight `OPTIONS` requests must be answered.
+Your frontend lives on one origin and your API on another, and the
+browser refuses to let them talk until the API plays by the
+Cross-Origin Resource Sharing rules. That means your responses need
+the right CORS headers, and the preflight `OPTIONS` requests need a
+proper answer.
 
 ## Solution
 
@@ -25,10 +27,10 @@ Stack = [
 ].
 ```
 
-A preflight (`OPTIONS` carrying `Access-Control-Request-Method`) is
-answered directly with `204` and the `Access-Control-Allow-*` headers;
-the handler is never called. A normal request runs the handler, then
-the CORS response headers are added.
+A preflight (an `OPTIONS` carrying `Access-Control-Request-Method`)
+is answered right away with `204` and the `Access-Control-Allow-*`
+headers, and your handler never sees it. A normal request runs the
+handler as usual, and the CORS headers are added on the way out.
 
 ## Origins
 
@@ -38,19 +40,21 @@ origins => [<<"https://a.test">>, <<"https://b.test">>]
 origins => fun(Origin) -> is_tenant_origin(Origin) end
 ```
 
-When the origin is not allowed, no `Access-Control-Allow-Origin` is
-emitted and the browser blocks the response.
+When an origin is not on the list, no `Access-Control-Allow-Origin`
+goes out, and the browser blocks the response for you.
 
 ## Credentials and the wildcard
 
-`Access-Control-Allow-Origin: *` is invalid with credentials. When
-`credentials => true`, `livery_cors` always echoes the request
+Here is a rule that trips people up: `Access-Control-Allow-Origin:
+*` is illegal once credentials are involved. So when you set
+`credentials => true`, `livery_cors` quietly echoes the request
 `Origin` instead of `*` and adds `Access-Control-Allow-Credentials:
-true`.
+true`. You do not have to think about it.
 
 ## Caching is handled for you
 
-`livery_cors` sets `Vary` so shared caches stay correct:
+Shared caches can serve the wrong response to the wrong origin if
+`Vary` is not set right, so `livery_cors` takes care of it:
 
 - `Vary: Origin` is added on every response (allowed, denied, and the
   no-`Origin` passthrough) whenever the output depends on the request

--- a/docs/guides/export-metrics.md
+++ b/docs/guides/export-metrics.md
@@ -2,13 +2,16 @@
 
 ## Problem
 
-You want Prometheus to scrape your service's metrics at `/metrics`.
+You are running a Prometheus setup, and you want it to scrape your
+service like any other target: hit `/metrics`, get request rates and
+latencies back in the format it expects.
 
 ## Solution
 
-Livery records HTTP server metrics through the `livery_instrument_metrics`
-middleware and exposes them with the `livery_metrics` handler. Add the
-middleware to the stack and mount the handler:
+Livery records HTTP server metrics through the
+`livery_instrument_metrics` middleware and serves them with the
+`livery_metrics` handler. So you do two things: add the middleware to
+the stack, and mount the handler at `/metrics`:
 
 ```erlang
 R1 = livery_router:add('GET', <<"/metrics">>, livery_metrics:handler(), #{}, R0),
@@ -30,10 +33,10 @@ metrics:
 - `http.server.request.duration` (histogram, seconds) - request latency
   with `_bucket`/`_sum`/`_count` series.
 
-Any other metric your app registers via the `instrument` library is
-exported too - `livery_metrics:handler()` simply renders the whole
-`instrument` registry. (Metric names are exposed verbatim, so the dots
-in the OpenTelemetry names are preserved.)
+Anything else your app registers through the `instrument` library
+shows up too, since `livery_metrics:handler()` just renders the whole
+`instrument` registry. Names go out verbatim, so the dots in the
+OpenTelemetry names stay exactly as they are.
 
 ## See also
 

--- a/docs/guides/graceful-shutdown.md
+++ b/docs/guides/graceful-shutdown.md
@@ -2,9 +2,10 @@
 
 ## Problem
 
-On deploy or scale-down you want to stop a service without cutting
-off requests that are mid-flight — finish them, refuse new ones,
-then close.
+You are deploying a new version, or scaling down a node, and right
+now there are requests in flight. You do not want to drop them on
+the floor. What you want is simple: finish the work already started,
+politely refuse anything new, then close the door.
 
 ## Solution
 
@@ -18,23 +19,23 @@ ok = livery:drain(Pid, #{timeout => 30000}).
 
 `drain/2`:
 
-1. **Stops accepting** — closes the listen sockets so no new
-   connections are taken. Connections already open keep serving.
-2. **Waits** up to `timeout` (default 30s) for the requests already
-   in flight to finish.
+1. **Stops accepting** - it closes the listen sockets, so no new
+   connection is taken. Connections already open keep serving.
+2. **Waits** up to `timeout` (30s by default) for the requests
+   already in flight to finish.
 3. **Stops** the service.
 
-It returns `ok` once everything drained, or `{error, timeout}` if
-the window elapsed with requests still running. Either way the
-service is stopped when `drain/2` returns.
+You get back `ok` once everything has drained, or `{error, timeout}`
+if the window ran out with requests still running. Either way, the
+service is stopped by the time `drain/2` returns.
 
-`livery:stop_service/1` remains the immediate, non-graceful stop —
-it cuts off in-flight requests.
+If you want the brutal version, `livery:stop_service/1` is still
+there: it stops immediately and cuts off in-flight requests.
 
 ## Wiring it into shutdown
 
-Call `drain/2` from your application's `stop/1`, or from a SIGTERM
-handler, before the node halts:
+The natural place to call `drain/2` is your application's `stop/1`,
+or a SIGTERM handler, right before the node halts:
 
 ```erlang
 stop(_State) ->
@@ -42,21 +43,21 @@ stop(_State) ->
     ok.
 ```
 
-Pick a timeout shorter than your orchestrator's kill grace period
-(e.g. Kubernetes `terminationGracePeriodSeconds`) so the drain
-finishes before a hard kill.
+One tip: pick a timeout shorter than your orchestrator's kill grace
+period (Kubernetes `terminationGracePeriodSeconds`, for instance) so
+the drain finishes on its own before a hard kill steps in.
 
 ## Notes
 
-- In-flight requests are counted node-wide (every request runs
-  under one shared supervisor). On a single-service node this is
-  exactly that service's requests; on a multi-service node
-  `drain/2` waits for all of them. `livery_drain:in_flight/0`
-  reports the current count.
-- "Stop accepting" closes the listen socket; it does not send
-  GOAWAY on existing keep-alive connections, so a client reusing
-  an open connection can still send one more request until the
-  drain completes.
+- In-flight requests are counted node-wide, because every request
+  runs under one shared supervisor. On a single-service node that is
+  exactly your service's requests; on a multi-service node `drain/2`
+  waits for all of them. `livery_drain:in_flight/0` tells you the
+  current count.
+- "Stop accepting" closes the listen socket, but it does not send
+  GOAWAY on existing keep-alive connections. So a client reusing an
+  open connection can still slip in one more request until the drain
+  completes.
 
 ## See also
 

--- a/docs/guides/handle-file-uploads.md
+++ b/docs/guides/handle-file-uploads.md
@@ -2,14 +2,17 @@
 
 ## Problem
 
-A client POSTs `multipart/form-data` (a browser form with files, or a
-multimodal request) and you need the fields and uploaded files without
-buffering the whole request in memory.
+A client sends you a `multipart/form-data` POST: a browser form with
+file attachments, say, or a multimodal request. You need the fields
+and the uploaded files, and you would rather not load the whole thing
+into memory while you are at it - a single big upload should not be
+able to fill your RAM.
 
 ## Solution
 
-Use `livery_multipart`. Pull parts one at a time and stream each part's
-body, so a large upload never sits in RAM:
+Reach for `livery_multipart`. You pull the parts one at a time and
+stream each part's body, so a large upload never sits in memory all
+at once:
 
 ```erlang
 upload(Req) ->
@@ -36,15 +39,16 @@ consume(MP, _Name, _File) ->
     end.
 ```
 
-`next_part/2` returns each part's `name`, `filename`, `content_type`,
-and raw `headers` (parsed from `Content-Disposition`). `read_part/2`
-streams that part's bytes; calling `next_part` again skips any unread
-remainder.
+`next_part/2` hands you each part's `name`, `filename`,
+`content_type`, and raw `headers` (parsed from `Content-Disposition`).
+`read_part/2` streams that part's bytes, and if you call `next_part`
+again before you have read it all, the unread remainder is simply
+skipped.
 
 ## Small forms: read everything at once
 
-When the parts are small, `read_all/1,2` collects them into memory under
-the limits:
+When the parts are small, streaming is overkill. `read_all/1,2`
+collects everything into memory for you, still under the limits:
 
 ```erlang
 {ok, Parts} = livery_multipart:read_all(Req),
@@ -53,8 +57,9 @@ the limits:
 
 ## Limits
 
-All buffering is bounded. Override the defaults via the options map on
-`new/2` / `read_all/2`:
+Every bit of buffering is bounded, so you are never at the mercy of
+the client. Tune the defaults through the options map on `new/2` or
+`read_all/2`:
 
 ```erlang
 livery_multipart:read_all(Req, #{
@@ -69,11 +74,12 @@ livery_multipart:read_all(Req, #{
 
 ## Security: sanitize the filename
 
-`filename` is returned exactly as the client sent it and the parser
-never touches the filesystem. A hostile client can send
-`../../etc/passwd`. If you write uploads to disk, confine the path
-yourself (basename + a fixed directory); never join the raw `filename`
-onto a path.
+Here is the thing to remember: `filename` comes back exactly as the
+client sent it, and the parser never touches the filesystem. A
+hostile client is free to send `../../etc/passwd`. So if you write
+uploads to disk, confine the path yourself - take the basename and
+join it onto a fixed directory. Never join the raw `filename` onto a
+path and hope for the best.
 
 ## See also
 

--- a/docs/guides/handler-errors.md
+++ b/docs/guides/handler-errors.md
@@ -2,13 +2,15 @@
 
 ## Problem
 
-A handler crashes (`error(badmatch)`, `throw(_)`, division by zero,
-etc.) and you want a controlled response instead of a propagating
-exit.
+Sooner or later a handler crashes - a `badmatch`, a stray `throw`, a
+division by zero. When that happens you would much rather send the
+client a clean, controlled response than let the exit propagate and
+turn into noise.
 
 ## Solution
 
-Wrap the rest of the stack with `livery_middleware:wrap/1`:
+Wrap the rest of the stack with `livery_middleware:wrap/1` and decide,
+in one place, how each kind of failure should look to the client:
 
 ```erlang
 Stack = [
@@ -27,20 +29,23 @@ errors_to_resp(_Class, _Reason, _Stack) ->
 ```
 
 The wrapper catches `throw`, `error`, and `exit` from anything
-downstream. `Class` is `throw | error | exit`.
+downstream, and tells you which one it was: `Class` is
+`throw | error | exit`.
 
 ## Without a wrapper
 
-When a handler runs inside `livery_req_proc` (the worker the H1/H2/H3
-adapters spawn), a crash is automatically mapped to
-`livery_resp:text(500, <<"internal server error">>)`. The wrapper
-is for when you want a custom shape (validation errors as 400,
-business errors as 422, etc.).
+You are not left exposed without one. When a handler runs inside
+`livery_req_proc` (the worker the H1/H2/H3 adapters spawn), a crash
+is automatically turned into
+`livery_resp:text(500, <<"internal server error">>)`. The wrapper is
+for when that generic 500 is not enough and you want a shape of your
+own: validation errors as 400, business errors as 422, and so on.
 
 ## In tests
 
-`livery_test_adapter:run/3` runs synchronously. Without a wrapper a
-crash propagates up through the test process. Either:
+One gotcha worth knowing: `livery_test_adapter:run/3` runs
+synchronously, so without a wrapper a crash propagates straight up
+through your test process. You have two ways around it:
 
 - Add a wrapper in the stack you are testing, or
 - Drive through `livery_req_proc:start_link/1` to exercise the
@@ -48,7 +53,8 @@ crash propagates up through the test process. Either:
 
 ## Domain exceptions as control flow
 
-Throw to short-circuit from deep inside the call tree:
+There is a nice trick hiding here: you can `throw` to short-circuit
+from deep inside the call tree, no error plumbing required.
 
 ```erlang
 authenticate(Req) ->
@@ -62,8 +68,9 @@ show(Req) ->
     livery_resp:json(200, payload()).
 ```
 
-The `wrap` middleware turns the `throw({validation, ...})` into a
-400 without explicit handler-level error handling.
+The `wrap` middleware quietly turns that `throw({validation, ...})`
+into a 400, and your handler never has to mention error handling at
+all.
 
 ## See also
 

--- a/docs/guides/health-checks.md
+++ b/docs/guides/health-checks.md
@@ -2,12 +2,14 @@
 
 ## Problem
 
-An orchestrator (Kubernetes, a load balancer) needs liveness and
-readiness probes: is the process up, and is it ready to take traffic?
+Your orchestrator - Kubernetes, a load balancer, whatever sits in
+front - wants to ask your service two different questions. Is the
+process even up? And is it actually ready to take traffic? Those are
+the liveness and readiness probes, and you need an endpoint for each.
 
 ## Solution
 
-Mount the `livery_health` handlers on routes:
+Mount the ready-made `livery_health` handlers on a couple of routes:
 
 ```erlang
 R0 = livery_router:new(),
@@ -24,22 +26,26 @@ R2 = livery_router:add(
 
 ## Liveness
 
-`livery_health:live()` always answers `200 {"status":"ok"}`. Use it for
-the liveness probe - it only signals that the process is running.
+`livery_health:live()` always answers `200 {"status":"ok"}`. That is
+exactly what you want for a liveness probe: it says nothing more than
+"the process is running", which is the only thing liveness should
+care about.
 
 ## Readiness
 
-`livery_health:ready(Checks)` runs each `{Name, Fun}` check. A check
-passes when its `Fun()` returns `ok`; any other return or a raised
-exception counts as a failure.
+Readiness is where it gets interesting. `livery_health:ready(Checks)`
+runs each `{Name, Fun}` check in turn. A check passes when its `Fun()`
+returns `ok`; anything else, or a raised exception, counts as a
+failure.
 
 - All pass -> `200 {"status":"ok"}`.
 - Any fail -> `503 {"status":"unavailable","failed":["db"]}` listing the
   failed names.
 
-`ready([])` is always ready. Checks run synchronously in the request
-process, so keep them fast (wrap slow dependencies with your own
-timeout).
+`ready([])` is always ready. One thing to keep in mind: the checks
+run synchronously in the request process, so keep them quick. If a
+dependency can be slow, wrap it in a timeout of your own rather than
+letting the probe hang.
 
 ## See also
 

--- a/docs/guides/http-caching.md
+++ b/docs/guides/http-caching.md
@@ -2,14 +2,18 @@
 
 ## Problem
 
-You want clients and CDNs to revalidate cheaply: hold a copy, send
-`If-None-Match`, and get a bodyless `304 Not Modified` when nothing
-changed. You also want to set `Cache-Control`.
+You would like clients and CDNs to stop re-downloading things that
+have not changed. The HTTP way to do this is cheap revalidation: a
+client keeps its copy, sends `If-None-Match` on the next request, and
+gets a bodyless `304 Not Modified` when nothing has moved. While you
+are at it, you also want to say how long a response may be cached with
+`Cache-Control`.
 
 ## Solution
 
-Add `livery_etag` to the stack. It gives a strong ETag to cacheable
-`GET`/`HEAD` responses and answers `304` on a matching `If-None-Match`:
+Drop `livery_etag` into the stack. It attaches a strong ETag to
+cacheable `GET`/`HEAD` responses and, when a client comes back with a
+matching `If-None-Match`, answers `304` for you:
 
 ```erlang
 Stack = [
@@ -18,14 +22,16 @@ Stack = [
 ].
 ```
 
-A first request returns `200` with an `ETag`; a later request that sends
-that ETag in `If-None-Match` gets a `304` with no body.
+The first request gets a `200` with an `ETag`; a later request that
+echoes that ETag back in `If-None-Match` gets a `304` and no body.
+That is the whole loop.
 
 ## Setting your own ETag and Cache-Control
 
-The middleware computes an ETag automatically from `{full, _}` bodies
-that don't already have one. A handler can set its own (respected on any
-body type, including `file`/`chunked`):
+By default the middleware computes an ETag for you, from `{full, _}`
+bodies that don't already have one. But you are always free to set
+your own, and it is respected on any body type, including `file` and
+`chunked`:
 
 ```erlang
 show(Req) ->
@@ -49,21 +55,23 @@ show(Req) ->
 }}
 ```
 
-With `auto => false` the middleware only acts on handler-set ETags.
+Flip `auto => false` and the middleware steps back entirely: it only
+acts on ETags you set yourself.
 
 ## Placement relative to compression
 
-Put `livery_etag` OUTSIDE `livery_compress` (earlier in the stack list)
-so the ETag covers the bytes actually sent on the wire:
+Order matters here. Put `livery_etag` OUTSIDE `livery_compress`
+(earlier in the stack list) so the ETag is computed over the bytes
+that actually go out on the wire:
 
 ```erlang
 Stack = [{livery_etag, #{}}, {livery_compress, #{}} | Rest].
 ```
 
-If you place it inside compression, the ETag is computed from the
-uncompressed body; rely on `Vary: Accept-Encoding` (which
-`livery_compress` already sets) so caches keep per-encoding variants
-distinct.
+If you place it inside compression instead, the ETag ends up computed
+from the uncompressed body. That can still work, but then you must
+lean on `Vary: Accept-Encoding` (which `livery_compress` already sets)
+to keep caches from mixing up the per-encoding variants.
 
 ## Notes
 

--- a/docs/guides/limit-concurrency.md
+++ b/docs/guides/limit-concurrency.md
@@ -2,14 +2,17 @@
 
 ## Problem
 
-A traffic spike can pile up more in-flight requests than your workers
-(or a downstream model) can handle. You want to cap concurrency and shed
-the overflow with `503` instead of collapsing.
+A traffic spike arrives and suddenly there are more in-flight
+requests than your workers - or a downstream model - can possibly
+handle. Left alone, everything slows down together and the whole
+service falls over. The healthier move is to cap concurrency and turn
+the overflow away with a quick `503`, so the requests you do accept
+stay fast.
 
 ## Solution
 
-Add `livery_concurrency` to the stack, built with the `limiter/1`
-factory (which creates the shared counter once):
+Add `livery_concurrency` to the stack, built through the `limiter/1`
+factory (it creates the shared counter once, up front):
 
 ```erlang
 Stack = [
@@ -18,10 +21,11 @@ Stack = [
 ].
 ```
 
-While at or under the limit the request proceeds; over the limit it is
-shed immediately with `503 Service Unavailable` and the handler is never
-called. The counter is a lock-free `atomics` cell shared across request
-processes, so there is no extra process and no lock.
+As long as you are at or under the limit, the request sails through.
+Go over, and it is shed right away with `503 Service Unavailable` and
+your handler is never even called. The counter is a lock-free
+`atomics` cell shared across request processes - no extra process to
+babysit, no lock to contend on.
 
 ## Options
 
@@ -35,8 +39,8 @@ livery_concurrency:limiter(500, #{
 
 ## Global vs per-route
 
-`limiter/1,2` returns a State carrying its own counter, so each call is
-an independent limiter:
+Each call to `limiter/1,2` returns a State carrying its own counter,
+which means every limiter is independent. Use that to your advantage:
 
 ```erlang
 %% one global limit in the service stack
@@ -48,15 +52,16 @@ InferStack = [{livery_concurrency, livery_concurrency:limiter(8)} | Common].
 
 ## Scope and caveats
 
-- A slot is held from admission until the handler RETURNS its response.
-  Body streaming runs after that (outside the middleware stack), so the
-  slot does not cover a long streamed/SSE body. For inference that
-  streams tokens, gate the streaming work yourself if you need to bound
-  active streams.
-- The slot is always released, including when the handler crashes.
-- The limit is approximate under a burst (a request that increments past
-  the limit decrements again), which is the expected behavior for
-  load-shedding.
+- A slot is held from admission until the handler RETURNS its
+  response. Body streaming happens after that, outside the middleware
+  stack, so the slot does not cover a long streamed or SSE body. If
+  you are streaming inference tokens and need to bound the active
+  streams, gate that work yourself.
+- The slot is always released, even when the handler crashes. You
+  cannot leak one.
+- Under a burst the limit is approximate: a request that increments
+  past the limit decrements again on its way out. That is exactly the
+  behavior you want from load-shedding, not a bug.
 
 ## See also
 

--- a/docs/guides/log-requests.md
+++ b/docs/guides/log-requests.md
@@ -2,10 +2,13 @@
 
 ## Problem
 
-You want one structured log entry per completed request with
-method, path, status, duration, and request id.
+You want the classic access log: one tidy, structured line per
+completed request, with the method, the path, the status, how long it
+took, and the request id to tie it all together.
 
 ## Solution
+
+Two middlewares, and you are done:
 
 ```erlang
 Stack = [
@@ -15,8 +18,8 @@ Stack = [
 ].
 ```
 
-`livery_access_log` emits one entry through `logger:log/2` after
-the handler returns. Fields:
+`livery_access_log` emits one entry through `logger:log/2` once the
+handler returns. Here is what each line carries:
 
 | Key | Value |
 |---|---|
@@ -30,14 +33,16 @@ the handler returns. Fields:
 
 ## Configure the level
 
-Default level is `info`. Override in state:
+The default level is `info`. Override it in the state:
 
 ```erlang
 {livery_access_log, #{level => notice}}
 ```
 
-If your `logger` primary level is at `notice` (OTP default), use
-`notice` or higher, or raise the primary level for development:
+A common surprise: if your `logger` primary level sits at `notice`
+(the OTP default), `info` lines are dropped before they reach a
+handler. So either log at `notice` or higher, or raise the primary
+level while you develop:
 
 ```erlang
 logger:set_primary_config(level, info).
@@ -45,8 +50,9 @@ logger:set_primary_config(level, info).
 
 ## Read the entries
 
-Standard `logger` handler. To send entries to a custom destination,
-add a handler:
+These are plain `logger` events, so any `logger` handler picks them
+up. To route them somewhere of your own, add a handler with a filter
+that keeps only the access lines:
 
 ```erlang
 logger:add_handler(my_access, my_handler,
@@ -59,9 +65,10 @@ logger:add_handler(my_access, my_handler,
 
 ## Ordering
 
-Place `livery_access_log` after `livery_request_id` so the
-recorded `request_id` is the one the client also receives. Place
-it inside an error wrapper so 500s are still logged.
+Order matters in two small ways. Place `livery_access_log` after
+`livery_request_id`, so the `request_id` you log is the same one the
+client receives. And place it inside your error wrapper, so the 500s
+get logged too instead of vanishing with the crash.
 
 ```erlang
 Stack = [
@@ -74,18 +81,19 @@ Stack = [
 
 ## Correlate access logs with traces
 
-If you also run the `livery_instrument_trace` middleware, install
+If you also run the `livery_instrument_trace` middleware, you can
+make your access logs and your traces point at each other. Install
 the `instrument` logger filter once at boot:
 
 ```erlang
 ok = livery_instrument_trace:install_logger().
 ```
 
-The filter enriches every `logger` event emitted while a span is
-active with the span's `trace_id`, `span_id`, and `trace_flags` in
-the event metadata. Stack the trace middleware *outside*
-`livery_access_log` and each access-log line carries the same ids
-as the request's span:
+From then on, every `logger` event emitted while a span is active is
+enriched with that span's `trace_id`, `span_id`, and `trace_flags` in
+its metadata. Stack the trace middleware *outside* `livery_access_log`
+and each access-log line then carries the same ids as the request's
+span:
 
 ```erlang
 Stack = [
@@ -96,9 +104,9 @@ Stack = [
 ].
 ```
 
-Any `logger` call your handler makes during the request inherits
-the same ids, so application logs and access logs line up with the
-trace in your backend.
+Better still, any `logger` call your handler makes during the request
+inherits the same ids, so your application logs, your access logs,
+and the trace in your backend all line up.
 
 ## See also
 

--- a/docs/guides/migrate-from-cowboy.md
+++ b/docs/guides/migrate-from-cowboy.md
@@ -2,8 +2,10 @@
 
 ## Problem
 
-You have a service running on Cowboy and you want to move it to
-Livery, ideally without rewriting handlers from scratch.
+You have a service happily running on Cowboy, and you want to bring
+it over to Livery. Ideally without throwing away your handlers and
+starting from a blank file. Good news: most of the move is mechanical,
+and a lot of Cowboy ceremony simply disappears.
 
 ## Mapping table
 
@@ -44,7 +46,8 @@ handle(_Req) ->
     livery_resp:json(200, json:encode(#{ok => true})).
 ```
 
-No `init`, no `Opts`, no `Req0/Req1` threading.
+No `init`, no `Opts`, no `Req0`/`Req1` to thread through. The handler
+takes a request and returns a response, and that is the whole story.
 
 ### 2. Convert a streaming `cowboy_loop` handler
 
@@ -84,15 +87,15 @@ loop(Emit) ->
     end.
 ```
 
-The producer fun runs in the per-request process. It can `receive`
-between emits and hibernate during idle stretches the same way
-`cowboy_loop` does, with one function instead of a three-callback
-state machine.
+The producer fun runs in the per-request process, so it can `receive`
+between emits and hibernate during the quiet stretches, exactly like
+`cowboy_loop` did. The difference is that it is one plain function
+instead of a three-callback state machine.
 
 ### 3. Convert the access log stream handler
 
-Cowboy registers a custom `cowboy_stream` handler module for access
-logging. In Livery the equivalent is a middleware:
+For access logging, Cowboy has you register a custom `cowboy_stream`
+handler module. In Livery the same job is just a middleware:
 
 ```erlang
 Stack = [
@@ -127,31 +130,34 @@ Livery:
 }).
 ```
 
-The H1/H2/H3 adapters are wired, so the same handler set serves all
-three protocols from one `start_service/1` call. You can also drive
-handlers in EUnit through `livery_test_adapter:run/3`.
+The H1/H2/H3 adapters are already wired in, so that same handler set
+now serves all three protocols from a single `start_service/1` call.
+And when you want to test a handler in EUnit, you can drive it
+directly through `livery_test_adapter:run/3`.
 
 ## Validated against Cowboy
 
-`examples/livery_example_migration.erl` is the "after" side of this
-guide: a plain handler, a small REST resource, SSE, a streaming
-(`cowboy_loop`) replacement, and a WebSocket echo, all in Livery.
-`test/livery_cowboy_parity_SUITE.erl` runs that exact handler set behind
-both a live Cowboy listener and Livery and diffs the observable behaviour
-(status, content-type, body, framing) over H1, then drives the same
-Livery handlers over H2 and H3 to show the protocol upgrade Cowboy cannot
-give you. The mappings in this guide are enforced by that suite.
+This guide is not hand-waving. `examples/livery_example_migration.erl`
+is the "after" side of it: a plain handler, a small REST resource,
+SSE, a streaming (`cowboy_loop`) replacement, and a WebSocket echo,
+all in Livery. Then `test/livery_cowboy_parity_SUITE.erl` runs that
+exact handler set behind both a live Cowboy listener and Livery, and
+diffs the observable behaviour (status, content-type, body, framing)
+over H1. After that it drives the same Livery handlers over H2 and H3,
+the protocol upgrade Cowboy simply cannot give you. So the mappings in
+this guide are not promises, they are checked by that suite.
 
 ## Cowboy concepts that do not move
 
-- `cowboy_rest`: there is no equivalent. Use plain handlers with
-  `livery_ext` extractors. A REST helper module is not on the
-  current roadmap.
-- `cowboy_req:cast/2`: not needed. The request process owns its
-  state; send a message to `livery_req:engine_pid/1` or use
+A few things will not come across, and it is better to know up front:
+
+- `cowboy_rest`: no equivalent, and none is on the roadmap. Write
+  plain handlers and lean on the `livery_ext` extractors instead.
+- `cowboy_req:cast/2`: you will not miss it. The request process owns
+  its state, so send a message to `livery_req:engine_pid/1`, or use
   application-level pub/sub.
-- `cowboy_stream` custom handlers: replaced by middleware. There is
-  no second extension point.
+- `cowboy_stream` custom handlers: folded into middleware. There is no
+  second extension point, and you will not need one.
 
 ## See also
 

--- a/docs/guides/mount-a-router.md
+++ b/docs/guides/mount-a-router.md
@@ -2,13 +2,16 @@
 
 ## Problem
 
-You have several routes and want the service to dispatch by
-method and path — with path-parameter binding and automatic
-404/405 — instead of writing one big handler.
+Your service has grown past a single endpoint. Now you have a handful
+of routes, and stuffing them all into one giant handler that switches
+on method and path is no fun. You want the service to do the
+dispatching for you - by method and path, with path parameters bound
+automatically and sensible 404/405 responses handled out of the box.
 
 ## Solution
 
-Compile a router and pass it to `start_service/1` as `router`:
+Compile a router and hand it to `start_service/1` under the `router`
+key:
 
 ```erlang
 Router = livery_router:compile([
@@ -25,9 +28,9 @@ Router = livery_router:compile([
 }).
 ```
 
-Each route handler is a normal handler — `fun(Req) -> Resp` or
-`{Module, Function}` — and receives the request with path
-parameters already bound:
+Each route handler is just a normal handler - a `fun(Req) -> Resp` or
+a `{Module, Function}` pair - and it receives the request with the
+path parameters already bound for you:
 
 ```erlang
 show(Req) ->
@@ -35,9 +38,10 @@ show(Req) ->
     livery_resp:json(200, lookup(Id)).
 ```
 
-`start_service/1` takes **exactly one** of `router` or `handler`.
-Use `handler` for a single catch-all; use `router` for dispatch.
-The service-level `middleware` stack wraps every route.
+A small rule to keep in mind: `start_service/1` takes **exactly one**
+of `router` or `handler`. Reach for `handler` when you genuinely want
+a single catch-all, and `router` whenever you want dispatch. Either
+way, the service-level `middleware` stack wraps every route.
 
 ## What you get for free
 
@@ -48,9 +52,10 @@ The service-level `middleware` stack wraps every route.
 
 ## Per-route middleware
 
-A route's optional `Meta` map (the fourth tuple element) may carry
-a `middleware` stack that runs only for that route, inside any
-service-level stack:
+Not every route needs the same treatment. A route's optional `Meta`
+map (the fourth element of the tuple) can carry its own `middleware`
+stack that runs for that route alone, nested inside any service-level
+stack:
 
 ```erlang
 Auth = {my_auth, #{required => true}},
@@ -60,13 +65,14 @@ Router = livery_router:compile([
 ]).
 ```
 
-`/private` runs `Auth` before its handler; `/public` does not.
-Nesting is service stack (outermost) → route match → route stack →
-handler.
+So `/private` runs `Auth` before its handler, and `/public` skips it
+entirely. The nesting, from the outside in, is: service stack → route
+match → route stack → handler.
 
 ## Customising 404 / 405
 
-To control the fallbacks, build the handler yourself with
+The default 404 and 405 are fine for most services, but when you want
+your own (a problem+json body, say), build the handler yourself with
 `livery:router_handler/2` and pass it as `handler`:
 
 ```erlang
@@ -79,8 +85,9 @@ livery:start_service(#{http => #{port => 8080}, handler => H}).
 
 ## Using a router without the service
 
-`livery:router_handler/1` returns a plain handler fun, so you can
-also use it with a single listener or drive it directly in tests:
+A router is not tied to a full service. `livery:router_handler/1`
+gives you back a plain handler fun, which you can wire into a single
+listener or drive straight from a test:
 
 ```erlang
 H = livery:router_handler(Router),

--- a/docs/guides/openapi-and-validation.md
+++ b/docs/guides/openapi-and-validation.md
@@ -2,15 +2,19 @@
 
 ## Problem
 
-You want a machine-readable OpenAPI spec for your routes, a
-browsable docs page, and automatic rejection of malformed request
-bodies.
+Your routes already exist in code, and now someone wants the spec,
+the pretty docs page, and a guarantee that junk request bodies never
+reach your handlers. You would rather not write all of that by hand,
+and you do not have to. Here we generate the OpenAPI document from
+your routes, serve a docs UI, and let a schema reject bad bodies for
+you.
 
 ## Generate the spec
 
-`livery_openapi:build/1` turns route metadata into an OpenAPI 3.1
-document. Livery path templates (`:param`, `*wildcard`) become
-`{param}` and gain synthesised path parameters:
+`livery_openapi:build/1` reads your route metadata and hands back an
+OpenAPI 3.1 document. Your Livery path templates (`:param`,
+`*wildcard`) become `{param}`, and the matching path parameters are
+filled in for you:
 
 ```erlang
 Doc = livery_openapi:build(#{
@@ -32,9 +36,9 @@ Serve it as JSON with `livery_openapi:handler/1`, mounted at
 
 ## Serve a docs UI
 
-Both UIs are self-contained HTML pages that load the spec from a
-URL; the JS bundles come from a CDN, so no static files are
-needed. Pick one:
+Both UIs are single self-contained HTML pages that fetch the spec
+from a URL. The JS bundles come from a CDN, so you ship no static
+files at all. Pick the one you like:
 
 ```erlang
 %% Redoc
@@ -48,9 +52,10 @@ Pass a custom spec URL to either: `redoc_handler(<<"/v2/openapi.json">>)`.
 
 ## Validate request bodies
 
-`livery_openapi_validate` rejects bodies that do not match a
-schema with `422`, and stores the decoded body under
-`meta(body, _)` on success:
+Drop `livery_openapi_validate` into the stack and bad bodies stop at
+the door: anything that does not match the schema gets a `422`, and a
+valid body is decoded and tucked away under `meta(body, _)` for your
+handler:
 
 ```erlang
 Schema = #{
@@ -66,7 +71,7 @@ Schema = #{
 Stack = [{livery_openapi_validate, #{body_schema => Schema}}],
 ```
 
-Supported keywords cover `type` (single or a list), `enum`,
+The keywords you can lean on cover `type` (single or a list), `enum`,
 `const`, the numeric bounds (`minimum`/`maximum`/`exclusive*`/
 `multipleOf`), string `minLength`/`maxLength`/`pattern`, object
 `required`/`properties`/`additionalProperties`/`min`/`maxProperties`,

--- a/docs/guides/parse-form-bodies.md
+++ b/docs/guides/parse-form-bodies.md
@@ -2,13 +2,14 @@
 
 ## Problem
 
-You need the fields from an `application/x-www-form-urlencoded` request
-body, or the parameters from the URL query string.
+A classic HTML form just posted to your route, or a link carried a few
+parameters in its query string, and now you want those values as plain
+binaries you can work with. That is exactly what this guide is for.
 
 ## Query string
 
-`livery_ext:query/2` pulls a single decoded parameter from the request
-URI:
+`livery_ext:query/2` pulls one decoded parameter straight out of the
+request URI:
 
 ```erlang
 search(Req) ->
@@ -18,9 +19,10 @@ search(Req) ->
 
 ## Form body (urlencoded)
 
-If the body is already buffered, `livery_ext:form/1` decodes it
-directly. Since adapters stream bodies by default, use `read_form/1,2`,
-which drains the stream (bounded) and decodes:
+If the body is already buffered, `livery_ext:form/1` decodes it on the
+spot. But adapters stream bodies by default, so most of the time you
+want `read_form/1,2`: it drains the stream for you (within bounds) and
+then decodes:
 
 ```erlang
 submit(Req) ->
@@ -35,14 +37,14 @@ submit(Req) ->
     end.
 ```
 
-The `Content-Type` check is case-insensitive and tolerates parameters
-(`Application/X-WWW-Form-Urlencoded; charset=utf-8`). Cap the body with
-`#{max_size => Bytes}` (default 1 MiB) and the per-read wait with
-`#{timeout => Ms}`.
+The `Content-Type` check is case-insensitive and forgiving about extra
+parameters, so `Application/X-WWW-Form-Urlencoded; charset=utf-8` is
+fine. Cap the body with `#{max_size => Bytes}` (1 MiB by default) and
+the per-read wait with `#{timeout => Ms}`.
 
-Decoding handles `%XX` escapes and `+` as space. A malformed escape
-(`%ZZ`) is kept verbatim rather than failing the whole body, matching
-`form/1`.
+Decoding handles `%XX` escapes and reads `+` as a space. A malformed
+escape like `%ZZ` is kept as-is rather than blowing up the whole body,
+just like `form/1` does.
 
 ## See also
 

--- a/docs/guides/parse-json-bodies.md
+++ b/docs/guides/parse-json-bodies.md
@@ -2,8 +2,9 @@
 
 ## Problem
 
-Your handler accepts a JSON-encoded request body and needs the
-decoded term.
+A client is sending you JSON, and your handler wants it as a proper
+Erlang term rather than a blob of bytes. This is the everyday case for
+any JSON API, and Livery makes the decode a one-liner.
 
 ## Solution
 
@@ -24,14 +25,15 @@ create_user(Req) ->
     end.
 ```
 
-`livery_ext:json/1` returns `{ok, Term}` or `{error, Reason}`. It
-uses the OTP `json` module (OTP 27+).
+`livery_ext:json/1` hands you back `{ok, Term}` or `{error, Reason}`.
+Under the hood it leans on the OTP `json` module (OTP 27+), so there
+is nothing extra to pull in.
 
 ## Body must be buffered
 
-JSON extraction requires the body to be in
-`#livery_req{body = {buffered, _}}` form. Streaming bodies must be
-drained first via `livery_body:read_all/2`:
+To decode JSON, the body has to be sitting in memory as
+`#livery_req{body = {buffered, _}}`. If you have a streaming body
+instead, drain it first with `livery_body:read_all/2`:
 
 ```erlang
 {stream, Reader} = livery_req:body(Req),
@@ -40,13 +42,14 @@ Req1 = livery_req:set_body({buffered, Bytes}, Req),
 {ok, Term} = livery_ext:json(Req1).
 ```
 
-The H1/H2/H3 adapters can be configured to buffer up to a
-per-route threshold automatically.
+If you would rather not do this by hand, the H1/H2/H3 adapters can
+buffer up to a per-route threshold for you automatically.
 
 ## Cap the size first
 
-JSON parsing on a large body wastes CPU and memory. Put
-`livery_body_limit` upstream:
+Parsing a huge JSON body burns CPU and memory for nothing, and it is
+an easy way for someone to hurt you. Put `livery_body_limit` upstream
+and let it reject oversized bodies before you ever parse them:
 
 ```erlang
 Stack = [

--- a/docs/guides/propagate-request-ids.md
+++ b/docs/guides/propagate-request-ids.md
@@ -2,9 +2,11 @@
 
 ## Problem
 
-Every request should carry a stable id that appears in logs and
-on the response, and that clients can pin to track work
-across services.
+A request comes in, fans out to three services, and something goes
+wrong somewhere. Without a shared id, good luck stitching the logs
+back together. What you want is one stable id per request that shows
+up in your logs, rides back out on the response, and follows the work
+across every service it touches.
 
 ## Solution
 
@@ -44,14 +46,14 @@ my_handler(Req) ->
 ```
 
 When the downstream service also runs Livery with
-`livery_request_id`, it will honor the value and keep the chain
-consistent.
+`livery_request_id`, it sees the header, reuses your value, and the
+chain stays consistent end to end.
 
 ## Place it first
 
-`livery_request_id` should be the outermost entry in the stack so
-every response — including ones produced by short-circuiting
-middleware below it — carries the id.
+Make `livery_request_id` the outermost entry in the stack. That way
+every response carries the id, even the ones produced by
+short-circuiting middleware sitting below it.
 
 ## See also
 

--- a/docs/guides/rate-limit-requests.md
+++ b/docs/guides/rate-limit-requests.md
@@ -2,13 +2,16 @@
 
 ## Problem
 
-You want to throttle how fast each client may call the API and answer
-`429 Too Many Requests` when a client exceeds its allowance.
+One eager client is hammering your API and starving everyone else, or
+you simply want fair quotas per caller. Either way, you want to cap how
+fast each client can call you and reply `429 Too Many Requests` once it
+goes over its share.
 
 ## Solution
 
 Add `livery_ratelimit` with the `limiter/2,3` factory. Each client gets
-a token bucket of `Capacity` tokens that refills at `RefillPerSec`:
+its own token bucket: it holds up to `Capacity` tokens and tops back up
+at `RefillPerSec`:
 
 ```erlang
 Stack = [
@@ -16,17 +19,17 @@ Stack = [
 ].
 ```
 
-A request consumes a token; an empty bucket sheds `429` (the handler is
-not called). "N requests per minute" maps to `limiter(N, N/60)` (burst
-N, sustained N/60).
+Every request spends one token. When the bucket runs dry the request is
+shed with a `429` and your handler never runs. Want "N requests per
+minute"? That is `limiter(N, N/60)`: a burst of N, sustained at N/60.
 
 ## Identifying clients
 
-The client IP is NOT available (the wire libraries do not surface the
-peer address), so the default key is the Authorization bearer token
-(`livery_ext:bearer_token/1`). A request with no token is NOT limited.
-Provide your own `key` fun to throttle by an API-key header or anything
-else:
+Heads up: the client IP is NOT available here, because the wire
+libraries do not surface the peer address. So the default key is the
+Authorization bearer token (`livery_ext:bearer_token/1`), and a request
+with no token is NOT limited at all. To key on something else, an
+API-key header or whatever you like, pass your own `key` fun:
 
 ```erlang
 livery_ratelimit:limiter(60, 1, #{
@@ -34,22 +37,25 @@ livery_ratelimit:limiter(60, 1, #{
 })
 ```
 
-A `key` fun that returns `undefined` skips limiting for that request.
-Keys are SHA-256 hashed before storage, so raw tokens are never kept in
+If your `key` fun returns `undefined`, that request is left alone. Keys
+are SHA-256 hashed before they hit storage, so raw tokens never sit in
 memory.
 
-The bearer-token default gives per-credential quotas, not flood
-protection: a client that rotates tokens gets a fresh bucket each time.
-For flood protection, key on an identity the client cannot freely rotate
-(an authenticated user id, or a forwarded-IP header you trust because you
-sit behind a known proxy). The store also caps its total key count
-(`ratelimit_max_keys`, default 1,000,000) and reaps idle buckets every
-minute, so a distinct-key flood bounds memory regardless of the key.
+One thing to keep in mind: the bearer-token default gives you
+per-credential quotas, not flood protection. A client that keeps
+rotating tokens just keeps getting fresh buckets. For real flood
+protection, key on something the client cannot freely change: an
+authenticated user id, or a forwarded-IP header you trust because you
+know the proxy in front of you. The store also caps how many keys it
+holds (`ratelimit_max_keys`, 1,000,000 by default) and sweeps idle
+buckets every minute, so even a flood of distinct keys keeps memory
+bounded.
 
 ## Headers and options
 
-Allowed responses carry `RateLimit-Limit`, `RateLimit-Remaining`, and
-`RateLimit-Reset`; a `429` adds `Retry-After`. Tune with:
+Allowed responses come back with `RateLimit-Limit`,
+`RateLimit-Remaining`, and `RateLimit-Reset`, and a `429` adds
+`Retry-After` so clients know when to come back. Tune the rest with:
 
 ```erlang
 livery_ratelimit:limiter(100, 10, #{
@@ -60,9 +66,10 @@ livery_ratelimit:limiter(100, 10, #{
 })
 ```
 
-Each `limiter/2,3` call allocates an isolated keyspace, so a global limit
-and tighter per-route limits do not interfere. Pass an explicit `name`
-to deliberately share one budget across several stacks.
+Each `limiter/2,3` call gets its own isolated keyspace, so a global
+limit and tighter per-route limits never step on each other. When you
+actually do want several stacks to share one budget, give them the same
+explicit `name`.
 
 ## Notes
 

--- a/docs/guides/read-headers.md
+++ b/docs/guides/read-headers.md
@@ -2,7 +2,9 @@
 
 ## Problem
 
-You need a header value from the request.
+You want to peek at a header on the incoming request, maybe the
+`Content-Type`, an `Accept`, or some custom flag, and act on it. It is
+about as everyday as it gets, so here is the short version.
 
 ## Solution
 
@@ -12,15 +14,16 @@ ContentType = livery_req:header(<<"content-type">>, Req),
 Accept = livery_req:header(<<"accept">>, Req, <<"*/*">>).
 ```
 
-Header names are matched case-insensitively. Both
-`<<"Content-Type">>` and `<<"content-type">>` work; Livery
-lowercases on ingest so lookups are constant-time after that.
+Header names are matched case-insensitively, so both
+`<<"Content-Type">>` and `<<"content-type">>` work the same. Livery
+lowercases everything on the way in, which keeps lookups
+constant-time afterwards.
 
 ## Repeated headers
 
-`livery_req:headers_all/2` returns every value for the header in
-wire order. Useful for `Set-Cookie`, `Vary`, comma-separated
-lists like `Accept-Encoding`:
+Some headers show up more than once. `livery_req:headers_all/2` gives
+you every value in wire order, which is just what you want for
+`Set-Cookie`, `Vary`, or comma-separated lists like `Accept-Encoding`:
 
 ```erlang
 Accepts = livery_req:headers_all(<<"accept">>, Req).
@@ -35,7 +38,8 @@ livery_req:has_header(<<"x-trace">>, Req)
 
 ## From a middleware
 
-Headers can also be inspected through extractors:
+From inside middleware you can read headers through extractors just as
+easily:
 
 ```erlang
 case livery_ext:header(<<"x-feature-flag">>, Req) of

--- a/docs/guides/read-query-strings.md
+++ b/docs/guides/read-query-strings.md
@@ -2,7 +2,9 @@
 
 ## Problem
 
-You need a query string value from the request URL.
+The interesting bits of a request often hang off the URL after the
+`?`: a search term, a page number, a filter. You want those values,
+already decoded, without parsing the query string by hand.
 
 ## Solution
 
@@ -13,12 +15,12 @@ search(Req) ->
     do_search(Q, Page).
 ```
 
-`livery_ext:query/2` returns the first value for the key, or
-`undefined` if it is missing.
+`livery_ext:query/2` gives you the first value for the key, or
+`undefined` when it is not there.
 
 ## Default values
 
-Wrap with a fallback:
+When a parameter is optional, wrap it with a fallback:
 
 ```erlang
 Page = case livery_ext:query(<<"page">>, Req) of
@@ -29,8 +31,8 @@ end.
 
 ## Integer values
 
-`livery_ext:query/2` always returns a binary. Convert at the call
-site:
+`livery_ext:query/2` always hands back a binary, so do the conversion
+yourself at the call site and pick a sensible default if it fails:
 
 ```erlang
 PageInt = try binary_to_integer(Page) catch _:_ -> 1 end.
@@ -38,7 +40,7 @@ PageInt = try binary_to_integer(Page) catch _:_ -> 1 end.
 
 ## URL-decoded
 
-Values are URL-decoded:
+You get values already URL-decoded, no extra step needed:
 
 ```erlang
 %% /search?q=hello%20world&unit=100%25
@@ -48,9 +50,10 @@ Values are URL-decoded:
 
 ## Multiple values for the same key
 
-Today `livery_ext:query/2` returns only the first. To read all
-values, call `livery_req:query/1` to get the raw query string and
-parse it yourself, or open an issue if you need this in `livery_ext`.
+For now `livery_ext:query/2` only gives you the first one. If you need
+them all, grab the raw query string with `livery_req:query/1` and parse
+it yourself, or open an issue if you would like this built into
+`livery_ext`.
 
 ## See also
 

--- a/docs/guides/read-streaming-body.md
+++ b/docs/guides/read-streaming-body.md
@@ -2,13 +2,16 @@
 
 ## Problem
 
-The request body is too large to buffer, or you want to process it
-incrementally as bytes arrive.
+Someone is uploading a file that would never fit comfortably in
+memory, or you simply want to start working on the bytes the moment
+they arrive instead of waiting for the whole thing. For that, you read
+the body as a stream rather than buffering it.
 
 ## Solution
 
-When `livery_req:body/1` returns `{stream, Reader}`, drain it via
-`livery_body:read/2` or `livery_body:read_all/2`:
+When `livery_req:body/1` hands you `{stream, Reader}`, drain it with
+`livery_body:read/2` chunk by chunk, or `livery_body:read_all/2` in one
+go:
 
 ```erlang
 upload(Req) ->
@@ -40,8 +43,9 @@ end.
 
 ## Discard the rest
 
-If the handler decides to short-circuit (auth failure, validation),
-drop the remaining body so the adapter does not stall:
+If your handler bails out early, say auth failed or validation
+tripped, throw away the rest of the body so the adapter does not sit
+there waiting:
 
 ```erlang
 {ok, _R1} = livery_body:discard(R0, 1_000),
@@ -50,15 +54,16 @@ livery_resp:text(401, <<"nope">>).
 
 ## Cap the size
 
-Combine with `livery_body_limit` (buffered only today) or call
-`livery_body:read/2` with a maximum byte count tracked yourself.
+You can pair this with `livery_body_limit` (buffered only for now), or
+keep a running byte count of your own as you call `livery_body:read/2`
+and stop once you have had enough.
 
 ## Backpressure
 
-`livery_body:signal_demand(R, N)` hints the adapter that the handler
-is ready for `N` more bytes. The H1/H2/H3 adapters translate this
-into engine-level window updates. This is a no-op for the test
-adapter; the H1 adapter wires it to `h1`'s read size.
+`livery_body:signal_demand(R, N)` tells the adapter you are ready for
+`N` more bytes. The H1/H2/H3 adapters turn that into engine-level
+window updates. It is a no-op for the test adapter, and on H1 it maps
+to `h1`'s read size.
 
 ## See also
 

--- a/docs/guides/return-trailers.md
+++ b/docs/guides/return-trailers.md
@@ -2,8 +2,10 @@
 
 ## Problem
 
-You need to emit response trailers (HTTP/1.1 chunked-trailers,
-HTTP/2/3 trailer frames) after the body.
+Sometimes you only know a value once the body is fully out the door:
+a checksum, a final status, a row count. Trailers let you send those
+headers after the body (HTTP/1.1 chunked-trailers, HTTP/2 and HTTP/3
+trailer frames), and that is what this guide covers.
 
 ## Solution
 
@@ -16,9 +18,9 @@ fetch(_Req) ->
 `livery_resp:with_trailers/2` accepts:
 
 - a list of `{Name, Value}` pairs, computed up front
-- a fun `fun() -> [{Name, Value}]` evaluated lazily after the body
-  has been emitted (useful when the trailer depends on bytes that
-  have not been produced yet)
+- a fun `fun() -> [{Name, Value}]` that runs lazily once the body is
+  out, which is exactly what you want when the trailer depends on
+  bytes you have not produced yet
 
 ```erlang
 livery_resp:with_trailers(
@@ -28,11 +30,11 @@ livery_resp:with_trailers(
 
 ## Capability gate
 
-Trailers are always supported on HTTP/2 and HTTP/3. On HTTP/1.1
-they require chunked transfer encoding; the H1 adapter
-auto-promotes when trailers are present. Check the adapter's
-capabilities map (`c:livery_adapter:capabilities/1`) if your code
-must adapt by protocol.
+HTTP/2 and HTTP/3 always support trailers. HTTP/1.1 needs chunked
+transfer encoding for them, but you do not have to wire that up: the
+H1 adapter promotes to chunked automatically as soon as trailers are
+present. If your code needs to branch on the protocol, check the
+adapter's capabilities map (`c:livery_adapter:capabilities/1`).
 
 ## See also
 

--- a/docs/guides/serve-a-file.md
+++ b/docs/guides/serve-a-file.md
@@ -2,8 +2,10 @@
 
 ## Problem
 
-You want to send a file from disk as the response body without
-reading it all into memory first.
+You have a file on disk and you want to send it back as the
+response. Maybe it is a stylesheet, a PDF, a download. You do not
+want to read the whole thing into memory first, especially when it
+is large. Livery can stream it straight off the disk for you.
 
 ## Solution
 
@@ -11,11 +13,12 @@ reading it all into memory first.
 livery_resp:file(200, <<"/var/www/index.html">>).
 ```
 
-Livery streams the file in 64 KiB chunks straight to the wire on
-H1, H2, and H3. `Content-Length` is set from the file size unless
-your handler already set it.
+That is all. Livery streams the file in 64 KiB chunks straight to
+the wire on H1, H2, and H3, and sets `Content-Length` from the file
+size unless your handler already set it.
 
-Set the content type yourself; Livery does not guess it:
+One thing it will not do for you is guess the content type, so set
+it yourself:
 
 ```erlang
 fun(_Req) ->
@@ -26,9 +29,10 @@ end.
 
 ## Serve a byte range
 
+Sometimes you only want part of the file, say to resume a download.
 Pass `{Offset, Length}` to send a slice. `Length` may be `eof` to
-read to the end of the file. Livery adds a `Content-Range` header
-and `Content-Length` for the slice:
+read to the end. Livery adds a `Content-Range` header and the right
+`Content-Length` for the slice:
 
 ```erlang
 %% bytes 1024-2047 of the file
@@ -38,16 +42,18 @@ livery_resp:file(206, Path, {1024, 1024}).
 livery_resp:file(206, Path, {1024, eof}).
 ```
 
-Set the status to `206` yourself when you serve a partial range.
+Remember to set the status to `206` yourself when you serve a
+partial range.
 
 ## Security: never pass unsanitised paths
 
-`livery_resp:file/2,3` serves exactly the path you give it; Livery
-does not confine it to a directory. If you build the path from
-request data (a path parameter, query string, header), an attacker
-can use `..` to escape your intended root and read arbitrary files.
+Here is the catch. `livery_resp:file/2,3` serves exactly the path
+you give it and nothing more; it does not confine it to a directory.
+So if you build the path from request data (a path parameter, a
+query string, a header), an attacker can slip in `..` to climb out
+of your intended root and read arbitrary files.
 
-Confine it yourself before serving:
+The fix is to confine the path yourself before serving:
 
 ```erlang
 serve_asset(Req) ->
@@ -62,7 +68,8 @@ serve_asset(Req) ->
     end.
 ```
 
-Prefer an allowlist of known filenames where you can.
+And when you can, prefer an allowlist of known filenames. It is the
+simplest thing that cannot go wrong.
 
 ## Error handling
 

--- a/docs/guides/serve-mcp-tools.md
+++ b/docs/guides/serve-mcp-tools.md
@@ -2,16 +2,19 @@
 
 ## Problem
 
-You want to expose tools, resources, and prompts to MCP clients
-(Claude, IDEs, agents) over the MCP Streamable HTTP transport,
-served by your Livery service alongside your other routes.
+You want your tools, resources, and prompts to be reachable by MCP
+clients - Claude, an IDE, an agent - and you would rather serve them
+from the same Livery service that already handles your other routes,
+not a separate process. The MCP Streamable HTTP transport is how
+those clients talk to you, and this guide wires it up.
 
 ## Solution
 
 `livery_mcp:handler/1` bridges Livery to the `barrel_mcp` protocol
-engine. Livery owns the wire (H1/H2/H3, router, middleware); the
-engine handles the MCP protocol (POST requests, GET SSE streams,
-DELETE session termination). Mount it at `/mcp`:
+engine. The split is clean: Livery owns the wire (H1/H2/H3, router,
+middleware), and the engine handles the MCP protocol itself (POST
+requests, GET SSE streams, DELETE session termination). Mount it at
+`/mcp`:
 
 ```erlang
 Mcp = livery_mcp:handler(#{session_enabled => true}),
@@ -29,8 +32,9 @@ livery:start_service(#{
 
 ## Register tools
 
-Tools live in the shared `barrel_mcp_registry`. Register them with
-`barrel_mcp`'s own API; `livery_mcp` does not wrap it:
+Tools live in the shared `barrel_mcp_registry`. You register them
+through `barrel_mcp`'s own API; `livery_mcp` deliberately does not
+wrap it:
 
 ```erlang
 ok = barrel_mcp:reg_tool(<<"echo">>, my_tools, echo, #{
@@ -45,8 +49,9 @@ ok = barrel_mcp:reg_tool(<<"echo">>, my_tools, echo, #{
 echo(#{<<"value">> := V}) -> <<"echo: ", V/binary>>.
 ```
 
-The `barrel_mcp` application is started automatically as a Livery
-dependency, so the registry is ready once your release boots.
+You do not need to start anything by hand: `barrel_mcp` comes up
+automatically as a Livery dependency, so the registry is ready the
+moment your release boots.
 
 ## Options
 
@@ -60,16 +65,17 @@ dependency, so the registry is ready once your release boots.
 | `allow_missing_origin` | `true` | Accept requests with no `Origin` |
 | `resource_metadata` | none | OAuth protected-resource-metadata |
 
-For public deployments, set `allowed_origins` to your client
-origins to guard against DNS-rebinding.
+If you are deploying this publicly, do set `allowed_origins` to your
+real client origins. It is your guard against DNS-rebinding, and the
+default `any` is too trusting for the open internet.
 
 ## Notes
 
 - The handler writes the response straight to the wire and returns
   the `taken_over` sentinel, so do not stack response-mutating
-  middleware after it.
-- The same handler serves all three protocols; mount it once on a
-  multi-protocol service and MCP rides H2/H3 automatically.
+  middleware after it. It has already left the building.
+- The same handler serves all three protocols. Mount it once on a
+  multi-protocol service and MCP rides H2/H3 for free.
 
 ## See also
 

--- a/docs/guides/serve-static-files.md
+++ b/docs/guides/serve-static-files.md
@@ -2,15 +2,17 @@
 
 ## Problem
 
-You want to serve a directory of files (assets, a built SPA, downloads)
-over HTTP, with correct `Content-Type`, conditional GET, and `Range`
-support - without exposing anything outside the directory.
+You have a whole directory to serve - your built SPA, a folder of
+assets, some downloads - and you want it done properly: the right
+`Content-Type`, conditional GET, `Range` support, and above all no
+way for a request to wander outside that directory. You could hand
+this off to nginx, but you do not have to.
 
 ## Solution
 
 Mount `livery_static:handler/1,2` on a router WILDCARD route. The `*path`
-segment captures the rest of the URL, which the handler maps to a file
-under the root:
+segment captures the rest of the URL, and the handler maps that onto a
+file under the root:
 
 ```erlang
 Router = livery_router:add(
@@ -18,14 +20,14 @@ Router = livery_router:add(
 ).
 ```
 
-`GET /assets/css/app.css` serves `priv/assets/css/app.css` with
-`Content-Type: text/css`, an `ETag`, and (if the client sends `Range`)
-partial content.
+Now `GET /assets/css/app.css` serves `priv/assets/css/app.css` with
+`Content-Type: text/css`, an `ETag`, and, if the client asks for a
+`Range`, partial content. All of that comes for free.
 
 ## Without the router
 
-If you are not using the router, configure a `prefix` to strip from the
-request path:
+Not using the router? Then tell the handler which `prefix` to strip
+from the request path:
 
 ```erlang
 {livery_static, never}  %% NB: it is a handler, not middleware
@@ -64,11 +66,12 @@ livery_static:handler("priv/assets", #{
 
 ## Security
 
-The sub-path is percent-decoded and then confined: any `..` segment,
-absolute path, control byte, or bad escape is rejected with `404`, so a
-request can never traverse out of the root. Only regular files are
-served - directories and symlinks yield `404` - so a symlink inside the
-root cannot be used to escape it.
+This is the part you do not have to worry about. The sub-path is
+percent-decoded and then confined: any `..` segment, absolute path,
+control byte, or bad escape is rejected with `404`, so a request can
+never climb out of the root. Only regular files are served -
+directories and symlinks both yield `404` - so a symlink planted
+inside the root cannot be used to escape it either.
 
 ## See also
 

--- a/docs/guides/serve-webtransport.md
+++ b/docs/guides/serve-webtransport.md
@@ -2,8 +2,11 @@
 
 ## Problem
 
-You want to accept WebTransport sessions (bidi/uni streams and
-datagrams) over HTTP/3 (or HTTP/2), served by your Livery handler.
+You need bidirectional streams and datagrams between browser and
+server, the kind of low-latency, multiplexed channel WebSockets
+never quite gave you. That is WebTransport, and it runs over HTTP/3
+(or HTTP/2). This guide shows how to accept those sessions straight
+from a Livery handler.
 
 ## Solution
 
@@ -12,10 +15,11 @@ extended-CONNECT request and hands the stream to the
 `webtransport` library, driven by a handler you implement
 (`webtransport_handler` behaviour).
 
-The listener must advertise the WebTransport settings. Merge
+First, the listener has to advertise the WebTransport settings, or
+the client never gets the chance to upgrade. Merge in
 `webtransport:h3_settings/0` (H3) or `webtransport:h2_settings/0`
-(H2) into the listener options; the adapter forwards the SETTINGS,
-datagram support, and stream routing to the wire library:
+(H2), and the adapter takes care of forwarding the SETTINGS, the
+datagram support, and the stream routing to the wire library:
 
 ```erlang
 Handler = fun(Req) -> livery_wt:upgrade(Req, my_wt_handler, #{}) end,
@@ -25,13 +29,15 @@ Opts = maps:merge(webtransport:h3_settings(), #{
 {ok, _} = livery_h3:start(Opts).
 ```
 
-WebTransport runs over H3 and H2 (RFC 9220 extended CONNECT). On
-H1, `upgrade/3` returns `501`.
+WebTransport lives on H3 and H2 (RFC 9220 extended CONNECT). There
+is no such thing over plain H1, so there `upgrade/3` simply returns
+`501`.
 
 ## Implement the session handler
 
-`my_wt_handler` implements the `webtransport_handler` behaviour
-(from `erlang-webtransport`). An echo handler:
+The actual session logic goes in `my_wt_handler`, which implements
+the `webtransport_handler` behaviour (from `erlang-webtransport`).
+Here is an echo handler to get you started:
 
 ```erlang
 -module(my_wt_handler).
@@ -51,9 +57,9 @@ handle_datagram(Data, State) ->
 
 ## Notes
 
-- On success `upgrade/3` returns the `taken_over` sentinel; the
-  session belongs to the `webtransport` process after that, so do
-  not stack response-mutating middleware after it.
+- On success `upgrade/3` returns the `taken_over` sentinel. From
+  that point the session belongs to the `webtransport` process, so
+  do not stack response-mutating middleware after it.
 - Requires `webtransport` >= 0.2.3 (so `accept/4` works from
   Livery's per-request worker process).
 - See `livery_wt_SUITE` for an end-to-end bidi-stream and datagram

--- a/docs/guides/server-sent-events.md
+++ b/docs/guides/server-sent-events.md
@@ -2,8 +2,11 @@
 
 ## Problem
 
-Your client uses the EventSource API (or any RFC 8895 compatible
-consumer) and expects `text/event-stream` framing.
+You want to push a stream of updates to the browser - a live
+counter, a progress feed, notifications - and the client is reading
+them with the EventSource API (or any RFC 8895 consumer). That means
+it expects `text/event-stream` framing, and you want Livery to do
+the framing so you can just emit events.
 
 ## Solution
 
@@ -17,8 +20,8 @@ events(_Req) ->
 ```
 
 `livery_resp:sse/2` sets `content-type: text/event-stream` and
-`cache-control: no-cache`. The producer fun runs in the per-request
-process and drives `Emit` with one event at a time.
+`cache-control: no-cache` for you. Your producer fun runs in the
+per-request process and drives `Emit`, one event at a time.
 
 ## Event shape
 
@@ -48,9 +51,9 @@ Emit(<<"plain">>).
 %%
 ```
 
-Multi-line data is fine: pass an iolist whose bytes contain `\n`
-and Livery emits each line with its own `data:` prefix when you use
-the helper. For multi-line, use `iolist` of lines:
+Multi-line data is fine. Pass an iolist whose bytes contain `\n` and
+Livery gives each line its own `data:` prefix. Just hand it an
+`iolist` of lines:
 
 ```erlang
 Emit(#{data => [<<"line 1">>, <<"\nline 2">>]}).
@@ -58,8 +61,9 @@ Emit(#{data => [<<"line 1">>, <<"\nline 2">>]}).
 
 ## Heartbeats
 
-To keep idle connections alive through proxies, emit a comment line
-periodically (a line beginning with `:`):
+Idle connections have a habit of being dropped by proxies. To keep
+yours alive, emit a comment line every so often (a line that begins
+with `:`):
 
 ```erlang
 loop(Emit) ->
@@ -73,9 +77,10 @@ loop(Emit) ->
 
 ## Disconnect detection
 
-`Emit` returns `{error, closed}` once the client disconnects (the
-H1/H2/H3 adapters surface this; the test adapter always returns
-`ok`).
+When the client goes away, `Emit` tells you: it returns
+`{error, closed}` once the connection is gone. The H1/H2/H3 adapters
+surface this; the test adapter always returns `ok`. Watch for it so
+you can stop producing and clean up.
 
 ```erlang
 loop(Emit) ->

--- a/docs/guides/session-cookies.md
+++ b/docs/guides/session-cookies.md
@@ -2,15 +2,18 @@
 
 ## Problem
 
-You want to keep a small amount of per-user state (a user id, a
-role) across requests without a server-side session store.
+You want to remember a little something about each user between
+requests - who they are, what role they have - but you would rather
+not stand up a session store, a database table, or a Redis to hold
+it. The trick is to keep that state in the cookie itself, signed so
+the client cannot forge it.
 
 ## Solution
 
-`livery_auth_session` signs a JSON payload with HMAC-SHA256 and
-stores it in a cookie. The payload travels with the client; the
-signature stops it being tampered with. Add the middleware with a
-shared `secret`:
+That is exactly what `livery_auth_session` does. It signs a JSON
+payload with HMAC-SHA256 and tucks it in a cookie. The payload rides
+along with the client, and the signature is what stops anyone
+tampering with it. Add the middleware with a shared `secret`:
 
 ```erlang
 Stack = [
@@ -19,8 +22,9 @@ Stack = [
 ].
 ```
 
-On each request the middleware reads the cookie, verifies it, and
-stores the payload under `meta(session, _)`. Read it in a handler:
+On every request the middleware reads the cookie, verifies the
+signature, and stashes the payload under `meta(session, _)`. Pull it
+back out in a handler:
 
 ```erlang
 fun(Req) ->
@@ -32,14 +36,16 @@ fun(Req) ->
 end.
 ```
 
-A missing cookie is allowed through by default. Set
-`required => true` to reject anonymous requests with `401`. A
-present but tampered or expired cookie is always rejected.
+By default a missing cookie is waved through, so guests are fine.
+Set `required => true` when you want to turn anonymous requests away
+with `401`. Either way, a cookie that is present but tampered with or
+expired is always rejected, no exceptions.
 
 ## Log in: set the cookie
 
-Sign a payload (optionally with `max_age` seconds for expiry) and
-attach the `Set-Cookie` header to your response:
+When someone logs in, sign a payload (add `max_age` in seconds if
+you want it to expire) and attach the `Set-Cookie` header to your
+response:
 
 ```erlang
 login(_Req) ->
@@ -65,10 +71,12 @@ logout(_Req) ->
 
 ## Notes
 
-- Use a long, random `secret` and keep it out of source control.
-- The payload is signed, not encrypted: do not store secrets in it.
-- Rotate the secret by accepting both old and new during a window
-  (verify against each), then drop the old one.
+- Use a long, random `secret`, and keep it out of source control.
+- The payload is signed, not encrypted. Anyone can read it, so never
+  put secrets in there.
+- To rotate the secret, accept both the old and the new one for a
+  while (verify against each), then drop the old one once the last
+  cookies signed with it have aged out.
 
 ## See also
 

--- a/docs/guides/set-security-headers.md
+++ b/docs/guides/set-security-headers.md
@@ -2,14 +2,16 @@
 
 ## Problem
 
-You want responses to carry baseline hardening headers
-(`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`,
-`Strict-Transport-Security`, optionally `Content-Security-Policy`).
+A security audit (or your own good sense) says every response should
+carry the usual hardening headers: `X-Content-Type-Options`,
+`X-Frame-Options`, `Referrer-Policy`, `Strict-Transport-Security`,
+and maybe a `Content-Security-Policy`. You do not want to set them by
+hand on each handler, you want them applied once, everywhere.
 
 ## Solution
 
-Add `livery_security_headers` to the stack. With no config it applies
-sensible defaults:
+Drop `livery_security_headers` into the stack. With no config at all
+it picks sensible defaults:
 
 ```erlang
 Stack = [
@@ -28,9 +30,9 @@ Defaults emitted:
 
 ## HSTS only on secure requests
 
-`Strict-Transport-Security` is meaningless over plain HTTP, so it is
-emitted only when the request is secure (`scheme` is `https` or TLS
-info is present). Tune or disable it:
+`Strict-Transport-Security` means nothing over plain HTTP, so Livery
+only emits it when the request is actually secure (`scheme` is
+`https`, or TLS info is present). You can tune it or turn it off:
 
 ```erlang
 {livery_security_headers, #{
@@ -42,7 +44,8 @@ info is present). Tune or disable it:
 
 ## Content-Security-Policy is opt-in
 
-A wrong CSP breaks pages, so there is no default. Set it explicitly:
+A wrong CSP will quietly break your pages, so there is no default on
+purpose. When you are ready, set it explicitly:
 
 ```erlang
 {livery_security_headers, #{csp => <<"default-src 'self'">>}}
@@ -50,8 +53,8 @@ A wrong CSP breaks pages, so there is no default. Set it explicitly:
 
 ## Overriding per header
 
-Any key set to a value replaces the default; set it to `false` to drop
-that header entirely:
+Set any key to a value and it replaces the default; set it to
+`false` to drop that header entirely:
 
 ```erlang
 {livery_security_headers, #{
@@ -60,8 +63,9 @@ that header entirely:
 }}
 ```
 
-A header the handler already set on the response is preserved, so a
-handler can override any of these per response.
+And if a handler already set one of these on its response, that
+value is left alone. So a handler always has the final say, per
+response, when it needs one.
 
 ## See also
 

--- a/docs/guides/stream-chunked.md
+++ b/docs/guides/stream-chunked.md
@@ -2,13 +2,15 @@
 
 ## Problem
 
-You need to emit response body bytes incrementally rather than
-buffering the whole payload in memory.
+The response is too big, or too slow to produce, to build up in
+memory first - a large file, a report you generate as you go, a feed
+of events. You want to send the bytes out in pieces, as they become
+ready, and let the client start reading right away.
 
 ## Solution
 
-`livery_resp:stream/3` takes a status, headers, and a producer fun
-that drives chunk emission:
+`livery_resp:stream/3` takes a status, some headers, and a producer
+fun. The fun gets an `Emit` and calls it once per chunk:
 
 ```erlang
 download(_Req) ->
@@ -33,13 +35,14 @@ emit_chunks(F, Emit) ->
     end.
 ```
 
-The producer runs in the per-request process. It returns when there
-is nothing more to emit.
+The producer runs in the per-request process, and you simply return
+from it when there is nothing left to emit.
 
 ## Stream from a message source
 
-The producer is free to `receive`. Subscribe to a publisher and
-forward events:
+Because the producer is an ordinary process, it is free to
+`receive`. That makes it easy to subscribe to a publisher and
+forward whatever comes in:
 
 ```erlang
 follow(_Req) ->
@@ -59,8 +62,9 @@ loop(Ref, Emit) ->
 
 ## Detect disconnect
 
-`Emit/1` returns the adapter's send result. On client disconnect
-the H1/H2/H3 adapters return `{error, closed}`. Break out:
+`Emit/1` hands back the adapter's send result. When the client hangs
+up, the H1/H2/H3 adapters return `{error, closed}`, which is your cue
+to stop and clean up:
 
 ```erlang
 case Emit(Chunk) of
@@ -69,12 +73,12 @@ case Emit(Chunk) of
 end.
 ```
 
-The test adapter always returns `ok`.
+(The test adapter always returns `ok`, so it never trips this path.)
 
 ## NDJSON
 
-`livery_resp:ndjson/2` does the JSON encoding and the `\n` framing
-for you:
+Streaming a sequence of JSON objects? `livery_resp:ndjson/2` handles
+both the encoding and the `\n` framing for you:
 
 ```erlang
 livery_resp:ndjson(200, fun(Emit) ->
@@ -83,10 +87,9 @@ livery_resp:ndjson(200, fun(Emit) ->
 end).
 ```
 
-Each `Emit(Term)` calls `json:encode(Term)` and appends a literal
-`\n` to one chunk. Content-Type defaults to
-`application/x-ndjson`. For pre-encoded bytes, drop down to
-`stream/3`.
+Each `Emit(Term)` calls `json:encode(Term)` and tacks a literal `\n`
+onto the chunk. Content-Type defaults to `application/x-ndjson`. If
+your bytes are already encoded, just drop down to `stream/3`.
 
 ## See also
 

--- a/docs/guides/test-handlers.md
+++ b/docs/guides/test-handlers.md
@@ -2,13 +2,16 @@
 
 ## Problem
 
-You want fast unit tests for a handler or a stack, without binding
-ports, without HTTP clients, without docker.
+You want to test a handler, or a whole middleware stack, and you
+want it to be fast. No binding ports, no HTTP client, no docker -
+just call the thing and check what came back, the way a unit test
+should feel.
 
 ## Solution
 
-`livery_test_adapter:run/3` runs a synthetic request through a
-stack and handler and captures the emitted response.
+`livery_test_adapter:run/3` pushes a synthetic request through your
+stack and handler, then hands you back everything that was emitted
+so you can assert on it.
 
 ```erlang
 ok_test() ->
@@ -23,8 +26,9 @@ ok_test() ->
 
 ## Build a request spec
 
-The spec map accepts any `#livery_req{}` field. Defaults: GET on `/`
-over `h1`.
+The spec map takes any `#livery_req{}` field, so you describe only
+what matters to your test and leave the rest. The defaults are a GET
+on `/` over `h1`.
 
 ```erlang
 #{
@@ -53,9 +57,10 @@ over `h1`.
 
 ## When run/3 is not enough
 
-Spawn through `livery_req_proc` if you need the per-request worker
-semantics: 500-on-crash, body-message routing via mailbox,
-multi-request concurrency.
+Sometimes you need the real per-request worker semantics: the
+500-on-crash behaviour, body messages routed through the mailbox,
+several requests running at once. For that, spawn through
+`livery_req_proc` instead.
 
 ```erlang
 {ok, Pid} = livery_req_proc:start_link(#{
@@ -74,8 +79,9 @@ four test levels and when to use each.
 
 ## Drive body messages
 
-Streaming handlers `receive` body chunks. Feed them through the
-test adapter helper:
+Streaming handlers sit in a `receive` waiting for body chunks, so
+your test has to play the other side and feed them in. The test
+adapter has a helper for exactly that:
 
 ```erlang
 Stream = livery_test_adapter:new_stream(Tab),

--- a/docs/guides/token-introspection.md
+++ b/docs/guides/token-introspection.md
@@ -2,17 +2,19 @@
 
 ## Problem
 
-Your bearer tokens are opaque reference tokens, not self-contained
-JWTs, so you cannot verify them locally. You need to ask the
-authorization server whether a token is still valid (RFC 7662).
+Your bearer tokens are opaque reference strings, not self-contained
+JWTs. There is nothing inside them to verify locally, so the only
+way to know whether a token is still good is to ask the
+authorization server that issued it. That conversation is token
+introspection (RFC 7662).
 
 ## Solution
 
-`livery_auth_introspect` POSTs the token to the introspection
-endpoint, authenticates this resource server with HTTP Basic, and
-trusts the `active` field of the JSON response. On success the
-response (with `scope`, `sub`, `exp`, ...) is stored under
-`meta(user, _)`:
+`livery_auth_introspect` does that round trip for you. It POSTs the
+token to the introspection endpoint, identifies your resource server
+with HTTP Basic, and looks at the `active` field of the JSON it gets
+back. When the token is active, the full response (`scope`, `sub`,
+`exp`, and friends) is stored under `meta(user, _)`:
 
 ```erlang
 Stack = [
@@ -34,9 +36,10 @@ fun(Req) ->
 end.
 ```
 
-A missing token is rejected with `401` unless `required => false`.
-An inactive token (or any transport/decoding failure) is always
-rejected with `401` and a `WWW-Authenticate: Bearer` header.
+A missing token gets a `401`, unless you pass `required => false`.
+An inactive token - or any failure to reach or decode the response -
+is always a `401`, together with a `WWW-Authenticate: Bearer`
+header. When in doubt, the request is turned away.
 
 ## JWT vs. introspection
 
@@ -45,14 +48,16 @@ rejected with `401` and a `WWW-Authenticate: Bearer` header.
 | Self-contained JWT | `livery_auth_bearer` (local verify, no round trip) |
 | Opaque / reference | `livery_auth_introspect` (round trip per request) |
 
-Introspection adds a network call per request. Cache results in
-your own layer if the round trip is too costly.
+Keep in mind that introspection costs a network call on every
+request. If that round trip starts to hurt, cache the results in a
+layer of your own.
 
 ## Custom HTTP client
 
-The call is pluggable. Pass `fetch => fun((Url, Headers, Body) ->
-{ok, Status, Body} | {error, _})` to use your own client or to
-test without a network:
+The HTTP call is pluggable, which is handy both in production and in
+tests. Pass `fetch => fun((Url, Headers, Body) -> {ok, Status, Body}
+| {error, _})` to swap in your own client, or to stub the whole
+thing out so your tests never touch the network:
 
 ```erlang
 #{endpoint => Endpoint,


### PR DESCRIPTION
A prose-only pass over the how-to guides so they read in the warm, conversational voice used in the tutorials and concept docs, with each `## Problem` opening on a concrete, plain-language situation instead of a dry restatement.

- 37 guides under `docs/guides/` (all except `bind-listen-address.md`, which is handled in PR #19).
- Structure, fenced code blocks, links, and inline code are unchanged. The doc suite passes, so every `erlang` snippet still compiles and every `livery_*` call still resolves at the right arity.
- No em-dash, no banned words.