### PR TITLE
Add client load balancing across endpoint pools

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -69,6 +69,7 @@ solution.
 
 **Calling out**
 - [Make outbound HTTP requests](guides/make-http-requests.md)
+- [Load-balance outbound requests](guides/load-balance-requests.md)
 
 **Operations**
 - [Shut down gracefully](guides/graceful-shutdown.md)

--- a/docs/concepts/adapters.md
+++ b/docs/concepts/adapters.md
@@ -123,8 +123,11 @@ Every adapter takes the same `ip => inet:ip_address()` and
 The same idea runs outbound. `livery_client_adapter` is the dual of this
 behaviour: it owns the wire for an outgoing request, while the client's
 layers (timeout, retry, circuit breaker) own the policy above it. The
-default `livery_client_hackney` covers HTTP/1.1, HTTP/2, and HTTP/3. See
-[Make outbound HTTP requests](../guides/make-http-requests.md).
+default `livery_client_hackney` covers HTTP/1.1, HTTP/2, and HTTP/3. When
+the target is a pool of replicas, a `balance` layer spreads requests
+across them and `livery_client_discover` resolves the endpoint set. See
+[Make outbound HTTP requests](../guides/make-http-requests.md) and
+[Load-balance outbound requests](../guides/load-balance-requests.md).
 
 ## See also
 

--- a/docs/guides/load-balance-requests.md
+++ b/docs/guides/load-balance-requests.md
@@ -1,0 +1,95 @@
+# How to load-balance outbound requests
+
+## Problem
+
+The service you call runs as several replicas, and you want to spread
+your requests across them, lean away from a slow one, and stop sending to
+a dead one until it recovers. You do not want a separate proxy in front;
+you want the client to do it.
+
+## Solution
+
+Add a `balance` layer to the client. Instead of a `base_url`, you give it
+a pool of endpoints and pass paths; the layer picks an endpoint per
+request and supplies the host.
+
+```erlang
+Client = livery_client:new(#{
+    stack => [
+        livery_client:retry(#{max => 3}),
+        livery_client:balance(#{
+            name      => users,
+            endpoints => [
+                <<"http://10.0.0.1:8080">>,
+                <<"http://10.0.0.2:8080">>,
+                <<"http://10.0.0.3:8080">>
+            ]
+        })
+    ]
+}),
+{ok, Resp} = livery_client:get(Client, <<"/users/42">>),
+200 = livery_client:status(Resp).
+```
+
+By default the layer uses power-of-two-choices: it samples two endpoints
+and sends to the one with fewer in-flight requests, which resists piling
+onto a slow node. Pass `policy => round_robin` for plain rotation.
+
+## Health: ejection and recovery
+
+The balancer watches outcomes. An endpoint that fails `eject_after`
+times in a row (default 5) is ejected from the pool for `eject_for` ms
+(default 10000). A failure is any `{error, _}` or, by default, any
+response with status `>= 500`, so a replica answering `503` is treated as
+unhealthy even though the call technically returned. Override what counts
+with `fail_status`:
+
+```erlang
+livery_client:balance(#{
+    name        => users,
+    endpoints   => Endpoints,
+    eject_after => 3,
+    eject_for   => 5000,
+    fail_status => [500, 502, 503, 504]
+}).
+```
+
+Recovery is lazy and safe: once the cooldown passes, the next request is
+leased as a single probe (an atomic compare-and-swap means only one
+caller probes, even under load). If it succeeds the endpoint rejoins; if
+it fails the endpoint stays out for another cooldown. Stack `retry` above
+`balance`, as shown, and that one probe failure is retried onto a healthy
+endpoint, invisibly to the caller.
+
+If every endpoint is ejected, a call returns `{error, no_endpoint}`.
+
+## Changing the pool at runtime
+
+A deploy adds a replica, or a node drains. Adjust the live pool without
+rebuilding the client:
+
+```erlang
+ok = livery_client:add_endpoint(users, <<"http://10.0.0.4:8080">>),
+ok = livery_client:remove_endpoint(users, <<"http://10.0.0.1:8080">>).
+```
+
+The pool is identified by its `name`, so every client built with the same
+name shares it. The `endpoints` list seeds the pool once, on first use;
+after that your `add`/`remove` calls are authoritative and a later
+request will not bring a removed endpoint back.
+
+## Discovery
+
+`endpoints` can be a `{Module, Arg}` pair naming a `livery_client_discover`
+provider instead of a fixed list. The shipped provider is static; a
+custom one can resolve endpoints from DNS or a registry:
+
+```erlang
+livery_client:balance(#{name => users, endpoints => {my_discovery, prod}}).
+```
+
+## See also
+
+- Guide: [Make outbound HTTP requests](make-http-requests.md)
+- Concept: [The middleware pipeline](../concepts/middleware-pipeline.md)
+- Reference: `livery_client`, `livery_client_balance`, `livery_client_discover`

--- a/docs/guides/make-http-requests.md
+++ b/docs/guides/make-http-requests.md
@@ -182,6 +182,13 @@ Body = {stream, fun() -> next_chunk() end},   %% {ok, Chunk, NextFun} | eof
 A streamed (one-shot) request body is never retried, since its chunks
 are already gone once sent; put `retry` on buffered calls.
 
+## Spread load across endpoints
+
+When the service you call has several replicas, swap the single
+`base_url` for a `balance` layer over a pool: it picks a replica per
+request, leans away from loaded or failing ones, and fails over for you.
+See [Load-balance outbound requests](load-balance-requests.md).
+
 ## Protocols and the transport
 
 The default transport is `livery_client_hackney`, and hackney 4.2 speaks

--- a/rebar.config
+++ b/rebar.config
@@ -128,6 +128,9 @@
         {"docs/guides/rate-limit-requests.md", #{title => <<"Rate-limit requests">>}},
         {"docs/guides/log-requests.md", #{title => <<"Log every request">>}},
         {"docs/guides/make-http-requests.md", #{title => <<"Make outbound HTTP requests">>}},
+        {"docs/guides/load-balance-requests.md", #{
+            title => <<"Load-balance outbound requests">>
+        }},
         {"docs/guides/propagate-request-ids.md", #{title => <<"Propagate request IDs">>}},
         {"docs/guides/handler-errors.md", #{title => <<"Catch handler errors">>}},
         {"docs/guides/cancel-on-disconnect.md", #{
@@ -199,6 +202,7 @@
             <<"docs/guides/rate-limit-requests.md">>,
             <<"docs/guides/log-requests.md">>,
             <<"docs/guides/make-http-requests.md">>,
+            <<"docs/guides/load-balance-requests.md">>,
             <<"docs/guides/propagate-request-ids.md">>,
             <<"docs/guides/handler-errors.md">>,
             <<"docs/guides/cancel-on-disconnect.md">>,
@@ -297,8 +301,10 @@
             %% `livery' and `livery_resp' are intentional public
             %% facades; `livery_req'/`livery_resp' expose req/0 and
             %% resp/0 as the public request/response value types.
+            %% livery_client is the client's public facade (verbs,
+            %% accessors, layer and sugar constructors), like livery_req/resp.
             {elvis_style, god_modules, #{
-                ignore => [livery_req, livery_resp]
+                ignore => [livery_req, livery_resp, livery_client]
             }},
             {elvis_style, private_data_types, #{
                 ignore => [livery_req, livery_resp]
@@ -315,10 +321,17 @@
             }},
             %% The adapter behaviour is dispatched dynamically by
             %% design (Adapter:send_*, accept_ws/accept_wt).
-            %% livery_client dispatches to the configured client adapter.
+            %% livery_client dispatches to the configured client adapter;
+            %% livery_client_discover dispatches to the discovery provider.
             {elvis_style, invalid_dynamic_call, #{
                 ignore => [
-                    livery, livery_mcp, livery_ws, livery_wt, livery_compress, livery_client
+                    livery,
+                    livery_mcp,
+                    livery_ws,
+                    livery_wt,
+                    livery_compress,
+                    livery_client,
+                    livery_client_discover
                 ]
             }},
             %% Per-stream translators block on receive and exit on the

--- a/src/livery_client.erl
+++ b/src/livery_client.erl
@@ -30,10 +30,12 @@ The transport is a `livery_client_adapter`; the default,
 -export([get/2, post/3, put/3, delete/2, request/3, request/4, run/2]).
 -export([status/1, headers/1, header/2, header/3, body/1, method/1, url/1, set_header/3]).
 -export([read/2, read_body/1]).
--export([timeout/1, concurrency/1, retry/1, circuit_breaker/1]).
+-export([timeout/1, concurrency/1, retry/1, circuit_breaker/1, balance/1]).
+-export([add_endpoint/2, remove_endpoint/2]).
 -export([before/1, after_response/1, wrap/1]).
+-export([rebase/2]).
 
--export_type([client/0, request/0, response/0, result/0, next/0, entry/0, stack/0]).
+-export_type([client/0, request/0, response/0, result/0, next/0, entry/0, stack/0, endpoint/0]).
 
 -type request() :: #{
     method := atom() | binary(),
@@ -50,6 +52,7 @@ The transport is a `livery_client_adapter`; the default,
     body := {full, binary()} | {stream, term()}
 }.
 -type result() :: {ok, response()} | {error, term()}.
+-type endpoint() :: binary().
 -type next() :: fun((request()) -> result()).
 -type entry() :: {module(), term()} | fun((request(), next()) -> result()).
 -type stack() :: [entry()].
@@ -187,6 +190,24 @@ retry(Opts) -> {livery_client_retry, Opts}.
 -spec circuit_breaker(map()) -> entry().
 circuit_breaker(Opts) -> {livery_client_circuit, Opts}.
 
+-doc """
+Spread requests across a pool of endpoints, with passive outlier
+ejection and lazy half-open recovery. `Opts`: `name` (required),
+`endpoints` (base URLs or a `{Module, Arg}` discovery pair), `policy`
+(`p2c` | `round_robin`), `eject_after`, `eject_for`, `fail_status`.
+With `balance` you pass paths; the chosen endpoint supplies the host.
+""".
+-spec balance(map()) -> entry().
+balance(Opts) -> {livery_client_balance, Opts}.
+
+-doc "Add an endpoint to a balance pool at runtime.".
+-spec add_endpoint(term(), endpoint()) -> ok.
+add_endpoint(Name, Endpoint) -> livery_client_balance_store:add(Name, Endpoint).
+
+-doc "Remove an endpoint from a balance pool at runtime.".
+-spec remove_endpoint(term(), endpoint()) -> ok.
+remove_endpoint(Name, Endpoint) -> livery_client_balance_store:remove(Name, Endpoint).
+
 %%====================================================================
 %% Sugar (mirrors livery_middleware, error-aware)
 %%====================================================================
@@ -250,6 +271,32 @@ full_url(Client, Path) ->
         <<>> -> Path;
         Base -> <<(strip_trailing_slash(Base))/binary, (ensure_leading_slash(Path))/binary>>
     end.
+
+-doc """
+Point a request URL at a chosen endpoint. Strips any scheme+authority
+the URL already carries and joins the endpoint with the remaining
+path+query, so the balancer owns the host. Used by `livery_client_balance`.
+""".
+-spec rebase(endpoint(), binary()) -> binary().
+rebase(Endpoint, Url) ->
+    Path = path_and_query(Url),
+    <<(strip_trailing_slash(Endpoint))/binary, Path/binary>>.
+
+%% The path+query of a URL, dropping scheme+authority if present.
+path_and_query(Url) ->
+    case binary:match(Url, <<"://">>) of
+        nomatch ->
+            ensure_leading_slash(Url);
+        {Start, Len} ->
+            Rest = binary_from(Url, Start + Len),
+            case binary:match(Rest, <<"/">>) of
+                nomatch -> <<"/">>;
+                {Slash, _} -> binary_from(Rest, Slash)
+            end
+    end.
+
+binary_from(Bin, Pos) ->
+    binary:part(Bin, Pos, byte_size(Bin) - Pos).
 
 strip_trailing_slash(B) ->
     case binary:last(B) of

--- a/src/livery_client_balance.erl
+++ b/src/livery_client_balance.erl
@@ -1,0 +1,66 @@
+-module(livery_client_balance).
+-moduledoc """
+Client layer: spread requests across a pool of endpoints.
+
+Picks an endpoint from the pool named in the opts, rewrites the request
+to target it, and records the outcome so a failing endpoint is ejected
+and a recovering one is probed back in. Selection load and health live in
+`livery_client_balance_store`. Add it with `livery_client:balance/1`.
+
+`Opts`: `name` (required), `endpoints` (a list of base URLs, or a
+`{Module, Arg}` discovery pair), `policy` (`p2c` default | `round_robin`),
+`eject_after` (consecutive failures to eject, default 5), `eject_for`
+(ms ejected before a half-open probe, default 10000), `fail_status`
+(what counts as a failure: a `fun((status()) -> boolean())` or a list of
+statuses; default treats any status `>= 500` and any `{error, _}` as a
+failure).
+""".
+
+-export([call/3]).
+
+-define(DEFAULT_EJECT_AFTER, 5).
+-define(DEFAULT_EJECT_FOR, 10000).
+
+-spec call(livery_client:request(), livery_client:next(), map()) ->
+    {ok, livery_client:response()} | {error, term()}.
+call(Req, Next, Opts) ->
+    Name = maps:get(name, Opts),
+    Endpoints = livery_client_discover:resolve(maps:get(endpoints, Opts, [])),
+    ok = livery_client_balance_store:ensure(Name, Endpoints),
+    Policy = maps:get(policy, Opts, p2c),
+    EjectFor = maps:get(eject_for, Opts, ?DEFAULT_EJECT_FOR),
+    case livery_client_balance_store:pick(Name, Policy, EjectFor) of
+        {error, no_endpoint} = Error ->
+            Error;
+        {ok, Endpoint, Token} ->
+            run(Req, Next, Opts, Name, Endpoint, Token, EjectFor)
+    end.
+
+run(Req, Next, Opts, Name, Endpoint, Token, EjectFor) ->
+    EjectAfter = maps:get(eject_after, Opts, ?DEFAULT_EJECT_AFTER),
+    Fail = fail_status(maps:get(fail_status, Opts, default)),
+    Url = livery_client:rebase(Endpoint, maps:get(url, Req)),
+    try Next(Req#{url => Url}) of
+        Result ->
+            Outcome = classify(Result, Fail),
+            livery_client_balance_store:record(Name, Endpoint, Outcome, EjectAfter, EjectFor),
+            Result
+    catch
+        Class:Reason:Stack ->
+            livery_client_balance_store:record(Name, Endpoint, err, EjectAfter, EjectFor),
+            erlang:raise(Class, Reason, Stack)
+    after
+        livery_client_balance_store:release(Token)
+    end.
+
+classify({error, _Reason}, _Fail) ->
+    err;
+classify({ok, #{status := Status}}, Fail) ->
+    case Fail(Status) of
+        true -> err;
+        false -> ok
+    end.
+
+fail_status(default) -> fun(Status) -> Status >= 500 end;
+fail_status(Fun) when is_function(Fun, 1) -> Fun;
+fail_status(List) when is_list(List) -> fun(Status) -> lists:member(Status, List) end.

--- a/src/livery_client_balance_store.erl
+++ b/src/livery_client_balance_store.erl
@@ -1,0 +1,256 @@
+-module(livery_client_balance_store).
+-moduledoc """
+Owns the ETS table backing the client load balancers.
+
+A `gen_server` that creates a public named table at startup; the
+selection logic in `livery_client_balance` reads and writes it directly
+(no per-request round trip through this process). One pool per `name`,
+with one row per endpoint:
+
+    {{ep, Name, Endpoint}, Status, Fails, Until, Inflight}
+
+`Status` is `up | ejected`. `Inflight` is a per-endpoint `atomics` ref
+holding the in-flight request count (the P2C load metric). `Until` is an
+`erlang:monotonic_time(millisecond)` deadline: while ejected, the
+endpoint rejoins only after `Until` has passed, and recovery is a single
+probe leased with an atomic compare-and-swap so concurrent callers cannot
+all probe at once. A `{{meta, Name}, RoundRobinRef}` row marks the pool's
+existence (for create-once `ensure/2`) and carries the round-robin
+counter.
+""".
+-behaviour(gen_server).
+
+-export([start_link/0, ensure/2, add/2, remove/2, reset/1]).
+-export([pick/3, record/5, release/1]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
+
+-define(TABLE, ?MODULE).
+-record(state, {}).
+-type state() :: #state{}.
+-type policy() :: p2c | round_robin.
+
+-spec start_link() -> {ok, pid()} | {error, term()}.
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-doc """
+Seed a pool from `Endpoints`, once. If the pool already exists this is a
+no-op, so a lazy call on a later request never undoes a runtime
+`remove/2` or re-adds a drained node. The cheap membership check runs in
+the caller; only a miss talks to the gen_server.
+""".
+-spec ensure(term(), [binary()]) -> ok.
+ensure(Name, Endpoints) ->
+    case ets:member(?TABLE, {meta, Name}) of
+        true -> ok;
+        false -> gen_server:call(?MODULE, {ensure, Name, Endpoints})
+    end.
+
+-doc "Add an endpoint to a pool at runtime.".
+-spec add(term(), binary()) -> ok.
+add(Name, Endpoint) ->
+    gen_server:call(?MODULE, {add, Name, Endpoint}).
+
+-doc "Remove an endpoint from a pool at runtime.".
+-spec remove(term(), binary()) -> ok.
+remove(Name, Endpoint) ->
+    gen_server:call(?MODULE, {remove, Name, Endpoint}).
+
+-doc "Forget a pool entirely.".
+-spec reset(term()) -> ok.
+reset(Name) ->
+    gen_server:call(?MODULE, {reset, Name}).
+
+-doc """
+Pick an endpoint for one request, incrementing its in-flight count.
+Returns `{ok, Endpoint, Token}` (pass `Token` to `release/1` when the
+request finishes) or `{error, no_endpoint}`. A recovering endpoint whose
+cooldown has expired is leased for a single probe via an atomic CAS;
+otherwise selection is over the healthy endpoints by `Policy`.
+""".
+-spec pick(term(), policy(), non_neg_integer()) ->
+    {ok, binary(), atomics:atomics_ref()} | {error, no_endpoint}.
+pick(Name, Policy, EjectFor) ->
+    case ets:select(?TABLE, all_spec(Name)) of
+        [] ->
+            {error, no_endpoint};
+        Rows ->
+            Now = now_ms(),
+            case lease_probe(Name, Rows, Now, EjectFor) of
+                {ok, _Ep, _Ref} = Ok ->
+                    Ok;
+                none ->
+                    pick_up(Name, Policy, Rows)
+            end
+    end.
+
+-doc "Release the in-flight slot taken by `pick/3` (safe if removed).".
+-spec release(atomics:atomics_ref()) -> ok.
+release(Ref) ->
+    atomics:sub(Ref, 1, 1),
+    ok.
+
+-doc """
+Record a request outcome against the endpoint. `ok` resets the failure
+streak and reinstates an ejected endpoint; `err` increments the streak
+and ejects at `EjectAfter`, or re-ejects a failed probe. A missing row
+(removed mid-flight) is a no-op.
+""".
+-spec record(term(), binary(), ok | err, pos_integer(), non_neg_integer()) -> ok.
+record(Name, Endpoint, Outcome, EjectAfter, EjectFor) ->
+    case ets:lookup(?TABLE, {ep, Name, Endpoint}) of
+        [] ->
+            ok;
+        [{Key, Status, Fails, _Until, Ref}] ->
+            apply_outcome(Key, Status, Fails, Ref, Outcome, EjectAfter, EjectFor)
+    end.
+
+%%====================================================================
+%% gen_server
+%%====================================================================
+
+-spec init([]) -> {ok, state()}.
+init([]) ->
+    _ = ets:new(?TABLE, [named_table, public, set, {write_concurrency, true}]),
+    {ok, #state{}}.
+
+-spec handle_call(term(), {pid(), term()}, state()) -> {reply, ok, state()}.
+handle_call({ensure, Name, Endpoints}, _From, State) ->
+    case ets:member(?TABLE, {meta, Name}) of
+        true ->
+            ok;
+        false ->
+            true = ets:insert(?TABLE, {{meta, Name}, atomics:new(1, [])}),
+            lists:foreach(fun(Ep) -> insert_endpoint(Name, Ep) end, Endpoints)
+    end,
+    {reply, ok, State};
+handle_call({add, Name, Endpoint}, _From, State) ->
+    case ets:member(?TABLE, {ep, Name, Endpoint}) of
+        true -> ok;
+        false -> insert_endpoint(Name, Endpoint)
+    end,
+    {reply, ok, State};
+handle_call({remove, Name, Endpoint}, _From, State) ->
+    true = ets:delete(?TABLE, {ep, Name, Endpoint}),
+    {reply, ok, State};
+handle_call({reset, Name}, _From, State) ->
+    true = ets:match_delete(?TABLE, {{ep, Name, '_'}, '_', '_', '_', '_'}),
+    true = ets:delete(?TABLE, {meta, Name}),
+    {reply, ok, State};
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+-spec handle_cast(term(), state()) -> {noreply, state()}.
+handle_cast(_Msg, State) -> {noreply, State}.
+
+-spec handle_info(term(), state()) -> {noreply, state()}.
+handle_info(_Info, State) -> {noreply, State}.
+
+%%====================================================================
+%% Selection
+%%====================================================================
+
+%% {Endpoint, Status, Fails, Until, Inflight} for every endpoint in Name.
+all_spec(Name) ->
+    [
+        {
+            {{ep, Name, '$1'}, '$2', '$3', '$4', '$5'},
+            [],
+            [{{'$1', '$2', '$3', '$4', '$5'}}]
+        }
+    ].
+
+%% Try to lease a single probe on the first expired-ejected endpoint, by
+%% atomically pushing its deadline forward. The winner of the CAS owns
+%% the probe; concurrent callers see 0 replacements and move on.
+lease_probe(_Name, [], _Now, _EjectFor) ->
+    none;
+lease_probe(Name, [{Ep, ejected, _F, Until, Ref} | Rest], Now, EjectFor) when Until =< Now ->
+    case cas_lease(Name, Ep, Now, EjectFor) of
+        1 ->
+            atomics:add(Ref, 1, 1),
+            {ok, Ep, Ref};
+        0 ->
+            lease_probe(Name, Rest, Now, EjectFor)
+    end;
+lease_probe(Name, [_Row | Rest], Now, EjectFor) ->
+    lease_probe(Name, Rest, Now, EjectFor).
+
+%% Bind the whole row in vars and keep the key untouched ('$1'): a bare
+%% tuple in a match-spec body is read as an action, so a tuple Name cannot
+%% be reconstructed there. {const, Key} injects it literally in the guard.
+cas_lease(Name, Ep, Now, EjectFor) ->
+    Key = {ep, Name, Ep},
+    NewUntil = Now + EjectFor,
+    ets:select_replace(?TABLE, [
+        {
+            {'$1', ejected, '$2', '$3', '$4'},
+            [{'=:=', '$1', {const, Key}}, {'=<', '$3', Now}],
+            [{{'$1', ejected, '$2', NewUntil, '$4'}}]
+        }
+    ]).
+
+pick_up(Name, Policy, Rows) ->
+    case [{Ep, Ref, load(Ref)} || {Ep, up, _F, _U, Ref} <- Rows] of
+        [] ->
+            {error, no_endpoint};
+        Ups ->
+            {Ep, Ref} = choose(Policy, Name, Ups),
+            atomics:add(Ref, 1, 1),
+            {ok, Ep, Ref}
+    end.
+
+choose(round_robin, Name, Ups) ->
+    [{_, RRRef}] = ets:lookup(?TABLE, {meta, Name}),
+    Idx = atomics:add_get(RRRef, 1, 1),
+    {Ep, Ref, _Load} = lists:nth((Idx rem length(Ups)) + 1, Ups),
+    {Ep, Ref};
+choose(_P2c, _Name, [{Ep, Ref, _Load}]) ->
+    {Ep, Ref};
+choose(_P2c, _Name, Ups) ->
+    N = length(Ups),
+    I = rand:uniform(N),
+    J0 = rand:uniform(N - 1),
+    J =
+        case J0 >= I of
+            true -> J0 + 1;
+            false -> J0
+        end,
+    {Ep, Ref, _} = lower_load(lists:nth(I, Ups), lists:nth(J, Ups)),
+    {Ep, Ref}.
+
+lower_load({_, _, La} = A, {_, _, Lb} = B) ->
+    case La =< Lb of
+        true -> A;
+        false -> B
+    end.
+
+load(Ref) -> atomics:get(Ref, 1).
+
+%%====================================================================
+%% Outcome accounting
+%%====================================================================
+
+apply_outcome(Key, _Status, _Fails, Ref, ok, _EjectAfter, _EjectFor) ->
+    true = ets:insert(?TABLE, {Key, up, 0, 0, Ref}),
+    ok;
+apply_outcome(Key, up, Fails, Ref, err, EjectAfter, EjectFor) ->
+    case Fails + 1 >= EjectAfter of
+        true -> true = ets:insert(?TABLE, {Key, ejected, 0, now_ms() + EjectFor, Ref});
+        false -> true = ets:insert(?TABLE, {Key, up, Fails + 1, 0, Ref})
+    end,
+    ok;
+apply_outcome(Key, ejected, Fails, Ref, err, _EjectAfter, EjectFor) ->
+    true = ets:insert(?TABLE, {Key, ejected, Fails, now_ms() + EjectFor, Ref}),
+    ok.
+
+%%====================================================================
+%% Internals
+%%====================================================================
+
+insert_endpoint(Name, Endpoint) ->
+    true = ets:insert(?TABLE, {{ep, Name, Endpoint}, up, 0, 0, atomics:new(1, [])}),
+    ok.
+
+now_ms() ->
+    erlang:monotonic_time(millisecond).

--- a/src/livery_client_discover.erl
+++ b/src/livery_client_discover.erl
@@ -1,0 +1,29 @@
+-module(livery_client_discover).
+-moduledoc """
+Behaviour for resolving a balance pool's endpoints.
+
+A provider turns some `Arg` into the list of endpoint base URLs the
+balancer should spread across. The shipped provider,
+`livery_client_discover_static`, just returns a fixed list; live
+providers (periodic DNS, a registry watcher) can implement the same
+callback later without touching the balancer.
+
+The `endpoints` option of `livery_client:balance/1` is either a plain
+list (sugar for the static provider) or `{Module, Arg}` naming a
+provider.
+""".
+
+-export([resolve/1]).
+
+-export_type([endpoints/0]).
+
+-type endpoints() :: [binary()] | {module(), term()}.
+
+-callback endpoints(Arg :: term()) -> [binary()].
+
+-doc "Resolve an `endpoints` option to a concrete list of base URLs.".
+-spec resolve(endpoints()) -> [binary()].
+resolve({Module, Arg}) when is_atom(Module) ->
+    Module:endpoints(Arg);
+resolve(List) when is_list(List) ->
+    List.

--- a/src/livery_client_discover_static.erl
+++ b/src/livery_client_discover_static.erl
@@ -1,0 +1,13 @@
+-module(livery_client_discover_static).
+-moduledoc """
+The default discovery provider: a fixed list of endpoints.
+
+`livery_client:balance/1` uses it implicitly when `endpoints` is a plain
+list, so you rarely name it directly.
+""".
+-behaviour(livery_client_discover).
+
+-export([endpoints/1]).
+
+-spec endpoints([binary()]) -> [binary()].
+endpoints(List) when is_list(List) -> List.

--- a/src/livery_sup.erl
+++ b/src/livery_sup.erl
@@ -3,8 +3,9 @@
 Top-level Livery supervisor.
 
 Supervises `livery_req_sup`, the per-request worker registry and
-concurrency cap, and `livery_ratelimit_store`, the owner of the
-rate-limiter ETS table. Listeners are owned by their wire libraries
+concurrency cap, and the ETS-table owners `livery_ratelimit_store`,
+`livery_client_circuit_store`, and `livery_client_balance_store`.
+Listeners are owned by their wire libraries
 (`h1`/`h2`/`quic`); `livery_service` starts and stops them per
 service rather than under this supervisor.
 """.
@@ -20,28 +21,20 @@ start_link() ->
 -spec init([]) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
 init([]) ->
     SupFlags = #{strategy => one_for_one, intensity => 5, period => 10},
-    ReqSup = #{
-        id => livery_req_sup,
-        start => {livery_req_sup, start_link, []},
+    Children = [
+        worker(livery_req_sup),
+        worker(livery_ratelimit_store),
+        worker(livery_client_circuit_store),
+        worker(livery_client_balance_store)
+    ],
+    {ok, {SupFlags, Children}}.
+
+worker(Module) ->
+    #{
+        id => Module,
+        start => {Module, start_link, []},
         restart => permanent,
         shutdown => 5000,
         type => worker,
-        modules => [livery_req_sup]
-    },
-    RateLimitStore = #{
-        id => livery_ratelimit_store,
-        start => {livery_ratelimit_store, start_link, []},
-        restart => permanent,
-        shutdown => 5000,
-        type => worker,
-        modules => [livery_ratelimit_store]
-    },
-    CircuitStore = #{
-        id => livery_client_circuit_store,
-        start => {livery_client_circuit_store, start_link, []},
-        restart => permanent,
-        shutdown => 5000,
-        type => worker,
-        modules => [livery_client_circuit_store]
-    },
-    {ok, {SupFlags, [ReqSup, RateLimitStore, CircuitStore]}}.
+        modules => [Module]
+    }.

--- a/test/livery_client_balance_SUITE.erl
+++ b/test/livery_client_balance_SUITE.erl
@@ -1,0 +1,244 @@
+%% @doc Drives livery_client's balance layer against real loopback Livery
+%% servers (real hackney, no external network), plus store unit tests.
+-module(livery_client_balance_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([
+    spreads_load/1,
+    fails_over_past_dead/1,
+    ejects_on_5xx/1,
+    half_open_recovers/1,
+    remove_endpoint_sticks/1,
+    store_p2c_least_loaded/1,
+    store_round_robin/1,
+    store_eject_lifecycle/1,
+    store_single_probe/1
+]).
+
+all() ->
+    [
+        spreads_load,
+        fails_over_past_dead,
+        ejects_on_5xx,
+        half_open_recovers,
+        remove_endpoint_sticks,
+        store_p2c_least_loaded,
+        store_round_robin,
+        store_eject_lifecycle,
+        store_single_probe
+    ].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(livery),
+    {ok, _} = application:ensure_all_started(hackney),
+    A = start_replica(a),
+    B = start_replica(b),
+    C = start_replica(c),
+    [{a, A}, {b, B}, {c, C} | Config].
+
+end_per_suite(Config) ->
+    lists:foreach(
+        fun(Key) -> livery:stop_service(maps:get(pid, ?config(Key, Config))) end,
+        [a, b, c]
+    ),
+    ok.
+
+%% Start one loopback replica tagged with its id, returning its base URL,
+%% pid, and shared failure counter.
+start_replica(Id) ->
+    Counter = atomics:new(1, [{signed, false}]),
+    Router = livery_router:compile([
+        {<<"GET">>, <<"/id">>, fun handle_id/1},
+        {<<"GET">>, <<"/flaky">>, fun handle_flaky/1},
+        {<<"GET">>, <<"/down">>, fun handle_down/1}
+    ]),
+    {ok, Pid} = livery:start_service(#{
+        http => #{port => 0},
+        config => #{id => Id, counter => Counter},
+        router => Router
+    }),
+    true = unlink(Pid),
+    Port = maps:get(h1, livery:which_listeners(Pid)),
+    Base = iolist_to_binary([<<"http://127.0.0.1:">>, integer_to_binary(Port)]),
+    #{pid => Pid, base => Base, counter => Counter}.
+
+%%====================================================================
+%% Handlers
+%%====================================================================
+
+handle_id(Req) ->
+    livery_resp:text(200, atom_to_binary(livery_req:config(id, Req), utf8)).
+
+%% Fail the first two calls with 503, then succeed.
+handle_flaky(Req) ->
+    Ref = livery_req:config(counter, Req),
+    case atomics:add_get(Ref, 1, 1) of
+        N when N =< 2 -> livery_resp:text(503, <<"busy">>);
+        _ -> livery_resp:text(200, <<"ok">>)
+    end.
+
+handle_down(_Req) -> livery_resp:text(503, <<"down">>).
+
+%%====================================================================
+%% Integration cases
+%%====================================================================
+
+spreads_load(Config) ->
+    Client = balance_client(spread_pool, [base(a, Config), base(b, Config)], #{
+        policy => round_robin
+    }),
+    Bodies = [body_of(Client, <<"/id">>) || _ <- lists:seq(1, 6)],
+    ?assert(lists:member(<<"a">>, Bodies)),
+    ?assert(lists:member(<<"b">>, Bodies)).
+
+fails_over_past_dead(Config) ->
+    Client = livery_client:new(#{
+        stack => [
+            livery_client:retry(#{max => 3}),
+            livery_client:balance(#{
+                name => failover_pool,
+                endpoints => [dead_base(), base(a, Config)],
+                policy => round_robin,
+                eject_after => 2
+            })
+        ]
+    }),
+    {ok, Resp} = livery_client:get(Client, <<"/id">>),
+    ?assertEqual(200, livery_client:status(Resp)),
+    ?assertEqual({full, <<"a">>}, livery_client:body(Resp)).
+
+ejects_on_5xx(Config) ->
+    Client = balance_client(eject_pool, [base(a, Config)], #{
+        eject_after => 2, eject_for => 60000
+    }),
+    %% A 503 is a valid response the caller still sees, but it counts as a
+    %% failure for health, so two of them eject the only endpoint.
+    {ok, R1} = livery_client:get(Client, <<"/down">>),
+    ?assertEqual(503, livery_client:status(R1)),
+    {ok, R2} = livery_client:get(Client, <<"/down">>),
+    ?assertEqual(503, livery_client:status(R2)),
+    ?assertEqual({error, no_endpoint}, livery_client:get(Client, <<"/down">>)).
+
+half_open_recovers(Config) ->
+    atomics:put(maps:get(counter, ?config(c, Config)), 1, 0),
+    Client = balance_client(recover_pool, [base(c, Config)], #{
+        eject_after => 2, eject_for => 80
+    }),
+    %% Two 503s eject it; while ejected it fast-fails with no_endpoint.
+    {ok, _} = livery_client:get(Client, <<"/flaky">>),
+    {ok, _} = livery_client:get(Client, <<"/flaky">>),
+    ?assertEqual({error, no_endpoint}, livery_client:get(Client, <<"/flaky">>)),
+    %% After the cooldown one request is leased as a probe; the endpoint is
+    %% healthy now, so it reinstates.
+    timer:sleep(150),
+    {ok, Resp} = livery_client:get(Client, <<"/flaky">>),
+    ?assertEqual(200, livery_client:status(Resp)),
+    ?assertEqual(200, livery_client:status(element(2, livery_client:get(Client, <<"/flaky">>)))).
+
+remove_endpoint_sticks(Config) ->
+    Client = balance_client(remove_pool, [base(a, Config), base(b, Config)], #{
+        policy => round_robin
+    }),
+    %% Warm the pool, then drop b at runtime.
+    _ = body_of(Client, <<"/id">>),
+    ok = livery_client:remove_endpoint(remove_pool, base(b, Config)),
+    Bodies = [body_of(Client, <<"/id">>) || _ <- lists:seq(1, 6)],
+    %% A later request lazily re-ensures the pool, but create-once means b
+    %% does not come back.
+    ?assert(lists:member(<<"a">>, Bodies)),
+    ?assertNot(lists:member(<<"b">>, Bodies)).
+
+%%====================================================================
+%% Store unit cases
+%%====================================================================
+
+store_p2c_least_loaded(_Config) ->
+    Name = unique(p2c),
+    ok = livery_client_balance_store:ensure(Name, [<<"u1">>, <<"u2">>]),
+    %% First pick lands on either; the second must avoid the now-loaded one.
+    {ok, Ep1, T1} = livery_client_balance_store:pick(Name, p2c, 1000),
+    {ok, Ep2, T2} = livery_client_balance_store:pick(Name, p2c, 1000),
+    ?assertNotEqual(Ep1, Ep2),
+    livery_client_balance_store:release(T1),
+    livery_client_balance_store:release(T2),
+    livery_client_balance_store:reset(Name).
+
+store_round_robin(_Config) ->
+    Name = unique(rr),
+    ok = livery_client_balance_store:ensure(Name, [<<"x">>, <<"y">>, <<"z">>]),
+    Picks = [
+        begin
+            {ok, Ep, T} = livery_client_balance_store:pick(Name, round_robin, 1000),
+            livery_client_balance_store:release(T),
+            Ep
+        end
+     || _ <- lists:seq(1, 6)
+    ],
+    Counts = [length([E || E <- Picks, E =:= Ep]) || Ep <- [<<"x">>, <<"y">>, <<"z">>]],
+    ?assertEqual([2, 2, 2], Counts),
+    livery_client_balance_store:reset(Name).
+
+store_eject_lifecycle(_Config) ->
+    Name = unique(life),
+    ok = livery_client_balance_store:ensure(Name, [<<"only">>]),
+    ok = livery_client_balance_store:record(Name, <<"only">>, err, 2, 50),
+    ok = livery_client_balance_store:record(Name, <<"only">>, err, 2, 50),
+    ?assertEqual({error, no_endpoint}, livery_client_balance_store:pick(Name, p2c, 50)),
+    timer:sleep(70),
+    {ok, <<"only">>, T} = livery_client_balance_store:pick(Name, p2c, 50),
+    livery_client_balance_store:release(T),
+    ok = livery_client_balance_store:record(Name, <<"only">>, ok, 2, 50),
+    {ok, <<"only">>, T2} = livery_client_balance_store:pick(Name, p2c, 50),
+    livery_client_balance_store:release(T2),
+    livery_client_balance_store:reset(Name).
+
+store_single_probe(_Config) ->
+    Name = unique(probe),
+    ok = livery_client_balance_store:ensure(Name, [<<"one">>]),
+    ok = livery_client_balance_store:record(Name, <<"one">>, err, 2, 50),
+    ok = livery_client_balance_store:record(Name, <<"one">>, err, 2, 50),
+    timer:sleep(70),
+    Self = self(),
+    [
+        spawn(fun() ->
+            Self ! {probe, livery_client_balance_store:pick(Name, p2c, 1000)}
+        end)
+     || _ <- lists:seq(1, 20)
+    ],
+    Results = [
+        receive
+            {probe, R} -> R
+        after 5000 -> timeout
+        end
+     || _ <- lists:seq(1, 20)
+    ],
+    Wins = [R || {ok, _, _} = R <- Results],
+    ?assertEqual(1, length(Wins)),
+    livery_client_balance_store:reset(Name).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+balance_client(Name, Endpoints, Extra) ->
+    Opts = maps:merge(#{name => Name, endpoints => Endpoints}, Extra),
+    livery_client:new(#{stack => [livery_client:balance(Opts)]}).
+
+body_of(Client, Path) ->
+    {ok, Resp} = livery_client:get(Client, Path),
+    {full, Body} = livery_client:body(Resp),
+    Body.
+
+base(Key, Config) -> maps:get(base, ?config(Key, Config)).
+
+unique(Tag) -> {Tag, erlang:unique_integer()}.
+
+%% A loopback port with nothing listening, so connects are refused.
+dead_base() ->
+    {ok, LSock} = gen_tcp:listen(0, [{ip, {127, 0, 0, 1}}]),
+    {ok, Port} = inet:port(LSock),
+    gen_tcp:close(LSock),
+    iolist_to_binary([<<"http://127.0.0.1:">>, integer_to_binary(Port)]).


### PR DESCRIPTION
Phase 4 of the Axum + Tower + Hyper parity work: Tower's `balance`/`discover`, the last closeable structural gap. The client could only target a single `base_url`; this lets it spread across a pool of replicas with load and health awareness.

## What

- `livery_client:balance/1`: a layer over a pool of endpoints. Pass paths; the chosen endpoint supplies the host.
- Selection: power-of-two-choices least-loaded by default (in-flight count via per-endpoint atomics), `round_robin` optional.
- Health: passive outlier ejection (consecutive failures, where a failure is any `{error, _}` or a `>= 500` response, configurable via `fail_status`), then lazy half-open recovery. After the cooldown, one request is leased as a probe via an `ets:select_replace` CAS so exactly one caller probes under load; stack `retry` above `balance` and that probe failure is retried onto a healthy endpoint.
- Runtime pool changes: `add_endpoint/2`, `remove_endpoint/2`. `endpoints` seeds the pool once (create-once), then add/remove are authoritative.
- Discovery: `endpoints` may be a list or a `{Module, Arg}` `livery_client_discover` pair; static provider shipped.
- State in `livery_client_balance_store`, a supervised ETS owner alongside the rate-limit and circuit stores.

## Docs

New guide (Load-balance outbound requests), a pointer from the outbound guide, and a concept note in adapters.

## Checks

fmt, compile, lint, xref, dialyzer clean. eunit 417. Full ct 175, including a new balance SUITE (9): spread, failover past a dead endpoint, 5xx ejection, half-open recovery, removal stickiness, and store unit tests for P2C, round-robin, the eject/probe/reinstate lifecycle, and the concurrent single-probe lease.