### PR TITLE
Add a composable HTTP client

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ Step-by-step, learning-oriented.
 - [Compose a middleware stack](tutorials/middleware-stack.md)
 - [Stream a response](tutorials/streaming-responses.md)
 - [Test your handlers](tutorials/testing-handlers.md)
+- [Call another service](tutorials/call-a-service.md)
 - [Build a complete service](tutorials/build-a-complete-service.md)
 
 ## How-to guides
@@ -65,6 +66,9 @@ solution.
 - [Generate OpenAPI docs and validate requests](guides/openapi-and-validation.md)
 - [Serve MCP tools](guides/serve-mcp-tools.md)
 - [Serve WebTransport](guides/serve-webtransport.md)
+
+**Calling out**
+- [Make outbound HTTP requests](guides/make-http-requests.md)
 
 **Operations**
 - [Shut down gracefully](guides/graceful-shutdown.md)

--- a/docs/concepts/adapters.md
+++ b/docs/concepts/adapters.md
@@ -118,6 +118,14 @@ Every adapter takes the same `ip => inet:ip_address()` and
 `livery_inet:socket_addr_opts/1`. See
 [Bind to an address or IPv6](../guides/bind-listen-address.md).
 
+## The client adapter, its dual
+
+The same idea runs outbound. `livery_client_adapter` is the dual of this
+behaviour: it owns the wire for an outgoing request, while the client's
+layers (timeout, retry, circuit breaker) own the policy above it. The
+default `livery_client_hackney` covers HTTP/1.1, HTTP/2, and HTTP/3. See
+[Make outbound HTTP requests](../guides/make-http-requests.md).
+
 ## See also
 
 - Concept: [Architecture](architecture.md)

--- a/docs/concepts/middleware-pipeline.md
+++ b/docs/concepts/middleware-pipeline.md
@@ -177,8 +177,19 @@ The pipeline is built per request as a chain of closures: each `Next` is
 per-request overhead is a few calls plus the real work. Keep stacks under
 about ten entries.
 
+## Outbound: the same model, the other direction
+
+The same composable model runs in the other direction. `livery_client`
+is the outbound twin of this pipeline: you stack layers (timeout, retry,
+circuit breaker, concurrency) around an HTTP request the same way you
+stack middleware around a handler, and each layer is the same
+`call(Request, Next, State)` shape, returning `{ok, Response} |
+{error, _}`. See
+[Make outbound HTTP requests](../guides/make-http-requests.md).
+
 ## See also
 
 - Tutorial: [Compose a middleware stack](../tutorials/middleware-stack.md)
 - Guide: [Write a custom middleware](../guides/custom-middleware.md)
+- Guide: [Make outbound HTTP requests](../guides/make-http-requests.md)
 - Reference: `livery_middleware`, `livery_request_id`, `livery_body_limit`, `livery_timeout`, `livery_access_log`

--- a/docs/guides/make-http-requests.md
+++ b/docs/guides/make-http-requests.md
@@ -1,0 +1,207 @@
+# How to make outbound HTTP requests
+
+## Problem
+
+Your service has to call other services: a payment API, an internal
+microservice, a webhook endpoint. You want the same guarantees you put
+in front of your own handlers, a timeout, a few retries, a circuit
+breaker, a concurrency cap, without hand-rolling them around every call
+site. Livery's client is the outbound twin of its middleware: you stack
+layers around a request the same way you stack them around a handler.
+
+## Solution
+
+Build a client once, keep it around, and call it. The layers run
+outermost-first, and every call returns `{ok, Response}` or
+`{error, Reason}`, so failures are values you match on, not exceptions
+you chase.
+
+```erlang
+Client = livery_client:new(#{
+    base_url => <<"https://api.example.com">>,
+    headers  => [{<<"authorization">>, <<"Bearer token">>}],
+    stack    => [
+        livery_client:timeout(5000),
+        livery_client:retry(#{max => 3}),
+        livery_client:circuit_breaker(#{name => payments}),
+        livery_client:concurrency(50)
+    ]
+}),
+
+case livery_client:get(Client, <<"/users/42">>) of
+    {ok, Resp} ->
+        200 = livery_client:status(Resp),
+        {full, Body} = livery_client:body(Resp),
+        handle(Body);
+    {error, timeout}      -> slow;
+    {error, circuit_open} -> degrade;
+    {error, Reason}       -> {failed, Reason}
+end.
+```
+
+`post/3`, `put/3`, `delete/2`, and `request/3,4` round it out. With a
+`base_url` set you pass paths; without one you pass full URLs.
+
+## A real client, end to end
+
+In practice you wrap the client in a small module: build it once, give
+each call a name, and turn the HTTP response into a domain result. Here
+is a typed wrapper around a JSON API, the shape you will actually write.
+
+```erlang
+-module(billing_api).
+-export([client/1, get_invoice/2, create_invoice/2]).
+
+%% Build once at startup (or in your supervision tree) and reuse.
+client(Token) ->
+    Auth = iolist_to_binary([<<"Bearer ">>, Token]),
+    livery_client:new(#{
+        base_url => <<"https://billing.internal">>,
+        headers  => [
+            {<<"authorization">>, Auth},
+            {<<"accept">>, <<"application/json">>}
+        ],
+        stack    => [
+            livery_client:timeout(5000),
+            livery_client:retry(#{max => 3, backoff => {200, 2.0}}),
+            livery_client:circuit_breaker(#{name => billing, window => 20, trip => 0.5})
+        ]
+    }).
+
+get_invoice(Client, Id) ->
+    Path = <<"/invoices/", Id/binary>>,
+    case livery_client:get(Client, Path) of
+        {ok, Resp} -> decode(Resp);
+        {error, _} = E -> E
+    end.
+
+create_invoice(Client, Invoice) ->
+    Body = json:encode(Invoice),
+    case livery_client:post(Client, <<"/invoices">>, Body) of
+        {ok, Resp} -> decode(Resp);
+        {error, _} = E -> E
+    end.
+
+%% One place to turn an HTTP response into a domain result.
+decode(Resp) ->
+    {full, Body} = livery_client:body(Resp),
+    case livery_client:status(Resp) of
+        S when S >= 200, S < 300 -> {ok, json:decode(Body)};
+        404 -> {error, not_found};
+        S -> {error, {http, S, Body}}
+    end.
+```
+
+Two things worth copying: build the multi-segment URL into a variable
+before the call (`Path = <<"/invoices/", Id/binary>>`), and keep one
+`decode/1` that every verb funnels through, so status handling lives in
+one place.
+
+## The layers
+
+Each constructor returns a stack entry; order matters (outermost first,
+so `timeout` wraps `retry` wraps the rest).
+
+- `timeout(Ms)` returns `{error, timeout}` if the call overruns, and
+  tears down the in-flight connection.
+- `retry(Opts)` retries transport errors and `502/503/504` with
+  exponential backoff. Idempotent methods only unless
+  `retry_non_idempotent => true`. `Opts`: `max`, `backoff`
+  (`{BaseMs, Factor}`), `statuses`.
+- `circuit_breaker(Opts)` trips once the failure ratio over a window
+  crosses a threshold, then fails fast with `{error, circuit_open}`
+  until it half-opens to probe. `Opts`: `name` (required), `window`,
+  `trip`, `cooldown`.
+- `concurrency(N)` caps in-flight requests, returning `{error,
+  overloaded}` past `N`.
+
+### Ordering, and why
+
+The order is the same reasoning as the server stack. A useful default:
+
+```erlang
+[
+    livery_client:timeout(5000),       %% a hard ceiling over everything
+    livery_client:retry(#{max => 3}),  %% retries live under the ceiling
+    livery_client:circuit_breaker(#{name => api}),
+    livery_client:concurrency(50)      %% closest to the wire
+].
+```
+
+`timeout` outermost means the deadline covers all retries, not each
+attempt. `circuit_breaker` below `retry` means a tripped breaker stops
+the retries too. `concurrency` innermost caps real connections.
+
+### Writing your own layer
+
+Layers are the same shape as server middleware, so a one-off is just a
+fun. This one stamps a request id on every outbound call:
+
+```erlang
+StampId = fun(Req, Next) ->
+    Id = integer_to_binary(erlang:unique_integer([positive])),
+    Next(livery_client:set_header(<<"x-request-id">>, Id, Req))
+end,
+Client = livery_client:new(#{base_url => Base, stack => [StampId]}).
+```
+
+For the common cases reach for the sugar: `livery_client:before/1`
+(transform the request), `after_response/1` (transform the response),
+`wrap/1` (catch a downstream crash).
+
+## Streaming
+
+For a large download, ask for a streamed response and read it chunk by
+chunk instead of holding it all in memory:
+
+```erlang
+{ok, Resp} = livery_client:request(Client, get, <<"/big.csv">>, #{stream => true}),
+{stream, Reader} = livery_client:body(Resp),
+{ok, All} = livery_client:read_body(Reader).
+```
+
+`read_body/1` drains the whole body; to process as it arrives, loop with
+`read/2`:
+
+```erlang
+drain(Reader, Acc) ->
+    case livery_client:read(Reader, 5000) of
+        {ok, Chunk, Reader1} -> drain(Reader1, [Acc, Chunk]);
+        {done, _}            -> {ok, iolist_to_binary(Acc)};
+        {error, _} = E       -> E
+    end.
+```
+
+To stream a request body, hand a producer that yields chunks:
+
+```erlang
+Body = {stream, fun() -> next_chunk() end},   %% {ok, Chunk, NextFun} | eof
+{ok, _} = livery_client:request(Client, post, <<"/upload">>, #{body => Body}).
+```
+
+A streamed (one-shot) request body is never retried, since its chunks
+are already gone once sent; put `retry` on buffered calls.
+
+## Protocols and the transport
+
+The default transport is `livery_client_hackney`, and hackney 4.2 speaks
+HTTP/1.1, HTTP/2, and HTTP/3, so one client reaches all three (TLS, ALPN,
+pooling, IPv6). Steer protocol and TLS details with `adapter_opts`:
+
+```erlang
+livery_client:new(#{
+    base_url     => <<"https://h3.example.com">>,
+    adapter_opts => #{hackney => [{ssl_options, [{verify, verify_peer}]}]}
+}).
+```
+
+The transport is a `livery_client_adapter`, the client-side dual of
+`livery_adapter`. To front a different client, implement that behaviour
+and pass `adapter => your_module`.
+
+## See also
+
+- Tutorial: [Call another service](../tutorials/call-a-service.md)
+- Concept: [The middleware pipeline](../concepts/middleware-pipeline.md)
+- Concept: [Adapters](../concepts/adapters.md)
+- Reference: `livery_client`, `livery_client_adapter`

--- a/docs/tutorials/call-a-service.md
+++ b/docs/tutorials/call-a-service.md
@@ -1,0 +1,218 @@
+# Tutorial: Call another service
+
+Almost no service lives alone. Sooner or later yours has to call someone
+else: an API for payments, an internal service for users, a webhook out
+to a partner. In this tutorial we build a client for one of those, step
+by step, and add the resilience you would want in production: a timeout,
+retries, a circuit breaker. About 15 minutes.
+
+The client is the outbound twin of Livery's middleware. If you have
+written a middleware stack, this will feel familiar: you stack layers
+around a request the way you stack them around a handler. Same idea, the
+other direction.
+
+## 1. The smallest possible call
+
+Let us start with the least you can write. Build a client, send a GET,
+read the answer.
+
+```erlang
+Client = livery_client:new(#{base_url => <<"https://api.example.com">>}),
+{ok, Resp} = livery_client:get(Client, <<"/health">>),
+200 = livery_client:status(Resp),
+{full, Body} = livery_client:body(Resp).
+```
+
+Three things are happening. `new/1` builds a client value, here with
+nothing but a base URL, so we can pass paths instead of full URLs. `get/2`
+sends the request and gives back `{ok, Resp}` or `{error, Reason}`. And
+the body comes back tagged: `{full, Body}` is the whole thing in memory,
+which is what you want for a small JSON reply.
+
+The client is just a value. Build it once, share it, call it from as
+many processes as you like.
+
+## 2. Headers and a base URL, set once
+
+Repeating an `authorization` header on every call gets old fast. Put the
+defaults on the client and forget about them:
+
+```erlang
+Token = <<"s3cret">>,
+Auth = iolist_to_binary([<<"Bearer ">>, Token]),
+Client = livery_client:new(#{
+    base_url => <<"https://api.example.com">>,
+    headers  => [
+        {<<"authorization">>, Auth},
+        {<<"accept">>, <<"application/json">>}
+    ]
+}),
+{ok, _} = livery_client:get(Client, <<"/users/42">>).
+```
+
+Every request the client sends now carries those two headers. A
+per-request header of the same name still wins, so you can override one
+without rebuilding the client.
+
+## 3. Turn the response into something useful
+
+A status and a blob of bytes is not what your code wants to work with.
+It wants a decoded value, or a clear error. Funnel every call through one
+decoder:
+
+```erlang
+fetch_user(Client, Id) ->
+    Path = <<"/users/", Id/binary>>,
+    case livery_client:get(Client, Path) of
+        {ok, Resp} -> decode(Resp);
+        {error, _} = E -> E
+    end.
+
+decode(Resp) ->
+    {full, Body} = livery_client:body(Resp),
+    case livery_client:status(Resp) of
+        S when S >= 200, S < 300 -> {ok, json:decode(Body)};
+        404 -> {error, not_found};
+        S -> {error, {http, S}}
+    end.
+```
+
+Notice we build the path into `Path` before the call rather than inline.
+That is a small habit worth keeping: it reads better, and a single
+`<<"/users/", Id/binary>>` expression in one place is easy to change.
+
+Now `fetch_user/2` returns `{ok, Map}`, `{error, not_found}`, or
+`{error, {http, Status}}`, and the caller never sees raw HTTP.
+
+## 4. Add a timeout
+
+The network will, eventually, hang. A call that never returns is worse
+than one that fails, so put a ceiling on it. This is your first layer:
+
+```erlang
+Client = livery_client:new(#{
+    base_url => <<"https://api.example.com">>,
+    stack    => [livery_client:timeout(5000)]
+}),
+case livery_client:get(Client, <<"/slow">>) of
+    {ok, Resp}       -> livery_client:status(Resp);
+    {error, timeout} -> too_slow
+end.
+```
+
+`timeout(5000)` gives the whole call five seconds; overrun and it returns
+`{error, timeout}` and tears down the connection underneath. A layer is
+just an entry in the `stack` list, exactly like a middleware entry.
+
+## 5. Retry the failures worth retrying
+
+Transient failures happen: a `503` while the other side restarts, a
+connection reset. For idempotent calls, retrying a few times with backoff
+papers over most of them.
+
+```erlang
+Client = livery_client:new(#{
+    base_url => <<"https://api.example.com">>,
+    stack    => [
+        livery_client:timeout(5000),
+        livery_client:retry(#{max => 3, backoff => {200, 2.0}})
+    ]
+}),
+{ok, _} = livery_client:get(Client, <<"/users/42">>).
+```
+
+`retry` retries transport errors and `502/503/504`, up to `max` times,
+waiting `200ms` then `400ms` then `800ms` (base `200`, factor `2.0`,
+with a little jitter). It only retries idempotent methods unless you opt
+in with `retry_non_idempotent => true`, so a `POST` is left alone by
+default.
+
+Order matters here. `timeout` sits outside `retry`, so the five seconds
+is the budget for all attempts together, not for each one. That is
+usually what you want: a hard ceiling on the whole operation.
+
+## 6. Stop hammering a service that is down
+
+Retries are kind to a service having a hiccup. They are cruel to one that
+is genuinely down: every caller piles on more load at the worst moment. A
+circuit breaker watches the failure rate and, once it crosses a line,
+trips, after which calls fail instantly without touching the network
+until the service has had time to recover.
+
+```erlang
+Client = livery_client:new(#{
+    base_url => <<"https://api.example.com">>,
+    stack    => [
+        livery_client:timeout(5000),
+        livery_client:retry(#{max => 3}),
+        livery_client:circuit_breaker(#{name => api, window => 20, trip => 0.5})
+    ]
+}),
+case livery_client:get(Client, <<"/users/42">>) of
+    {ok, Resp}            -> livery_client:status(Resp);
+    {error, circuit_open} -> serve_from_cache();
+    {error, _}            -> give_up()
+end.
+```
+
+Once half of the last 20 calls have failed (`window => 20`,
+`trip => 0.5`), the breaker opens and the next call returns
+`{error, circuit_open}` straight away. After a cooldown it half-opens to
+let one probe through; if that succeeds, it closes again. The `name` is
+how breakers are kept apart, so give each upstream its own.
+
+The breaker sits below `retry` on purpose: when it is open, the retries
+do not even start.
+
+## 7. Put it together
+
+Here is the whole thing as the module you would actually keep, a small
+typed client over one API:
+
+```erlang
+-module(users_api).
+-export([client/1, fetch/2]).
+
+client(Token) ->
+    Auth = iolist_to_binary([<<"Bearer ">>, Token]),
+    livery_client:new(#{
+        base_url => <<"https://api.example.com">>,
+        headers  => [{<<"authorization">>, Auth}],
+        stack    => [
+            livery_client:timeout(5000),
+            livery_client:retry(#{max => 3, backoff => {200, 2.0}}),
+            livery_client:circuit_breaker(#{name => users, window => 20, trip => 0.5})
+        ]
+    }).
+
+fetch(Client, Id) ->
+    Path = <<"/users/", Id/binary>>,
+    case livery_client:get(Client, Path) of
+        {ok, Resp} ->
+            {full, Body} = livery_client:body(Resp),
+            case livery_client:status(Resp) of
+                200 -> {ok, json:decode(Body)};
+                404 -> {error, not_found};
+                S -> {error, {http, S}}
+            end;
+        {error, _} = E ->
+            E
+    end.
+```
+
+Call `users_api:client/1` once, hold the value, and call `fetch/2`
+wherever you need a user. Timeout, retry, and breaker come along for free
+on every call, and the caller only ever sees `{ok, User}` or a clean
+error.
+
+## Where to go next
+
+- Need to download something large without buffering it? See
+  [Make outbound HTTP requests](../guides/make-http-requests.md) for
+  streaming responses and request bodies.
+- Want to understand why the layers compose the way they do? Read
+  [The middleware pipeline](../concepts/middleware-pipeline.md): the
+  client is the same model, outbound.
+- Fronting a different HTTP client or a mock in tests? The transport is
+  a `livery_client_adapter`, the dual of the server
+  [adapters](../concepts/adapters.md).

--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
     {ws, "0.3.0", {pkg, erlang_ws}},
     {instrument, "1.1.3"},
     {webtransport, "0.3.1"},
-    {hackney, "4.1.0"},
+    {hackney, "4.2.0"},
     {barrel_mcp, "2.1.0"}
 ]}.
 
@@ -94,6 +94,7 @@
         {"docs/tutorials/middleware-stack.md", #{title => <<"Compose a middleware stack">>}},
         {"docs/tutorials/streaming-responses.md", #{title => <<"Stream a response">>}},
         {"docs/tutorials/testing-handlers.md", #{title => <<"Test your handlers">>}},
+        {"docs/tutorials/call-a-service.md", #{title => <<"Call another service">>}},
         {"docs/tutorials/build-a-complete-service.md", #{
             title => <<"Build a complete service">>
         }},
@@ -126,6 +127,7 @@
         {"docs/guides/limit-concurrency.md", #{title => <<"Limit concurrency">>}},
         {"docs/guides/rate-limit-requests.md", #{title => <<"Rate-limit requests">>}},
         {"docs/guides/log-requests.md", #{title => <<"Log every request">>}},
+        {"docs/guides/make-http-requests.md", #{title => <<"Make outbound HTTP requests">>}},
         {"docs/guides/propagate-request-ids.md", #{title => <<"Propagate request IDs">>}},
         {"docs/guides/handler-errors.md", #{title => <<"Catch handler errors">>}},
         {"docs/guides/cancel-on-disconnect.md", #{
@@ -168,6 +170,7 @@
             <<"docs/tutorials/middleware-stack.md">>,
             <<"docs/tutorials/streaming-responses.md">>,
             <<"docs/tutorials/testing-handlers.md">>,
+            <<"docs/tutorials/call-a-service.md">>,
             <<"docs/tutorials/build-a-complete-service.md">>
         ]},
         {<<"How-to guides">>, [
@@ -195,6 +198,7 @@
             <<"docs/guides/limit-concurrency.md">>,
             <<"docs/guides/rate-limit-requests.md">>,
             <<"docs/guides/log-requests.md">>,
+            <<"docs/guides/make-http-requests.md">>,
             <<"docs/guides/propagate-request-ids.md">>,
             <<"docs/guides/handler-errors.md">>,
             <<"docs/guides/cancel-on-disconnect.md">>,
@@ -311,8 +315,11 @@
             }},
             %% The adapter behaviour is dispatched dynamically by
             %% design (Adapter:send_*, accept_ws/accept_wt).
+            %% livery_client dispatches to the configured client adapter.
             {elvis_style, invalid_dynamic_call, #{
-                ignore => [livery, livery_mcp, livery_ws, livery_wt, livery_compress]
+                ignore => [
+                    livery, livery_mcp, livery_ws, livery_wt, livery_compress, livery_client
+                ]
             }},
             %% Per-stream translators block on receive and exit on the
             %% monitored worker's DOWN, so an after clause is wrong.

--- a/src/livery_client.erl
+++ b/src/livery_client.erl
@@ -1,0 +1,267 @@
+-module(livery_client).
+-moduledoc """
+A composable HTTP client: the outbound twin of the server middleware.
+
+Build a client once with `new/1` (a transport adapter, a base URL,
+default headers, and a layer stack), then call it with `get/2`, `post/3`,
+`request/3,4`. Layers run outermost-first and each is
+`call(Request, Next, State) -> {ok, response()} | {error, term()}`, the
+same shape as server middleware, with errors threaded as values.
+
+```erlang
+Client = livery_client:new(#{
+    base_url => <<"https://api.example.com">>,
+    stack    => [
+        livery_client:timeout(5000),
+        livery_client:retry(#{max => 3}),
+        livery_client:circuit_breaker(#{name => api}),
+        livery_client:concurrency(50)
+    ]
+}),
+{ok, Resp} = livery_client:get(Client, <<"/users/42">>),
+200 = livery_client:status(Resp).
+```
+
+The transport is a `livery_client_adapter`; the default,
+`livery_client_hackney`, speaks HTTP/1.1, HTTP/2, and HTTP/3.
+""".
+
+-export([new/1]).
+-export([get/2, post/3, put/3, delete/2, request/3, request/4, run/2]).
+-export([status/1, headers/1, header/2, header/3, body/1, method/1, url/1, set_header/3]).
+-export([read/2, read_body/1]).
+-export([timeout/1, concurrency/1, retry/1, circuit_breaker/1]).
+-export([before/1, after_response/1, wrap/1]).
+
+-export_type([client/0, request/0, response/0, result/0, next/0, entry/0, stack/0]).
+
+-type request() :: #{
+    method := atom() | binary(),
+    url := binary(),
+    headers := [{binary(), binary()}],
+    body := empty | {full, iodata()} | {stream, fun()},
+    timeout := timeout(),
+    stream := boolean(),
+    meta := map()
+}.
+-type response() :: #{
+    status := 100..599,
+    headers := [{binary(), binary()}],
+    body := {full, binary()} | {stream, term()}
+}.
+-type result() :: {ok, response()} | {error, term()}.
+-type next() :: fun((request()) -> result()).
+-type entry() :: {module(), term()} | fun((request(), next()) -> result()).
+-type stack() :: [entry()].
+-opaque client() :: #{
+    adapter := module(),
+    adapter_opts := map(),
+    base_url := binary(),
+    headers := [{binary(), binary()}],
+    stack := stack()
+}.
+
+%%====================================================================
+%% Build and call
+%%====================================================================
+
+-doc """
+Build a client. Opts: `adapter` (default `livery_client_hackney`),
+`adapter_opts`, `base_url`, `headers` (defaults applied to every
+request), `stack` (the layers).
+""".
+-spec new(map()) -> client().
+new(Opts) ->
+    #{
+        adapter => maps:get(adapter, Opts, livery_client_hackney),
+        adapter_opts => maps:get(adapter_opts, Opts, #{}),
+        base_url => maps:get(base_url, Opts, <<>>),
+        headers => maps:get(headers, Opts, []),
+        stack => maps:get(stack, Opts, [])
+    }.
+
+-spec get(client(), binary()) -> result().
+get(Client, Path) -> request(Client, get, Path, #{}).
+
+-spec post(client(), binary(), iodata()) -> result().
+post(Client, Path, Body) -> request(Client, post, Path, #{body => {full, Body}}).
+
+-spec put(client(), binary(), iodata()) -> result().
+put(Client, Path, Body) -> request(Client, put, Path, #{body => {full, Body}}).
+
+-spec delete(client(), binary()) -> result().
+delete(Client, Path) -> request(Client, delete, Path, #{}).
+
+-spec request(client(), atom() | binary(), binary()) -> result().
+request(Client, Method, Path) -> request(Client, Method, Path, #{}).
+
+-doc """
+Send a request. `Opts`: `body` (`iodata` | `{full, _}` | `{stream, Fun}`),
+`headers`, `timeout`, `stream` (`true` to receive a `{stream, Reader}`
+response body), `meta`.
+""".
+-spec request(client(), atom() | binary(), binary(), map()) -> result().
+request(Client, Method, Path, Opts) ->
+    run(Client, build_request(Client, Method, Path, Opts)).
+
+-doc "Run a fully built request through the client's layer stack.".
+-spec run(client(), request()) -> result().
+run(Client, Req) ->
+    #{adapter := Adapter, adapter_opts := AdapterOpts, stack := Stack} = Client,
+    Handler = fun(R) -> Adapter:request(R, AdapterOpts) end,
+    run_stack(Stack, Handler, Req).
+
+%%====================================================================
+%% Accessors
+%%====================================================================
+
+-spec status(response()) -> 100..599.
+status(#{status := S}) -> S.
+
+-spec headers(request() | response()) -> [{binary(), binary()}].
+headers(#{headers := H}) -> H.
+
+-spec header(binary(), request() | response()) -> binary() | undefined.
+header(Name, Map) -> header(Name, Map, undefined).
+
+-spec header(binary(), request() | response(), Default) -> binary() | Default.
+header(Name, #{headers := H}, Default) ->
+    L = string:lowercase(Name),
+    case lists:search(fun({K, _}) -> string:lowercase(K) =:= L end, H) of
+        {value, {_, V}} -> V;
+        false -> Default
+    end.
+
+-spec body(response()) -> {full, binary()} | {stream, term()}.
+body(#{body := B}) -> B.
+
+-spec method(request()) -> atom() | binary().
+method(#{method := M}) -> M.
+
+-spec url(request()) -> binary().
+url(#{url := U}) -> U.
+
+-spec set_header(binary(), binary(), request()) -> request().
+set_header(Name, Value, #{headers := H} = Req) ->
+    L = string:lowercase(Name),
+    Kept = [KV || {K, _} = KV <- H, string:lowercase(K) =/= L],
+    Req#{headers => [{Name, Value} | Kept]}.
+
+%%====================================================================
+%% Streamed response bodies
+%%====================================================================
+
+-doc "Pull the next chunk of a `{stream, Reader}` response body.".
+-spec read(term(), timeout()) -> {ok, binary(), term()} | {done, term()} | {error, term()}.
+read({Adapter, State}, Timeout) ->
+    case Adapter:read(State, Timeout) of
+        {ok, Data, State1} -> {ok, Data, {Adapter, State1}};
+        {done, State1} -> {done, {Adapter, State1}};
+        {error, _} = E -> E
+    end.
+
+-doc "Drain a `{stream, Reader}` response body to a single binary.".
+-spec read_body(term()) -> {ok, binary()} | {error, term()}.
+read_body(Reader) -> read_body(Reader, []).
+
+read_body(Reader, Acc) ->
+    case read(Reader, 30000) of
+        {ok, Data, Reader1} -> read_body(Reader1, [Data | Acc]);
+        {done, _Reader1} -> {ok, iolist_to_binary(lists:reverse(Acc))};
+        {error, _} = E -> E
+    end.
+
+%%====================================================================
+%% Layer constructors
+%%====================================================================
+
+-spec timeout(pos_integer()) -> entry().
+timeout(Ms) -> {livery_client_timeout, Ms}.
+
+-spec concurrency(non_neg_integer()) -> entry().
+concurrency(Limit) -> {livery_client_concurrency, livery_client_concurrency:limiter(Limit)}.
+
+-spec retry(map()) -> entry().
+retry(Opts) -> {livery_client_retry, Opts}.
+
+-spec circuit_breaker(map()) -> entry().
+circuit_breaker(Opts) -> {livery_client_circuit, Opts}.
+
+%%====================================================================
+%% Sugar (mirrors livery_middleware, error-aware)
+%%====================================================================
+
+-spec before(fun((request()) -> request())) -> entry().
+before(Fun) when is_function(Fun, 1) ->
+    fun(Req, Next) -> Next(Fun(Req)) end.
+
+-spec after_response(fun((response()) -> response())) -> entry().
+after_response(Fun) when is_function(Fun, 1) ->
+    fun(Req, Next) ->
+        case Next(Req) of
+            {ok, Resp} -> {ok, Fun(Resp)};
+            {error, _} = E -> E
+        end
+    end.
+
+-spec wrap(fun((throw | error | exit, term(), list()) -> result())) -> entry().
+wrap(Fun) when is_function(Fun, 3) ->
+    fun(Req, Next) ->
+        try
+            Next(Req)
+        catch
+            Class:Reason:Stack -> Fun(Class, Reason, Stack)
+        end
+    end.
+
+%%====================================================================
+%% Internals
+%%====================================================================
+
+build_request(Client, Method, Path, Opts) ->
+    #{
+        method => Method,
+        url => full_url(Client, Path),
+        headers => merge_headers(maps:get(headers, Client), maps:get(headers, Opts, [])),
+        body => normalize_body(maps:get(body, Opts, empty)),
+        timeout => maps:get(timeout, Opts, 30000),
+        stream => maps:get(stream, Opts, false),
+        meta => maps:get(meta, Opts, #{})
+    }.
+
+run_stack([], Handler, Req) ->
+    Handler(Req);
+run_stack([Entry | Rest], Handler, Req) ->
+    Next = fun(R) -> run_stack(Rest, Handler, R) end,
+    call_entry(Entry, Req, Next).
+
+call_entry({Mod, State}, Req, Next) when is_atom(Mod) ->
+    Mod:call(Req, Next, State);
+call_entry(Fun, Req, Next) when is_function(Fun, 2) ->
+    Fun(Req, Next).
+
+normalize_body(empty) -> empty;
+normalize_body({full, _} = B) -> B;
+normalize_body({stream, _} = B) -> B;
+normalize_body(IoData) -> {full, IoData}.
+
+full_url(Client, Path) ->
+    case maps:get(base_url, Client) of
+        <<>> -> Path;
+        Base -> <<(strip_trailing_slash(Base))/binary, (ensure_leading_slash(Path))/binary>>
+    end.
+
+strip_trailing_slash(B) ->
+    case binary:last(B) of
+        $/ -> binary:part(B, 0, byte_size(B) - 1);
+        _ -> B
+    end.
+
+ensure_leading_slash(<<$/, _/binary>> = P) -> P;
+ensure_leading_slash(P) -> <<$/, P/binary>>.
+
+%% Default headers are overridden by per-request headers of the same name.
+merge_headers(Defaults, Extra) ->
+    Names = [string:lowercase(N) || {N, _} <- Extra],
+    Kept = [KV || {N, _} = KV <- Defaults, not lists:member(string:lowercase(N), Names)],
+    Kept ++ Extra.

--- a/src/livery_client_adapter.erl
+++ b/src/livery_client_adapter.erl
@@ -1,0 +1,29 @@
+-module(livery_client_adapter).
+-moduledoc """
+Behaviour for an outbound HTTP transport, the client-side dual of
+`livery_adapter`.
+
+An adapter owns the wire: it takes a `livery_client:request()` and
+produces a `livery_client:response()` (or an error). The composable
+layers (timeout, retry, concurrency, circuit breaker) sit above it and
+do not care which transport runs underneath. The default adapter is
+`livery_client_hackney` (HTTP/1.1, HTTP/2, and HTTP/3 via hackney);
+write your own to front a different client.
+
+## Callbacks
+
+- `request(Request, Opts) -> {ok, Response} | {error, term()}` - send
+  one request. The adapter owns its connections and pooling.
+- `read(Reader, Timeout) -> {ok, Data, Reader} | {done, Reader} |
+  {error, term()}` - *optional*; pull the next chunk of a streamed
+  response body. Only adapters that return a `{stream, Reader}` response
+  body implement it.
+""".
+
+-callback request(livery_client:request(), map()) ->
+    {ok, livery_client:response()} | {error, term()}.
+
+-callback read(term(), timeout()) ->
+    {ok, binary(), term()} | {done, term()} | {error, term()}.
+
+-optional_callbacks([read/2]).

--- a/src/livery_client_circuit.erl
+++ b/src/livery_client_circuit.erl
@@ -1,0 +1,35 @@
+-module(livery_client_circuit).
+-moduledoc """
+Client layer: a circuit breaker.
+
+Tracks the recent failure ratio for a named target. While the circuit is
+closed, requests pass and outcomes are tallied over a tumbling `window`;
+once the failure ratio reaches `trip`, the circuit opens and further
+requests fail fast with `{error, circuit_open}`. After `cooldown` ms the
+breaker half-opens to let one probe through, closing again on success or
+re-opening on failure. Add it with `livery_client:circuit_breaker/1`.
+
+`Opts`: `name` (required), `window` (default 20), `trip` (default 0.5),
+`cooldown` ms (default 5000).
+""".
+
+-export([call/3]).
+
+-spec call(livery_client:request(), livery_client:next(), map()) ->
+    {ok, livery_client:response()} | {error, term()}.
+call(Req, Next, Opts) ->
+    Name = maps:get(name, Opts),
+    Cooldown = maps:get(cooldown, Opts, 5000),
+    case livery_client_circuit_store:allow(Name, Cooldown) of
+        deny ->
+            {error, circuit_open};
+        allow ->
+            Result = Next(Req),
+            Window = maps:get(window, Opts, 20),
+            Trip = maps:get(trip, Opts, 0.5),
+            livery_client_circuit_store:record(Name, outcome(Result), Window, Trip),
+            Result
+    end.
+
+outcome({ok, _Response}) -> ok;
+outcome({error, _Reason}) -> err.

--- a/src/livery_client_circuit_store.erl
+++ b/src/livery_client_circuit_store.erl
@@ -1,0 +1,106 @@
+-module(livery_client_circuit_store).
+-moduledoc """
+Owns the ETS table backing the client circuit breakers.
+
+A `gen_server` that creates a public named table at startup and clears it
+on shutdown; the decision logic in `livery_client_circuit` reads and
+writes the table directly (no per-request round trip through this
+process). One row per breaker name: `{Name, Status, Fails, Total,
+OpenedAtMs}` where `Status` is `closed | open | half_open`.
+""".
+-behaviour(gen_server).
+
+-export([start_link/0, allow/2, record/4, reset/1]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
+
+-define(TABLE, ?MODULE).
+-record(state, {}).
+-type state() :: #state{}.
+
+-spec start_link() -> {ok, pid()} | {error, term()}.
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-doc "May a request pass? Half-opens an expired-cooldown breaker to probe.".
+-spec allow(term(), non_neg_integer()) -> allow | deny.
+allow(Name, Cooldown) ->
+    case lookup(Name) of
+        {open, _F, _T, OpenedAt} ->
+            case now_ms() - OpenedAt >= Cooldown of
+                true ->
+                    true = ets:insert(?TABLE, {Name, half_open, 0, 0, now_ms()}),
+                    allow;
+                false ->
+                    deny
+            end;
+        _ ->
+            allow
+    end.
+
+-doc "Record a request outcome and update the breaker state.".
+-spec record(term(), ok | err, pos_integer(), float()) -> ok.
+record(Name, Outcome, Window, Trip) ->
+    case lookup(Name) of
+        {half_open, _F, _T, _O} when Outcome =:= ok ->
+            put_row(Name, closed, 0, 0, 0);
+        {half_open, _F, _T, _O} ->
+            put_row(Name, open, 0, 0, now_ms());
+        {open, _F, _T, _O} ->
+            ok;
+        {S, F, T, _O} when S =:= closed ->
+            F1 = F + fail(Outcome),
+            T1 = T + 1,
+            evaluate(Name, F1, T1, Window, Trip)
+    end.
+
+-doc "Forget a breaker's state.".
+-spec reset(term()) -> ok.
+reset(Name) ->
+    true = ets:delete(?TABLE, Name),
+    ok.
+
+%%====================================================================
+%% gen_server
+%%====================================================================
+
+-spec init([]) -> {ok, state()}.
+init([]) ->
+    _ = ets:new(?TABLE, [named_table, public, set, {write_concurrency, true}]),
+    {ok, #state{}}.
+
+-spec handle_call(term(), {pid(), term()}, state()) -> {reply, ok, state()}.
+handle_call(_Request, _From, State) -> {reply, ok, State}.
+
+-spec handle_cast(term(), state()) -> {noreply, state()}.
+handle_cast(_Msg, State) -> {noreply, State}.
+
+-spec handle_info(term(), state()) -> {noreply, state()}.
+handle_info(_Info, State) -> {noreply, State}.
+
+%%====================================================================
+%% Internals
+%%====================================================================
+
+lookup(Name) ->
+    case ets:lookup(?TABLE, Name) of
+        [{_, S, F, T, O}] -> {S, F, T, O};
+        [] -> {closed, 0, 0, 0}
+    end.
+
+evaluate(Name, Fails, Total, Window, Trip) when Total >= Window ->
+    case Fails / Total >= Trip of
+        true -> put_row(Name, open, 0, 0, now_ms());
+        false -> put_row(Name, closed, 0, 0, 0)
+    end;
+evaluate(Name, Fails, Total, _Window, _Trip) ->
+    put_row(Name, closed, Fails, Total, 0).
+
+put_row(Name, Status, Fails, Total, OpenedAt) ->
+    true = ets:insert(?TABLE, {Name, Status, Fails, Total, OpenedAt}),
+    ok.
+
+fail(ok) -> 0;
+fail(err) -> 1.
+
+now_ms() ->
+    erlang:monotonic_time(millisecond).

--- a/src/livery_client_concurrency.erl
+++ b/src/livery_client_concurrency.erl
@@ -1,0 +1,33 @@
+-module(livery_client_concurrency).
+-moduledoc """
+Client layer: cap in-flight requests.
+
+A lock-free `atomics` counter admits up to `limit` concurrent requests
+through this layer; past the cap a request returns `{error, overloaded}`
+without calling downstream. Add it with `livery_client:concurrency/1`.
+""".
+
+-export([limiter/1, call/3]).
+
+-export_type([state/0]).
+
+-opaque state() :: #{ref := atomics:atomics_ref(), limit := non_neg_integer()}.
+
+-spec limiter(non_neg_integer()) -> state().
+limiter(Limit) when is_integer(Limit), Limit >= 0 ->
+    #{ref => atomics:new(1, [{signed, false}]), limit => Limit}.
+
+-spec call(livery_client:request(), livery_client:next(), state()) ->
+    {ok, livery_client:response()} | {error, term()}.
+call(Req, Next, #{ref := Ref, limit := Limit}) ->
+    case atomics:add_get(Ref, 1, 1) of
+        Count when Count > Limit ->
+            atomics:sub(Ref, 1, 1),
+            {error, overloaded};
+        _Count ->
+            try
+                Next(Req)
+            after
+                atomics:sub(Ref, 1, 1)
+            end
+    end.

--- a/src/livery_client_hackney.erl
+++ b/src/livery_client_hackney.erl
@@ -1,0 +1,118 @@
+-module(livery_client_hackney).
+-moduledoc """
+Default client adapter: hackney.
+
+hackney 4.2 speaks HTTP/1.1, HTTP/2, and HTTP/3 (with TLS, pooling, and
+IPv6), so this one adapter covers every protocol. The request body may be
+buffered (`{full, _}`) or a producer (`{stream, Fun}`); the response is
+buffered by default, or streamed (`{stream, Reader}`) when the request
+sets `stream => true`.
+
+`Opts` (the client's `adapter_opts`) may carry `hackney => [opt]`, a list
+of raw hackney options forwarded verbatim (e.g. `{ssl_options, _}`, a
+pool name, HTTP/3 controls like `zero_rtt`/`family`).
+
+hackney's `request/5` always buffers the response, so any request that
+either streams its body or wants a streamed response goes through the
+connection API (`request` with a `stream` body, `start_response`,
+`stream_body`).
+""".
+-behaviour(livery_client_adapter).
+
+-export([request/2, read/2]).
+
+-spec request(livery_client:request(), map()) ->
+    {ok, livery_client:response()} | {error, term()}.
+request(Req, Opts) ->
+    Method = maps:get(method, Req),
+    Url = maps:get(url, Req),
+    Headers = maps:get(headers, Req, []),
+    Timeout = maps:get(timeout, Req, 30000),
+    Stream = maps:get(stream, Req, false),
+    Body = maps:get(body, Req, empty),
+    HackneyOpts = [{recv_timeout, Timeout} | maps:get(hackney, Opts, [])],
+    case conn_flow(Body, Stream) of
+        false ->
+            buffered(Method, Url, Headers, to_body(Body), HackneyOpts);
+        true ->
+            via_conn(Method, Url, Headers, Body, HackneyOpts, Stream)
+    end.
+
+%% Optional callback: pull the next chunk of a streamed response body.
+-spec read(term(), timeout()) ->
+    {ok, binary(), term()} | {done, term()} | {error, term()}.
+read(Conn, _Timeout) ->
+    case hackney:stream_body(Conn) of
+        {ok, Data} -> {ok, Data, Conn};
+        done -> {done, Conn};
+        {error, Reason} -> {error, Reason}
+    end.
+
+%%====================================================================
+%% Internals
+%%====================================================================
+
+%% The connection API is needed when the request body streams or the
+%% caller wants to stream the response; otherwise request/5 (which always
+%% buffers) is simplest.
+conn_flow({stream, _}, _Stream) -> true;
+conn_flow(_Body, Stream) -> Stream.
+
+buffered(Method, Url, Headers, Body, Opts) ->
+    case hackney:request(Method, Url, Headers, Body, Opts) of
+        {ok, Status, RespHeaders, RespBody} ->
+            {ok, response(Status, RespHeaders, {full, RespBody})};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+via_conn(Method, Url, Headers, Body, Opts, Stream) ->
+    case hackney:request(Method, Url, Headers, stream, Opts) of
+        {ok, Conn} ->
+            case send_request_body(Conn, Body) of
+                ok -> finish(Conn, Stream);
+                {error, Reason} -> {error, Reason}
+            end;
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+send_request_body(Conn, empty) ->
+    hackney:finish_send_body(Conn);
+send_request_body(Conn, {full, IoData}) ->
+    case hackney:send_body(Conn, IoData) of
+        ok -> hackney:finish_send_body(Conn);
+        {error, Reason} -> {error, Reason}
+    end;
+send_request_body(Conn, {stream, Producer}) ->
+    stream_request_body(Conn, Producer).
+
+stream_request_body(Conn, Producer) ->
+    case Producer() of
+        eof ->
+            hackney:finish_send_body(Conn);
+        {ok, Chunk, Next} ->
+            case hackney:send_body(Conn, Chunk) of
+                ok -> stream_request_body(Conn, Next);
+                {error, Reason} -> {error, Reason}
+            end
+    end.
+
+finish(Conn, Stream) ->
+    case hackney:start_response(Conn) of
+        {ok, Status, RespHeaders, Conn1} when Stream ->
+            {ok, response(Status, RespHeaders, {stream, {?MODULE, Conn1}})};
+        {ok, Status, RespHeaders, Conn1} ->
+            case hackney:body(Conn1) of
+                {ok, Body} -> {ok, response(Status, RespHeaders, {full, Body})};
+                {error, Reason} -> {error, Reason}
+            end;
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+to_body(empty) -> <<>>;
+to_body({full, IoData}) -> IoData.
+
+response(Status, Headers, Body) ->
+    #{status => Status, headers => Headers, body => Body}.

--- a/src/livery_client_retry.erl
+++ b/src/livery_client_retry.erl
@@ -1,0 +1,67 @@
+-module(livery_client_retry).
+-moduledoc """
+Client layer: retry failed requests with exponential backoff.
+
+Retries on transport errors and on the configured retryable status codes
+(502/503/504 by default), up to `max` extra attempts, sleeping
+`Base * Factor^Attempt` ms plus jitter between tries. Only idempotent
+methods (GET/HEAD/PUT/DELETE/OPTIONS) are retried unless
+`retry_non_idempotent => true`, and a request with a one-shot streaming
+body is never retried (the producer cannot be replayed). Add it with
+`livery_client:retry/1`.
+
+`Opts`: `max` (default 2), `backoff` (`{BaseMs, Factor}`, default
+`{200, 2.0}`), `statuses` (default `[502, 503, 504]`),
+`retry_non_idempotent` (default `false`).
+""".
+
+-export([call/3]).
+
+-spec call(livery_client:request(), livery_client:next(), map()) ->
+    {ok, livery_client:response()} | {error, term()}.
+call(Req, Next, Opts) ->
+    Max = maps:get(max, Opts, 2),
+    loop(Req, Next, Opts, Max, 0).
+
+loop(Req, Next, Opts, Max, Attempt) ->
+    Result = Next(Req),
+    case retry(Result, Req, Opts, Attempt, Max) of
+        true ->
+            timer:sleep(backoff(Opts, Attempt)),
+            loop(Req, Next, Opts, Max, Attempt + 1);
+        false ->
+            Result
+    end.
+
+retry(Result, Req, Opts, Attempt, Max) ->
+    Attempt < Max andalso
+        replayable(Req, Opts) andalso
+        retryable(Result, Opts).
+
+%% A streaming request body cannot be replayed, so do not retry it.
+replayable(Req, Opts) ->
+    case maps:get(body, Req, empty) of
+        {stream, _} -> false;
+        _ -> idempotent(maps:get(method, Req), Opts)
+    end.
+
+idempotent(_Method, #{retry_non_idempotent := true}) ->
+    true;
+idempotent(Method, _Opts) ->
+    lists:member(
+        normalize(Method),
+        [<<"get">>, <<"head">>, <<"put">>, <<"delete">>, <<"options">>]
+    ).
+
+normalize(M) when is_atom(M) -> normalize(atom_to_binary(M, utf8));
+normalize(M) when is_binary(M) -> string:lowercase(M).
+
+retryable({error, _Reason}, _Opts) ->
+    true;
+retryable({ok, #{status := Status}}, Opts) ->
+    lists:member(Status, maps:get(statuses, Opts, [502, 503, 504])).
+
+backoff(Opts, Attempt) ->
+    {Base, Factor} = maps:get(backoff, Opts, {200, 2.0}),
+    Delay = round(Base * math:pow(Factor, Attempt)),
+    Delay + rand:uniform(Base).

--- a/src/livery_client_timeout.erl
+++ b/src/livery_client_timeout.erl
@@ -1,0 +1,40 @@
+-module(livery_client_timeout).
+-moduledoc """
+Client layer: bound a request to a deadline.
+
+Runs the downstream call in a monitored child process and returns
+`{error, timeout}` if it does not finish within `Ms`, killing the child
+(which tears down the in-flight connection). Add it with
+`livery_client:timeout/1`.
+""".
+
+-export([call/3]).
+
+-spec call(livery_client:request(), livery_client:next(), pos_integer()) ->
+    {ok, livery_client:response()} | {error, term()}.
+call(Req, Next, Ms) ->
+    Self = self(),
+    Ref = make_ref(),
+    {Pid, MRef} = spawn_monitor(fun() ->
+        Result =
+            try
+                Next(Req)
+            catch
+                Class:Reason:Stack -> {'$crash', Class, Reason, Stack}
+            end,
+        Self ! {Ref, Result}
+    end),
+    receive
+        {Ref, {'$crash', Class, Reason, Stack}} ->
+            erlang:demonitor(MRef, [flush]),
+            erlang:raise(Class, Reason, Stack);
+        {Ref, Result} ->
+            erlang:demonitor(MRef, [flush]),
+            Result;
+        {'DOWN', MRef, process, Pid, Reason} ->
+            {error, {worker_down, Reason}}
+    after Ms ->
+        exit(Pid, kill),
+        erlang:demonitor(MRef, [flush]),
+        {error, timeout}
+    end.

--- a/src/livery_sup.erl
+++ b/src/livery_sup.erl
@@ -36,4 +36,12 @@ init([]) ->
         type => worker,
         modules => [livery_ratelimit_store]
     },
-    {ok, {SupFlags, [ReqSup, RateLimitStore]}}.
+    CircuitStore = #{
+        id => livery_client_circuit_store,
+        start => {livery_client_circuit_store, start_link, []},
+        restart => permanent,
+        shutdown => 5000,
+        type => worker,
+        modules => [livery_client_circuit_store]
+    },
+    {ok, {SupFlags, [ReqSup, RateLimitStore, CircuitStore]}}.

--- a/test/livery_client_SUITE.erl
+++ b/test/livery_client_SUITE.erl
@@ -1,0 +1,220 @@
+%% @doc Drives livery_client against a real loopback Livery server (real
+%% hackney over the loopback, no external network), exercising each layer.
+-module(livery_client_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([
+    get_round_trip/1,
+    post_round_trip/1,
+    timeout_layer/1,
+    retry_layer/1,
+    concurrency_layer/1,
+    circuit_layer/1,
+    circuit_store_recovers/1,
+    stream_response/1,
+    stream_request/1,
+    custom_adapter/1
+]).
+
+all() ->
+    [
+        get_round_trip,
+        post_round_trip,
+        timeout_layer,
+        retry_layer,
+        concurrency_layer,
+        circuit_layer,
+        circuit_store_recovers,
+        stream_response,
+        stream_request,
+        custom_adapter
+    ].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(livery),
+    {ok, _} = application:ensure_all_started(hackney),
+    %% An atomics ref survives the init_per_suite process (unlike an ETS
+    %% table owned by it) and gives handle_flaky a shared counter.
+    Counter = atomics:new(1, [{signed, false}]),
+    Router = livery_router:compile([
+        {<<"GET">>, <<"/ok">>, fun handle_ok/1},
+        {<<"POST">>, <<"/echo">>, fun handle_echo/1},
+        {<<"GET">>, <<"/slow">>, fun handle_slow/1},
+        {<<"GET">>, <<"/flaky">>, fun handle_flaky/1},
+        {<<"GET">>, <<"/big">>, fun handle_big/1},
+        {<<"GET">>, <<"/block">>, fun handle_block/1}
+    ]),
+    {ok, Pid} = livery:start_service(#{
+        http => #{port => 0},
+        config => #{counter => Counter},
+        router => Router
+    }),
+    %% start_service links to us; unlink so the service survives the
+    %% init_per_suite process and lives for the whole suite.
+    true = unlink(Pid),
+    Port = maps:get(h1, livery:which_listeners(Pid)),
+    Base = iolist_to_binary([<<"http://127.0.0.1:">>, integer_to_binary(Port)]),
+    [{service, Pid}, {counter, Counter}, {base, Base} | Config].
+
+end_per_suite(Config) ->
+    livery:stop_service(?config(service, Config)),
+    ok.
+
+%%====================================================================
+%% Handlers
+%%====================================================================
+
+handle_ok(_Req) -> livery_resp:text(200, <<"ok">>).
+
+handle_echo(Req) -> livery_resp:text(200, read_body(Req)).
+
+handle_slow(_Req) ->
+    timer:sleep(300),
+    livery_resp:text(200, <<"slow">>).
+
+%% Fail the first two calls with 503, then succeed.
+handle_flaky(Req) ->
+    Ref = livery_req:config(counter, Req),
+    case atomics:add_get(Ref, 1, 1) of
+        N when N =< 2 -> livery_resp:text(503, <<"busy">>);
+        _ -> livery_resp:text(200, <<"recovered">>)
+    end.
+
+handle_big(_Req) -> livery_resp:text(200, binary:copy(<<"x">>, 100000)).
+
+handle_block(_Req) ->
+    timer:sleep(200),
+    livery_resp:text(200, <<"done">>).
+
+read_body(Req) ->
+    case livery_req:body(Req) of
+        {stream, Reader} ->
+            {ok, Bin, _} = livery_body:read_all(Reader),
+            Bin;
+        {buffered, IoData} ->
+            iolist_to_binary(IoData);
+        empty ->
+            <<>>
+    end.
+
+%%====================================================================
+%% Cases
+%%====================================================================
+
+get_round_trip(Config) ->
+    C = livery_client:new(#{base_url => ?config(base, Config)}),
+    {ok, Resp} = livery_client:get(C, <<"/ok">>),
+    ?assertEqual(200, livery_client:status(Resp)),
+    ?assertEqual({full, <<"ok">>}, livery_client:body(Resp)).
+
+post_round_trip(Config) ->
+    C = livery_client:new(#{base_url => ?config(base, Config)}),
+    {ok, Resp} = livery_client:post(C, <<"/echo">>, <<"hello">>),
+    ?assertEqual(200, livery_client:status(Resp)),
+    ?assertEqual({full, <<"hello">>}, livery_client:body(Resp)).
+
+timeout_layer(Config) ->
+    C = livery_client:new(#{
+        base_url => ?config(base, Config),
+        stack => [livery_client:timeout(50)]
+    }),
+    ?assertEqual({error, timeout}, livery_client:get(C, <<"/slow">>)).
+
+retry_layer(Config) ->
+    atomics:put(?config(counter, Config), 1, 0),
+    C = livery_client:new(#{
+        base_url => ?config(base, Config),
+        stack => [livery_client:retry(#{max => 5, backoff => {10, 1.2}})]
+    }),
+    {ok, Resp} = livery_client:get(C, <<"/flaky">>),
+    ?assertEqual(200, livery_client:status(Resp)),
+    ?assertEqual({full, <<"recovered">>}, livery_client:body(Resp)).
+
+concurrency_layer(Config) ->
+    C = livery_client:new(#{
+        base_url => ?config(base, Config),
+        stack => [livery_client:concurrency(1)]
+    }),
+    Self = self(),
+    [spawn(fun() -> Self ! {res, livery_client:get(C, <<"/block">>)} end) || _ <- [1, 2, 3]],
+    Results = [
+        receive
+            {res, R} -> R
+        after 5000 -> timeout
+        end
+     || _ <- [1, 2, 3]
+    ],
+    ?assert(lists:member({error, overloaded}, Results)),
+    ?assert(
+        lists:any(
+            fun
+                ({ok, _}) -> true;
+                (_) -> false
+            end,
+            Results
+        )
+    ).
+
+circuit_layer(_Config) ->
+    C = livery_client:new(#{
+        base_url => dead_base(),
+        adapter_opts => #{hackney => [{connect_timeout, 200}]},
+        stack => [livery_client:circuit_breaker(#{name => cb_test, window => 3, trip => 0.5})]
+    }),
+    %% Three real failures trip the breaker (window 3, ratio 1.0 >= 0.5).
+    [?assertMatch({error, _}, livery_client:get(C, <<"/x">>)) || _ <- [1, 2, 3]],
+    %% Now it fails fast without touching the network.
+    ?assertEqual({error, circuit_open}, livery_client:get(C, <<"/x">>)).
+
+circuit_store_recovers(_Config) ->
+    Name = {cb_unit, erlang:unique_integer()},
+    Cooldown = 50,
+    %% Closed: record failures until the window trips it open.
+    allow = livery_client_circuit_store:allow(Name, Cooldown),
+    ok = livery_client_circuit_store:record(Name, err, 2, 0.5),
+    ok = livery_client_circuit_store:record(Name, err, 2, 0.5),
+    ?assertEqual(deny, livery_client_circuit_store:allow(Name, Cooldown)),
+    %% After the cooldown it half-opens to probe, and a success closes it.
+    timer:sleep(Cooldown + 20),
+    ?assertEqual(allow, livery_client_circuit_store:allow(Name, Cooldown)),
+    ok = livery_client_circuit_store:record(Name, ok, 2, 0.5),
+    ?assertEqual(allow, livery_client_circuit_store:allow(Name, Cooldown)),
+    livery_client_circuit_store:reset(Name).
+
+stream_response(Config) ->
+    C = livery_client:new(#{base_url => ?config(base, Config)}),
+    {ok, Resp} = livery_client:request(C, get, <<"/big">>, #{stream => true}),
+    {stream, Reader} = livery_client:body(Resp),
+    {ok, Body} = livery_client:read_body(Reader),
+    ?assertEqual(100000, byte_size(Body)).
+
+stream_request(Config) ->
+    C = livery_client:new(#{base_url => ?config(base, Config)}),
+    Body = {stream, producer([<<"a">>, <<"b">>, <<"c">>])},
+    {ok, Resp} = livery_client:request(C, post, <<"/echo">>, #{body => Body}),
+    ?assertEqual({full, <<"abc">>}, livery_client:body(Resp)).
+
+custom_adapter(_Config) ->
+    C = livery_client:new(#{adapter => livery_client_fake_adapter}),
+    {ok, Resp} = livery_client:get(C, <<"http://ignored/">>),
+    ?assertEqual(418, livery_client:status(Resp)),
+    ?assertEqual({full, <<"teapot">>}, livery_client:body(Resp)).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+producer([]) ->
+    fun() -> eof end;
+producer([H | T]) ->
+    fun() -> {ok, H, producer(T)} end.
+
+%% A loopback port with nothing listening, so connects are refused.
+dead_base() ->
+    {ok, LSock} = gen_tcp:listen(0, [{ip, {127, 0, 0, 1}}]),
+    {ok, Port} = inet:port(LSock),
+    gen_tcp:close(LSock),
+    iolist_to_binary([<<"http://127.0.0.1:">>, integer_to_binary(Port)]).

--- a/test/livery_client_fake_adapter.erl
+++ b/test/livery_client_fake_adapter.erl
@@ -1,0 +1,7 @@
+%% @doc A no-socket client adapter, to prove the behaviour is pluggable.
+-module(livery_client_fake_adapter).
+-behaviour(livery_client_adapter).
+-export([request/2]).
+
+request(_Request, _Opts) ->
+    {ok, #{status => 418, headers => [{<<"x-fake">>, <<"1">>}], body => {full, <<"teapot">>}}}.


### PR DESCRIPTION
Livery's middleware was server-inbound only. This adds the outbound twin: a composable HTTP client built the same way you build a middleware stack.

## What

- `livery_client`: build a client with a transport adapter, base URL, default headers, and a layer stack, then call it (`get/2`, `post/3`, `put/3`, `delete/2`, `request/3,4`). Each layer is `call(Request, Next, State) -> {ok, Response} | {error, _}`, the same shape as server middleware with errors threaded as values.
- Layers: `timeout`, `retry` (backoff + jitter, idempotent-only by default), `concurrency` (lock-free atomics), and a `circuit_breaker` backed by a supervised ETS store under `livery_sup`.
- Streaming both ways: a producer request body and a `{stream, Reader}` response body drained with `read/2` / `read_body/1`.
- `livery_client_adapter`: the dual of `livery_adapter`. Default `livery_client_hackney` (hackney 4.2) covers HTTP/1.1, HTTP/2, and HTTP/3 over one transport; the behaviour stays open for alternative or mock adapters.

## Docs

A guide (Make outbound HTTP requests) and a tutorial (Call another service), plus notes in the middleware-pipeline and adapters concepts.

## Checks

fmt, compile, lint, xref, dialyzer clean. eunit 417. CT: client SUITE (10, dogfooded against a loopback Livery server) + docs SUITE (2).