### PR TITLE
Add a livery/cowboy/bandit benchmark comparison

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -49,6 +49,43 @@ Loopback, single host (Apple silicon); absolute numbers are
 host-specific. Use them only as a same-host before/after baseline,
 not as cross-environment targets.
 
+## Cross-server comparison (livery vs cowboy vs bandit)
+
+`bench/compare.sh` benchmarks the same `GET / -> {"ok":true}` endpoint on
+**livery**, **cowboy**, and **bandit** over HTTP/1.1. Each server runs out
+of process on its own port and is driven by [`wrk`](https://github.com/wg/wrk),
+so all three are treated identically and the load generator never shares a
+VM with the server under test. Livery and cowboy boot under one BEAM (via
+`livery_bench:serve/3`); bandit boots under Elixir, pulling itself in with
+`Mix.install` on first run (needs network and a one-time compile).
+
+```
+bench/compare.sh                       # 4 threads, 64 conns, 10s
+DUR=20 CONN=128 THREADS=8 bench/compare.sh
+```
+
+Requires `wrk`, `elixir`, `rebar3`, and `curl` on the PATH.
+
+Indicative numbers (loopback, Apple silicon, 4t / 64c / 8s):
+
+| Server | req/s | p50 | p99 |
+|---|---|---|---|
+| livery | ~104k | 0.57 ms | 1.60 ms |
+| cowboy | ~142k | 0.36 ms | 1.23 ms |
+| bandit | ~148k | 0.33 ms | 1.59 ms |
+
+Same-host, single run; absolute numbers are host-specific. Two things to
+keep in mind when reading them:
+
+- Livery serves H1 full bodies with **chunked** transfer-encoding (it has
+  no `send_full/5` coalescing on `livery_h1`), while cowboy and bandit send
+  `content-length`. `wrk` handles both, but the extra framing and the
+  separate header/body writes cost livery some throughput here. Coalescing
+  H1 full responses is a worthwhile follow-up.
+- Livery spawns a worker process per request (the `cowboy_loop` analogue),
+  which trades a little raw throughput for the ability to block/`receive`
+  in a handler.
+
 ## p99 regression gate
 
 Capture a baseline on your benchmark host and compare future runs:

--- a/bench/compare.sh
+++ b/bench/compare.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Fair cross-server HTTP/1.1 benchmark: livery vs cowboy vs bandit.
+#
+# Each server runs out of process on its own port and is driven by `wrk`,
+# so all three are treated identically and the load generator never shares
+# a VM with the server under test. Livery and cowboy boot under one BEAM
+# (via livery_bench:serve/3 on the bench profile code path); bandit boots
+# under Elixir (Mix.install pulls it on first run, needs network).
+#
+# Usage:
+#   bench/compare.sh                 # 4 threads, 64 conns, 10s
+#   DUR=20 CONN=128 THREADS=8 bench/compare.sh
+#
+# Requires: wrk, elixir, rebar3 (and curl).
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+DUR="${DUR:-10}"
+CONN="${CONN:-64}"
+THREADS="${THREADS:-4}"
+LPORT="${LPORT:-9101}"
+CPORT="${CPORT:-9102}"
+BPORT="${BPORT:-9103}"
+
+for tool in wrk curl elixir rebar3; do
+    command -v "$tool" >/dev/null 2>&1 || { echo "missing required tool: $tool" >&2; exit 1; }
+done
+
+echo "Compiling bench profile..."
+rebar3 as bench compile >/dev/null
+# App ebins (deps + livery) come from ERL_LIBS; the bench modules
+# (livery_bench, bench_cowboy_h) compile to livery/bench, added with -pa.
+BENCH_LIBS="$PWD/_build/bench/lib"
+BENCH_PA="$BENCH_LIBS/livery/bench"
+
+wait_ready() { # port
+    for _ in $(seq 1 100); do
+        curl -fsS "http://127.0.0.1:$1/" >/dev/null 2>&1 && return 0
+        sleep 0.2
+    done
+    return 1
+}
+
+drive() { # label port
+    echo
+    echo "=== $1 (http/1.1, ${THREADS}t/${CONN}c/${DUR}s) ==="
+    wrk -t"$THREADS" -c"$CONN" -d"${DUR}s" --latency "http://127.0.0.1:$2/"
+}
+
+bench_beam() { # label server port
+    ERL_LIBS="$BENCH_LIBS" erl -noshell -pa "$BENCH_PA" \
+        -eval "livery_bench:serve($2, h1, $3)" >/dev/null 2>&1 &
+    local pid=$!
+    if wait_ready "$3"; then drive "$1" "$3"; else echo "$1 did not become ready" >&2; fi
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+}
+
+bench_bandit() { # port
+    elixir bench/servers/bandit_server.exs "$1" >/dev/null 2>&1 &
+    local pid=$!
+    if wait_ready "$1"; then drive "bandit" "$1"; else echo "bandit did not become ready (first run needs network for Mix.install)" >&2; fi
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+}
+
+bench_beam "livery" livery "$LPORT"
+bench_beam "cowboy" cowboy "$CPORT"
+bench_bandit "$BPORT"
+
+echo
+echo "Done. Note: livery serves H1 full bodies with chunked transfer-encoding;"
+echo "cowboy and bandit send content-length. wrk handles both."

--- a/bench/livery_bench.erl
+++ b/bench/livery_bench.erl
@@ -24,7 +24,7 @@ pass it to `compare/2` to gate future runs.
 
 -export([run/0, run/1, run_all/0, run_all/1, compare/2, report/1]).
 -export([profile/2, sweep/3, compare_servers/0, compare_servers/1]).
--export([compare_servers_to_file/2]).
+-export([compare_servers_to_file/2, serve/3]).
 
 -define(RAW_REQUEST, <<"GET / HTTP/1.1\r\nHost: bench\r\n\r\n">>).
 
@@ -205,6 +205,19 @@ report(M) ->
             maps:get(max_us, M) / 1000
         ]
     ).
+
+%% @doc Start a reference listener on a fixed port and block forever, so
+%% an external load tool (wrk) can drive it out of process. `Server' is
+%% `livery' or `cowboy'. Launch it under its own BEAM and kill that BEAM
+%% to stop; this never returns. Used by `bench/compare.sh'.
+serve(Server, Protocol, Port) ->
+    {ok, _} = application:ensure_all_started(livery),
+    {ok, _} = ensure_started(Server, Protocol),
+    {ok, _Listener} = start_listener(Server, Protocol, #{port => Port}),
+    io:format("READY ~p ~p ~p~n", [Server, Protocol, Port]),
+    receive
+        stop -> ok
+    end.
 
 %%====================================================================
 %% Listener lifecycle per protocol
@@ -439,11 +452,17 @@ await_h3(Conn, StreamId) ->
         {error, timeout}
     end.
 
-%% H1: read headers, then exactly Content-Length body bytes (keep-alive).
+%% H1: read one full response and keep the connection alive. The body is
+%% framed either by Content-Length or by chunked transfer-encoding (livery
+%% chunk-frames full bodies over H1); handle both so the next keep-alive
+%% request starts from a clean buffer.
 read_response(Sock, Buf) ->
     case binary:split(Buf, <<"\r\n\r\n">>) of
         [Headers, Rest] ->
-            read_body(Sock, Rest, content_length(Headers));
+            case is_chunked(Headers) of
+                true -> read_chunked(Sock, Rest);
+                false -> read_body(Sock, Rest, content_length(Headers))
+            end;
         [_] ->
             case gen_tcp:recv(Sock, 0, 5000) of
                 {ok, Data} -> read_response(Sock, <<Buf/binary, Data/binary>>);
@@ -458,6 +477,21 @@ read_body(Sock, Body, Len) ->
         {ok, Data} -> read_body(Sock, <<Body/binary, Data/binary>>, Len);
         {error, _} = E -> E
     end.
+
+%% Read chunks until the terminating zero-length chunk ("0\r\n\r\n").
+read_chunked(Sock, Buf) ->
+    case binary:match(Buf, <<"0\r\n\r\n">>) of
+        nomatch ->
+            case gen_tcp:recv(Sock, 0, 5000) of
+                {ok, Data} -> read_chunked(Sock, <<Buf/binary, Data/binary>>);
+                {error, _} = E -> E
+            end;
+        _ ->
+            ok
+    end.
+
+is_chunked(Headers) ->
+    binary:match(string:lowercase(Headers), <<"transfer-encoding: chunked">>) =/= nomatch.
 
 content_length(Headers) ->
     Lower = string:lowercase(Headers),

--- a/bench/servers/bandit_server.exs
+++ b/bench/servers/bandit_server.exs
@@ -1,0 +1,34 @@
+# Reference Bandit server for the cross-server benchmark.
+#
+# Serves the same endpoint as the livery/cowboy reference handlers:
+# GET / -> 200 application/json {"ok":true} over HTTP/1.1.
+#
+# Run: elixir bench/servers/bandit_server.exs <port>
+# Pulls Bandit (and Plug, Thousand Island) via Mix.install on first run,
+# which needs network access; compiled artifacts are cached afterwards.
+
+port =
+  case System.argv() do
+    [p | _] -> String.to_integer(p)
+    [] -> 9103
+  end
+
+Mix.install([:bandit])
+
+defmodule BenchPlug do
+  @behaviour Plug
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(conn, _opts) do
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.send_resp(200, ~s({"ok":true}))
+  end
+end
+
+{:ok, _} = Bandit.start_link(plug: BenchPlug, scheme: :http, port: port)
+IO.puts("READY bandit http #{port}")
+Process.sleep(:infinity)


### PR DESCRIPTION
Adds a fair cross-server HTTP/1.1 benchmark and fixes the in-VM driver so the existing harness runs on livery.

## What

- `bench/compare.sh` — drives the same `GET / -> {"ok":true}` endpoint on **livery**, **cowboy**, and **bandit** with `wrk`. Each server runs out of process on its own port, so all three are treated identically and the load generator never shares a VM with the server under test.
- `bench/servers/bandit_server.exs` — the Bandit (Elixir) reference server, pulled in with `Mix.install` on first run.
- `livery_bench:serve/3` — boots a livery or cowboy reference listener and blocks, for out-of-process launching.
- Driver fix: the in-VM H1 reader only understood `content-length`. Livery serves H1 full bodies as **chunked** (no `send_full/5` on `livery_h1`), which desynced keep-alive and crashed runs under load; the reader now handles chunked too.

## Numbers (loopback, Apple silicon, 4t/64c/8s)

| Server | req/s | p50 | p99 |
|---|---|---|---|
| livery | ~104k | 0.57 ms | 1.60 ms |
| cowboy | ~142k | 0.36 ms | 1.23 ms |
| bandit | ~148k | 0.33 ms | 1.59 ms |

Two honest caveats (documented in `bench/README.md`): livery chunk-frames H1 full bodies where cowboy/bandit send `content-length` (coalescing H1 full responses is a worthwhile follow-up), and livery spawns a worker process per request.

Bench-profile only; no `src/` change.