### PR TITLE
Router composition: routes, merge, nest, layer

### DIFF
--- a/docs/concepts/routing.md
+++ b/docs/concepts/routing.md
@@ -106,6 +106,23 @@ service-level stack:
  #{middleware => [{my_api_key, #{keys => [<<"s3cret">>]}}]}}
 ```
 
+## Composing routers
+
+A router is a value, so you can build it in pieces and join them. This is
+how you keep a self-contained feature's routes together and stitch them
+in, the way Axum's `nest`/`merge` work:
+
+- `livery_router:merge/2` puts two routers side by side (the later one
+  wins on a clash).
+- `livery_router:nest/3` mounts a sub-router under a prefix, so
+  `livery_mcp:router()` (at `/mcp`) can land at `/ai/mcp`.
+- `livery_router:layer/2` wraps a whole router in a middleware stack, the
+  easy way to guard a mounted subtree.
+- `livery_router:routes/1` reconstructs the flat route list from any
+  router, composed or not (the inverse of `compile/1`).
+
+See [Mount a router on a service](../guides/mount-a-router.md).
+
 ## Performance
 
 The trie allocates nothing on a lookup besides the bindings map, and

--- a/docs/guides/mount-a-router.md
+++ b/docs/guides/mount-a-router.md
@@ -2,9 +2,10 @@
 
 ## Problem
 
-You have several routes and want the service to dispatch by
-method and path — with path-parameter binding and automatic
-404/405 — instead of writing one big handler.
+Your service has grown past a single endpoint, and you would rather
+declare routes than grow one giant handler with a `case` on the path.
+You want dispatch by method and path, path parameters bound for you, and
+404/405 handled automatically.
 
 ## Solution
 
@@ -25,8 +26,8 @@ Router = livery_router:compile([
 }).
 ```
 
-Each route handler is a normal handler — `fun(Req) -> Resp` or
-`{Module, Function}` — and receives the request with path
+Each route handler is a normal handler - `fun(Req) -> Resp` or
+`{Module, Function}` - and receives the request with path
 parameters already bound:
 
 ```erlang
@@ -61,8 +62,41 @@ Router = livery_router:compile([
 ```
 
 `/private` runs `Auth` before its handler; `/public` does not.
-Nesting is service stack (outermost) → route match → route stack →
+Nesting is service stack (outermost) -> route match -> route stack ->
 handler.
+
+## Composing routers
+
+Once a piece of your app is self-contained, it is nicer to keep its
+routes together and stitch them in, rather than copy them into one big
+list. Three functions let you do that, and they all return a router you
+can keep composing.
+
+`merge/2` puts two routers side by side. The later one wins if they
+register the same method and path:
+
+```erlang
+App = livery_router:compile([{<<"GET">>, <<"/">>, {my_app, index}}]),
+Router = livery_router:merge(App, livery_mcp:router()).
+```
+
+`nest/3` mounts a sub-router under a prefix. Here the MCP endpoint, which
+lives at `/mcp` on its own, ends up at `/ai/mcp`:
+
+```erlang
+Router = livery_router:nest(<<"/ai">>, livery_mcp:router(), App).
+```
+
+`layer/2` wraps a whole router in a middleware stack, which is the easy
+way to put one rule, say auth, over an entire mounted subtree:
+
+```erlang
+Admin = livery_router:compile([{<<"GET">>, <<"/admin/stats">>, {my_app, stats}}]),
+Guarded = livery_router:nest(<<"/v1">>, livery_router:layer([Auth], Admin), App).
+```
+
+Need the flat list back, perhaps to feed `livery_openapi:build/1`?
+`livery_router:routes/1` reconstructs it from any router, composed or not.
 
 ## Customising 404 / 405
 

--- a/src/livery_mcp.erl
+++ b/src/livery_mcp.erl
@@ -44,6 +44,7 @@ middleware after it.
 -include("livery.hrl").
 
 -export([handler/0, handler/1]).
+-export([router/0, router/1]).
 
 -export_type([opts/0]).
 
@@ -62,6 +63,25 @@ middleware after it.
 -spec handler() -> fun((livery_req:req()) -> livery_resp:resp()).
 handler() ->
     handler(#{}).
+
+-doc """
+A router for the MCP endpoint at `/mcp`, ready to mount with
+`livery_router:nest/3` or `merge/2`.
+""".
+-spec router() -> livery_router:router().
+router() ->
+    router(#{}).
+
+-doc "`router/0` with MCP handler options.".
+-spec router(opts()) -> livery_router:router().
+router(Opts) ->
+    Mcp = handler(Opts),
+    livery_router:compile([
+        {<<"POST">>, <<"/mcp">>, Mcp},
+        {<<"GET">>, <<"/mcp">>, Mcp},
+        {<<"DELETE">>, <<"/mcp">>, Mcp},
+        {<<"OPTIONS">>, <<"/mcp">>, Mcp}
+    ]).
 
 -doc "MCP handler built from `Opts` (see the module docs).".
 -spec handler(opts()) -> fun((livery_req:req()) -> livery_resp:resp()).

--- a/src/livery_openapi.erl
+++ b/src/livery_openapi.erl
@@ -98,6 +98,10 @@ build_paths(Routes) ->
 
 add_route({Method, Path, _Handler}, Acc) ->
     add_route({Method, Path, ignore, #{}}, Acc);
+%% `livery_router:routes/1' yields `undefined' Meta for routes with none
+%% (the `compile/1' default); treat it as an empty map.
+add_route({Method, Path, Handler, undefined}, Acc) ->
+    add_route({Method, Path, Handler, #{}}, Acc);
 add_route({Method, Path, _Handler, Meta}, Acc) ->
     {Template, PathParams} = template(Path),
     Operation = operation(Meta, PathParams),

--- a/src/livery_router.erl
+++ b/src/livery_router.erl
@@ -14,22 +14,35 @@ pattern is one of:
 method-aware hit, `{error, {method_not_allowed, Methods}}` when
 the path matches but no route is registered for the requested
 method, or `{error, not_found}` otherwise.
+
+Routers compose: `merge/2` stitches two together, `nest/3` mounts a
+sub-router under a path prefix, `layer/2` wraps one in a middleware
+stack, and `routes/1` reconstructs the flat route list from any router.
 """.
 
 -export([
     new/0,
     add/5,
     compile/1,
-    match/3
+    match/3,
+    routes/1,
+    merge/1,
+    merge/2,
+    nest/2,
+    nest/3,
+    layer/2
 ]).
 
--export_type([router/0, handler/0, pattern/0, method/0, meta/0]).
+-export_type([router/0, handler/0, pattern/0, method/0, meta/0, route/0]).
 
 -type method() :: binary() | '_'.
 -type pattern() :: binary().
 -type handler() :: term().
 -type meta() :: term().
 -type bindings() :: #{binary() => binary()}.
+-type route() ::
+    {method(), pattern(), handler()}
+    | {method(), pattern(), handler(), meta()}.
 
 -record(node, {
     static = #{} :: #{binary() => #node{}},
@@ -91,6 +104,59 @@ match(Method, Path, Router) ->
         nomatch ->
             {error, not_found}
     end.
+
+%%====================================================================
+%% Composition
+%%====================================================================
+
+-doc """
+Reconstruct the route list a router was built from.
+
+Returns one `{Method, Pattern, Handler, Meta}` per registered handler.
+The inverse of `compile/1`: `compile(routes(R))` matches the same paths
+as `R`. Handy for feeding a router (including a composed one) to
+`livery_openapi:build/1`, which takes a route list.
+""".
+-spec routes(router()) -> [{method(), pattern(), handler(), meta()}].
+routes(Router) ->
+    lists:reverse(collect(Router, [], [])).
+
+-doc "Combine routers into one. On a duplicate Method+Pattern, the later router wins.".
+-spec merge([router()]) -> router().
+merge(Routers) when is_list(Routers) ->
+    compile(lists:append([routes(R) || R <- Routers])).
+
+-doc "Merge two routers. `R2` wins on a duplicate Method+Pattern.".
+-spec merge(router(), router()) -> router().
+merge(R1, R2) ->
+    merge([R1, R2]).
+
+-doc """
+Mount a sub-router under a path prefix.
+
+Every route of `Sub` is re-registered with `Prefix` prepended to its
+pattern. A wildcard sub-route stays last under the prefix, so mounting a
+static router keeps `*path` valid.
+""".
+-spec nest(pattern(), router()) -> router().
+nest(Prefix, Sub) ->
+    compile([{M, join_prefix(Prefix, P), H, Meta} || {M, P, H, Meta} <- routes(Sub)]).
+
+-doc "Mount `Sub` under `Prefix` into `Parent` (`merge(Parent, nest(Prefix, Sub))`).".
+-spec nest(pattern(), router(), router()) -> router().
+nest(Prefix, Sub, Parent) ->
+    merge(Parent, nest(Prefix, Sub)).
+
+-doc """
+Wrap every route of a router with a middleware stack.
+
+`Stack` is prepended to each route's `Meta`'s `middleware` (so it runs
+outside the route's own middleware). Use it to put one stack, say auth,
+over a whole mounted subtree: `nest(Prefix, layer(Stack, Sub), Parent)`.
+""".
+-spec layer(livery_middleware:stack(), router()) -> router().
+layer(Stack, Router) ->
+    compile([{M, P, H, add_middleware(Stack, Meta)} || {M, P, H, Meta} <- routes(Router)]).
 
 %%====================================================================
 %% Insertion
@@ -221,3 +287,73 @@ join(Segs) -> iolist_to_binary(lists:join(<<"/">>, Segs)).
 classify(<<$:, Name/binary>>) when byte_size(Name) > 0 -> {param, Name};
 classify(<<$*, Name/binary>>) when byte_size(Name) > 0 -> {wildcard, Name};
 classify(Seg) -> {static, Seg}.
+
+%% Depth-first walk that rebuilds the route list. `RevSegs` holds the
+%% pattern segments from the root to this node, reversed; `*'/':' are
+%% restored so the patterns round-trip through `compile/1'.
+-spec collect(#node{}, [binary()], [route()]) -> [route()].
+collect(#node{static = Static, param = Param, wildcard = Wild, handlers = Hs}, RevSegs, Acc0) ->
+    Acc1 = emit_handlers(Hs, RevSegs, Acc0),
+    Acc2 = maps:fold(
+        fun(Seg, Child, A) -> collect(Child, [Seg | RevSegs], A) end,
+        Acc1,
+        Static
+    ),
+    Acc3 =
+        case Param of
+            undefined -> Acc2;
+            {Name, Child} -> collect(Child, [<<$:, Name/binary>> | RevSegs], Acc2)
+        end,
+    case Wild of
+        undefined -> Acc3;
+        {WName, WHs} -> emit_handlers(WHs, [<<$*, WName/binary>> | RevSegs], Acc3)
+    end.
+
+-spec emit_handlers(handlers(), [binary()], [route()]) -> [route()].
+emit_handlers(Hs, RevSegs, Acc) ->
+    Pattern = route_pattern(RevSegs),
+    maps:fold(
+        fun(Method, {Handler, Meta}, A) -> [{Method, Pattern, Handler, Meta} | A] end,
+        Acc,
+        Hs
+    ).
+
+-spec route_pattern([binary()]) -> pattern().
+route_pattern([]) -> <<"/">>;
+route_pattern(RevSegs) -> <<"/", (join(lists:reverse(RevSegs)))/binary>>.
+
+%% Prepend `Prefix' to `Pattern', collapsing surrounding slashes so the
+%% result has exactly one leading slash and single internal separators.
+-spec join_prefix(pattern(), pattern()) -> pattern().
+join_prefix(Prefix, Pattern) ->
+    P = trim_slashes(Prefix),
+    Q = trim_slashes(Pattern),
+    Joined =
+        case {P, Q} of
+            {<<>>, _} -> Q;
+            {_, <<>>} -> P;
+            _ -> <<P/binary, $/, Q/binary>>
+        end,
+    <<$/, Joined/binary>>.
+
+-spec trim_slashes(binary()) -> binary().
+trim_slashes(<<$/, Rest/binary>>) ->
+    trim_slashes(Rest);
+trim_slashes(B) ->
+    case B of
+        <<>> ->
+            <<>>;
+        _ ->
+            case binary:last(B) of
+                $/ -> trim_slashes(binary:part(B, 0, byte_size(B) - 1));
+                _ -> B
+            end
+    end.
+
+%% Prepend `Stack' to a route's existing `Meta.middleware', normalising a
+%% missing or non-map `Meta' to a map.
+-spec add_middleware(livery_middleware:stack(), meta()) -> map().
+add_middleware(Stack, Meta) when is_map(Meta) ->
+    Meta#{middleware => Stack ++ maps:get(middleware, Meta, [])};
+add_middleware(Stack, _Meta) ->
+    #{middleware => Stack}.

--- a/test/livery_router_tests.erl
+++ b/test/livery_router_tests.erl
@@ -119,3 +119,98 @@ conflicting_param_name_test() ->
             {<<"GET">>, <<"/u/:name">>, b}
         ])
     ).
+
+%%====================================================================
+%% Composition: routes/1, merge, nest, layer
+%%====================================================================
+
+routes_round_trip_test() ->
+    Spec = [
+        {<<"GET">>, <<"/">>, root},
+        {<<"GET">>, <<"/users/:id">>, show},
+        {<<"POST">>, <<"/users">>, create},
+        {<<"GET">>, <<"/files/*path">>, files}
+    ],
+    R = livery_router:compile(Spec),
+    %% routes/1 is the inverse of compile/1: the rebuilt router matches
+    %% the same paths, patterns and bindings restored.
+    R2 = livery_router:compile(livery_router:routes(R)),
+    ?assertEqual({ok, root, #{}, undefined}, livery_router:match(<<"GET">>, <<"/">>, R2)),
+    ?assertEqual(
+        {ok, show, #{<<"id">> => <<"7">>}, undefined},
+        livery_router:match(<<"GET">>, <<"/users/7">>, R2)
+    ),
+    ?assertEqual({ok, create, #{}, undefined}, livery_router:match(<<"POST">>, <<"/users">>, R2)),
+    ?assertEqual(
+        {ok, files, #{<<"path">> => <<"a/b.txt">>}, undefined},
+        livery_router:match(<<"GET">>, <<"/files/a/b.txt">>, R2)
+    ).
+
+merge_combines_routers_test() ->
+    A = livery_router:compile([{<<"GET">>, <<"/a">>, a}]),
+    B = livery_router:compile([{<<"GET">>, <<"/b">>, b}]),
+    R = livery_router:merge(A, B),
+    ?assertEqual({ok, a, #{}, undefined}, livery_router:match(<<"GET">>, <<"/a">>, R)),
+    ?assertEqual({ok, b, #{}, undefined}, livery_router:match(<<"GET">>, <<"/b">>, R)).
+
+merge_later_router_wins_test() ->
+    A = livery_router:compile([{<<"GET">>, <<"/x">>, first}]),
+    B = livery_router:compile([{<<"GET">>, <<"/x">>, second}]),
+    R = livery_router:merge(A, B),
+    ?assertEqual({ok, second, #{}, undefined}, livery_router:match(<<"GET">>, <<"/x">>, R)).
+
+merge_propagates_conflicts_test() ->
+    A = livery_router:compile([{<<"GET">>, <<"/u/:id">>, a}]),
+    B = livery_router:compile([{<<"GET">>, <<"/u/:name">>, b}]),
+    ?assertError({conflicting_param, _, _}, livery_router:merge(A, B)).
+
+nest_prefixes_subroutes_test() ->
+    Sub = livery_router:compile([
+        {<<"GET">>, <<"/mcp">>, mcp},
+        {<<"GET">>, <<"/files/*path">>, files}
+    ]),
+    R = livery_router:nest(<<"/ai">>, Sub),
+    ?assertEqual({ok, mcp, #{}, undefined}, livery_router:match(<<"GET">>, <<"/ai/mcp">>, R)),
+    %% A wildcard sub-route stays last under the prefix.
+    ?assertEqual(
+        {ok, files, #{<<"path">> => <<"x/y">>}, undefined},
+        livery_router:match(<<"GET">>, <<"/ai/files/x/y">>, R)
+    ),
+    ?assertEqual({error, not_found}, livery_router:match(<<"GET">>, <<"/mcp">>, R)).
+
+nest_root_subroute_maps_to_prefix_test() ->
+    Sub = livery_router:compile([{<<"GET">>, <<"/">>, home}]),
+    R = livery_router:nest(<<"/app">>, Sub),
+    ?assertEqual({ok, home, #{}, undefined}, livery_router:match(<<"GET">>, <<"/app">>, R)).
+
+nest_into_parent_test() ->
+    App = livery_router:compile([{<<"GET">>, <<"/">>, index}]),
+    Sub = livery_router:compile([{<<"GET">>, <<"/mcp">>, mcp}]),
+    R = livery_router:nest(<<"/ai">>, Sub, App),
+    ?assertEqual({ok, index, #{}, undefined}, livery_router:match(<<"GET">>, <<"/">>, R)),
+    ?assertEqual({ok, mcp, #{}, undefined}, livery_router:match(<<"GET">>, <<"/ai/mcp">>, R)).
+
+mcp_router_merges_and_nests_test() ->
+    App = livery_router:compile([{<<"GET">>, <<"/">>, index}]),
+    %% Merge: MCP keeps its own /mcp path.
+    Merged = livery_router:merge(App, livery_mcp:router()),
+    {ok, Mcp, #{}, _} = livery_router:match(<<"POST">>, <<"/mcp">>, Merged),
+    ?assert(is_function(Mcp, 1)),
+    ?assertEqual({ok, index, #{}, undefined}, livery_router:match(<<"GET">>, <<"/">>, Merged)),
+    %% Nest: MCP mounted under a prefix.
+    Nested = livery_router:nest(<<"/ai">>, livery_mcp:router(), App),
+    {ok, Mcp2, #{}, _} = livery_router:match(<<"GET">>, <<"/ai/mcp">>, Nested),
+    ?assert(is_function(Mcp2, 1)).
+
+layer_prepends_subtree_middleware_test() ->
+    Mw = {auth, #{}},
+    Sub = livery_router:compile([
+        {<<"GET">>, <<"/x">>, x, #{middleware => [{log, undefined}]}},
+        {<<"GET">>, <<"/y">>, y}
+    ]),
+    R = livery_router:layer([Mw], Sub),
+    {ok, x, _, MetaX} = livery_router:match(<<"GET">>, <<"/x">>, R),
+    {ok, y, _, MetaY} = livery_router:match(<<"GET">>, <<"/y">>, R),
+    %% Stack is prepended, ahead of the route's own middleware.
+    ?assertEqual([Mw, {log, undefined}], maps:get(middleware, MetaX)),
+    ?assertEqual([Mw], maps:get(middleware, MetaY)).


### PR DESCRIPTION
Phase 1 of Axum-parity work: let routers compose. A router is a value you can build in pieces and join, instead of one flat list.

## What is new
- `livery_router:routes/1` - reconstruct the route list from a router (inverse of `compile/1`).
- `livery_router:merge/1,2` - combine routers; the later one wins on a duplicate method+path.
- `livery_router:nest/2,3` - mount a sub-router under a path prefix (a wildcard sub-route stays last).
- `livery_router:layer/2` - wrap a whole router in a middleware stack (e.g. auth over a mounted subtree).
- `livery_mcp:router/0,1` - the MCP endpoint as a router, so `merge(App, livery_mcp:router())` (serves `/mcp`) or `nest(<<"/ai">>, livery_mcp:router(), App)` (serves `/ai/mcp`) work directly.
- `livery_openapi:build/1` treats `undefined` Meta as empty, so `routes/1` output (composed routers included) feeds OpenAPI generation.

All composition is reconstruct-and-recompile, so `compile/1`'s last-wins and param/wildcard conflict semantics carry over. `router()` stays opaque; no consumer changes.

## Docs
The mount-a-router guide gains a "Composing routers" section with the MCP example; the routing concept gets a composition note.

## Verification
fmt, compile, lint, xref, dialyzer, eunit (410, incl. new composition tests), the doc suite, and MCP CT all pass. Confirmed a nested router's routes flow into `livery_openapi:build/1` (paths `/` and `/ai/mcp`).