### PR TITLE
Coalesce H1 full responses into one content-length write

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -70,21 +70,18 @@ Indicative numbers (loopback, Apple silicon, 4t / 64c / 8s):
 
 | Server | req/s | p50 | p99 |
 |---|---|---|---|
-| livery | ~104k | 0.57 ms | 1.60 ms |
-| cowboy | ~142k | 0.36 ms | 1.23 ms |
-| bandit | ~148k | 0.33 ms | 1.59 ms |
+| livery | ~129k | 0.46 ms | 1.31 ms |
+| cowboy | ~142k | 0.36 ms | 1.22 ms |
+| bandit | ~151k | 0.33 ms | 1.24 ms |
 
-Same-host, single run; absolute numbers are host-specific. Two things to
-keep in mind when reading them:
+Same-host, single run; absolute numbers are host-specific. Notes:
 
-- Livery serves H1 full bodies with **chunked** transfer-encoding (it has
-  no `send_full/5` coalescing on `livery_h1`), while cowboy and bandit send
-  `content-length`. `wrk` handles both, but the extra framing and the
-  separate header/body writes cost livery some throughput here. Coalescing
-  H1 full responses is a worthwhile follow-up.
-- Livery spawns a worker process per request (the `cowboy_loop` analogue),
-  which trades a little raw throughput for the ability to block/`receive`
-  in a handler.
+- Livery now coalesces H1 full responses into a single `content-length`
+  write (`livery_h1:send_full/5` -> `h1:respond/5`); earlier it sent them
+  as chunked over two writes, which cost ~20% throughput here.
+- The remaining gap is largely livery's worker process per request (the
+  `cowboy_loop` analogue), which trades a little raw throughput for the
+  ability to block/`receive` in a handler.
 
 ## p99 regression gate
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -52,36 +52,54 @@ not as cross-environment targets.
 ## Cross-server comparison (livery vs cowboy vs bandit)
 
 `bench/compare.sh` benchmarks the same `GET / -> {"ok":true}` endpoint on
-**livery**, **cowboy**, and **bandit** over HTTP/1.1. Each server runs out
-of process on its own port and is driven by [`wrk`](https://github.com/wg/wrk),
+**livery**, **cowboy**, and **bandit** over HTTP/1.1 (cleartext) and
+HTTP/2 (over TLS, ALPN-negotiated - the way h2 is actually deployed). Each
+server runs out of process on its own port and is driven by an external
+client ([`wrk`](https://github.com/wg/wrk) for H1,
+[`h2load`](https://nghttp2.org/documentation/h2load-howto.html) for H2),
 so all three are treated identically and the load generator never shares a
 VM with the server under test. Livery and cowboy boot under one BEAM (via
 `livery_bench:serve/3`); bandit boots under Elixir, pulling itself in with
-`Mix.install` on first run (needs network and a one-time compile).
+`Mix.install` on first run (needs network and a one-time compile). TLS uses
+the vendored self-signed test certs.
 
 ```
 bench/compare.sh                       # 4 threads, 64 conns, 10s
 DUR=20 CONN=128 THREADS=8 bench/compare.sh
 ```
 
-Requires `wrk`, `elixir`, `rebar3`, and `curl` on the PATH.
+Requires `wrk`, `h2load`, `elixir`, `rebar3`, and `curl` on the PATH.
 
 Indicative numbers (loopback, Apple silicon, 4t / 64c / 8s):
 
+**HTTP/1.1 (cleartext, wrk)**
+
 | Server | req/s | p50 | p99 |
 |---|---|---|---|
-| livery | ~129k | 0.46 ms | 1.31 ms |
-| cowboy | ~142k | 0.36 ms | 1.22 ms |
-| bandit | ~151k | 0.33 ms | 1.24 ms |
+| livery | ~130k | 0.45 ms | 1.26 ms |
+| cowboy | ~142k | 0.36 ms | 1.11 ms |
+| bandit | ~147k | 0.34 ms | 1.30 ms |
+
+**HTTP/2 over TLS (h2load, 32 streams/conn)**
+
+| Server | req/s | errors |
+|---|---|---|
+| livery | ~154k | 0 |
+| bandit | ~139k | 0 |
+| cowboy | ~80k | resets under load |
 
 Same-host, single run; absolute numbers are host-specific. Notes:
 
-- Livery now coalesces H1 full responses into a single `content-length`
-  write (`livery_h1:send_full/5` -> `h1:respond/5`); earlier it sent them
-  as chunked over two writes, which cost ~20% throughput here.
-- The remaining gap is largely livery's worker process per request (the
-  `cowboy_loop` analogue), which trades a little raw throughput for the
-  ability to block/`receive` in a handler.
+- **H1**: livery now coalesces full responses into a single
+  `content-length` write (`livery_h1:send_full/5` -> `h1:respond/5`);
+  earlier it sent them chunked over two writes, which cost ~20% here. The
+  small remaining gap is largely livery's worker process per request (the
+  `cowboy_loop` analogue), traded for the ability to block/`receive` in a
+  handler.
+- **H2**: livery is fastest of the three over TLS (its H2 adapter already
+  coalesces via `h2:respond/5`). Cowboy's HTTP/2 returns fewer req/s and
+  resets a fraction of streams under `h2load`'s stream churn (its built-in
+  HTTP/2 flow-rate protection), so its number is noisier.
 
 ## p99 regression gate
 

--- a/bench/compare.sh
+++ b/bench/compare.sh
@@ -1,18 +1,21 @@
 #!/usr/bin/env bash
 #
-# Fair cross-server HTTP/1.1 benchmark: livery vs cowboy vs bandit.
+# Fair cross-server benchmark: livery vs cowboy vs bandit, over HTTP/1.1
+# (cleartext) and HTTP/2 (over TLS, ALPN-negotiated - the way h2 is
+# actually deployed).
 #
-# Each server runs out of process on its own port and is driven by `wrk`,
-# so all three are treated identically and the load generator never shares
-# a VM with the server under test. Livery and cowboy boot under one BEAM
-# (via livery_bench:serve/3 on the bench profile code path); bandit boots
-# under Elixir (Mix.install pulls it on first run, needs network).
+# Each server runs out of process on its own port and is driven by an
+# external client (`wrk` for H1, `h2load` for H2), so all three are
+# treated identically and the load generator never shares a VM with the
+# server under test. Livery and cowboy boot under one BEAM (via
+# livery_bench:serve/3); bandit boots under Elixir (Mix.install on first
+# run, needs network). TLS uses the vendored self-signed test certs.
 #
 # Usage:
 #   bench/compare.sh                 # 4 threads, 64 conns, 10s
 #   DUR=20 CONN=128 THREADS=8 bench/compare.sh
 #
-# Requires: wrk, elixir, rebar3 (and curl).
+# Requires: wrk, h2load, elixir, rebar3 (and curl).
 
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -20,11 +23,11 @@ cd "$(dirname "$0")/.."
 DUR="${DUR:-10}"
 CONN="${CONN:-64}"
 THREADS="${THREADS:-4}"
-LPORT="${LPORT:-9101}"
-CPORT="${CPORT:-9102}"
-BPORT="${BPORT:-9103}"
+STREAMS="${STREAMS:-32}"   # h2 max concurrent streams per connection
+CERT="$PWD/test/certs/cert.pem"
+KEY="$PWD/test/certs/key.pem"
 
-for tool in wrk curl elixir rebar3; do
+for tool in wrk h2load curl elixir rebar3; do
     command -v "$tool" >/dev/null 2>&1 || { echo "missing required tool: $tool" >&2; exit 1; }
 done
 
@@ -35,41 +38,57 @@ rebar3 as bench compile >/dev/null
 BENCH_LIBS="$PWD/_build/bench/lib"
 BENCH_PA="$BENCH_LIBS/livery/bench"
 
-wait_ready() { # port
+# The server-side listener protocol for each benchmark mode.
+serve_proto() { case "$1" in h1) echo h1 ;; h2) echo h2tls ;; esac; }
+
+wait_ready() { # mode port
+    local url
+    case "$1" in h1) url="http://127.0.0.1:$2/" ;; h2) url="https://127.0.0.1:$2/" ;; esac
     for _ in $(seq 1 100); do
-        curl -fsS "http://127.0.0.1:$1/" >/dev/null 2>&1 && return 0
+        curl -fskS "$url" >/dev/null 2>&1 && return 0
         sleep 0.2
     done
     return 1
 }
 
-drive() { # label port
+drive() { # mode label port
     echo
-    echo "=== $1 (http/1.1, ${THREADS}t/${CONN}c/${DUR}s) ==="
-    wrk -t"$THREADS" -c"$CONN" -d"${DUR}s" --latency "http://127.0.0.1:$2/"
+    echo "=== $2 ($1, ${DUR}s) ==="
+    case "$1" in
+        h1) wrk -t"$THREADS" -c"$CONN" -d"${DUR}s" --latency "http://127.0.0.1:$3/" ;;
+        h2) h2load -t"$THREADS" -c"$CONN" -m"$STREAMS" -D"$DUR" "https://127.0.0.1:$3/" \
+                | grep -iE "Application protocol|finished|requests:|status codes" ;;
+    esac
 }
 
-bench_beam() { # label server port
+bench_beam() { # mode label server port
     ERL_LIBS="$BENCH_LIBS" erl -noshell -pa "$BENCH_PA" \
-        -eval "livery_bench:serve($2, h1, $3)" >/dev/null 2>&1 &
+        -eval "livery_bench:serve($3, $(serve_proto "$1"), $4)" >/dev/null 2>&1 &
     local pid=$!
-    if wait_ready "$3"; then drive "$1" "$3"; else echo "$1 did not become ready" >&2; fi
+    if wait_ready "$1" "$4"; then drive "$1" "$2" "$4"; else echo "$2 did not become ready" >&2; fi
     kill "$pid" 2>/dev/null || true
     wait "$pid" 2>/dev/null || true
 }
 
-bench_bandit() { # port
-    elixir bench/servers/bandit_server.exs "$1" >/dev/null 2>&1 &
+bench_bandit() { # mode port
+    case "$1" in
+        h1) elixir bench/servers/bandit_server.exs "$2" >/dev/null 2>&1 & ;;
+        h2) elixir bench/servers/bandit_server.exs "$2" "$CERT" "$KEY" >/dev/null 2>&1 & ;;
+    esac
     local pid=$!
-    if wait_ready "$1"; then drive "bandit" "$1"; else echo "bandit did not become ready (first run needs network for Mix.install)" >&2; fi
+    if wait_ready "$1" "$2"; then drive "$1" "bandit" "$2"; else echo "bandit did not become ready (first run needs network for Mix.install)" >&2; fi
     kill "$pid" 2>/dev/null || true
     wait "$pid" 2>/dev/null || true
 }
-
-bench_beam "livery" livery "$LPORT"
-bench_beam "cowboy" cowboy "$CPORT"
-bench_bandit "$BPORT"
 
 echo
-echo "Done. Note: livery serves H1 full bodies with chunked transfer-encoding;"
-echo "cowboy and bandit send content-length. wrk handles both."
+echo "##### HTTP/1.1 cleartext (wrk) #####"
+bench_beam h1 "livery" livery 9101
+bench_beam h1 "cowboy" cowboy 9102
+bench_bandit h1 9103
+
+echo
+echo "##### HTTP/2 over TLS (h2load) #####"
+bench_beam h2 "livery" livery 9111
+bench_beam h2 "cowboy" cowboy 9112
+bench_bandit h2 9113

--- a/bench/livery_bench.erl
+++ b/bench/livery_bench.erl
@@ -223,10 +223,17 @@ serve(Server, Protocol, Port) ->
 %% Listener lifecycle per protocol
 %%====================================================================
 
-ensure_started(livery, h1) -> application:ensure_all_started(h1);
-ensure_started(livery, h2) -> application:ensure_all_started(h2);
-ensure_started(livery, h3) -> application:ensure_all_started(quic);
-ensure_started(cowboy, _Protocol) -> application:ensure_all_started(cowboy).
+ensure_started(livery, h1) ->
+    application:ensure_all_started(h1);
+ensure_started(livery, h2) ->
+    application:ensure_all_started(h2);
+ensure_started(livery, h2tls) ->
+    {ok, _} = application:ensure_all_started(ssl),
+    application:ensure_all_started(h2);
+ensure_started(livery, h3) ->
+    application:ensure_all_started(quic);
+ensure_started(cowboy, _Protocol) ->
+    application:ensure_all_started(cowboy).
 
 ref_handler() ->
     fun(_Req) -> livery_resp:json(200, <<"{\"ok\":true}">>) end.
@@ -241,6 +248,16 @@ start_listener(livery, h2, Opts) ->
     livery_h2:start(#{
         port => maps:get(port, Opts, 0),
         transport => tcp,
+        stack => [],
+        handler => ref_handler()
+    });
+start_listener(livery, h2tls, Opts) ->
+    {CertFile, KeyFile} = certfiles(),
+    livery_h2:start(#{
+        port => maps:get(port, Opts, 0),
+        transport => ssl,
+        cert => CertFile,
+        key => KeyFile,
         stack => [],
         handler => ref_handler()
     });
@@ -271,11 +288,24 @@ start_listener(cowboy, Protocol, Opts) when Protocol =:= h1; Protocol =:= h2 ->
         [{port, maps:get(port, Opts, 0)}],
         #{env => #{dispatch => Dispatch}, protocols => Protocols}
     ),
+    {ok, Ref};
+%% Cowboy over TLS with ALPN-negotiated HTTP/2: the realistic h2 path.
+start_listener(cowboy, h2tls, Opts) ->
+    Ref = bench_cowboy_h2tls,
+    {CertFile, KeyFile} = certfiles(),
+    Dispatch = cowboy_router:compile([{'_', [{"/", bench_cowboy_h, []}]}]),
+    {ok, _} = cowboy:start_tls(
+        Ref,
+        [{port, maps:get(port, Opts, 0)}, {certfile, CertFile}, {keyfile, KeyFile}],
+        #{env => #{dispatch => Dispatch}, protocols => [http2]}
+    ),
     {ok, Ref}.
 
 listener_port(livery, h1, L) ->
     h1:server_port(L);
 listener_port(livery, h2, L) ->
+    h2:server_port(L);
+listener_port(livery, h2tls, L) ->
     h2:server_port(L);
 listener_port(livery, h3, L) ->
     {ok, P} = quic:get_server_port(L),
@@ -285,11 +315,18 @@ listener_port(cowboy, _Protocol, Ref) ->
 
 stop_listener(livery, h1, L) -> livery_h1:stop(L);
 stop_listener(livery, h2, L) -> livery_h2:stop(L);
+stop_listener(livery, h2tls, L) -> livery_h2:stop(L);
 stop_listener(livery, h3, L) -> livery_h3:stop(L);
 stop_listener(cowboy, _Protocol, Ref) -> cowboy:stop_listener(Ref).
 
 cowboy_ref(h1) -> bench_cowboy_h1;
 cowboy_ref(h2) -> bench_cowboy_h2.
+
+%% Self-signed test cert/key file paths (shared with the test suites).
+certfiles() ->
+    Base = code:lib_dir(livery),
+    Dir = filename:join([Base, "..", "..", "..", "..", "test", "certs"]),
+    {filename:join(Dir, "cert.pem"), filename:join(Dir, "key.pem")}.
 
 %% Reuse the vendored self-signed test certs for the H3 listener.
 load_certs() ->

--- a/bench/servers/bandit_server.exs
+++ b/bench/servers/bandit_server.exs
@@ -1,16 +1,25 @@
 # Reference Bandit server for the cross-server benchmark.
 #
 # Serves the same endpoint as the livery/cowboy reference handlers:
-# GET / -> 200 application/json {"ok":true} over HTTP/1.1.
+# GET / -> 200 application/json {"ok":true}.
 #
-# Run: elixir bench/servers/bandit_server.exs <port>
+# Run:
+#   elixir bench/servers/bandit_server.exs <port>                  # HTTP/1.1
+#   elixir bench/servers/bandit_server.exs <port> <cert> <key>     # HTTPS (h2 via ALPN)
+#
 # Pulls Bandit (and Plug, Thousand Island) via Mix.install on first run,
 # which needs network access; compiled artifacts are cached afterwards.
 
-port =
+{port, scheme, extra} =
   case System.argv() do
-    [p | _] -> String.to_integer(p)
-    [] -> 9103
+    [p, cert, key] ->
+      {String.to_integer(p), :https, [certfile: cert, keyfile: key]}
+
+    [p | _] ->
+      {String.to_integer(p), :http, []}
+
+    [] ->
+      {9103, :http, []}
   end
 
 Mix.install([:bandit])
@@ -29,6 +38,6 @@ defmodule BenchPlug do
   end
 end
 
-{:ok, _} = Bandit.start_link(plug: BenchPlug, scheme: :http, port: port)
-IO.puts("READY bandit http #{port}")
+{:ok, _} = Bandit.start_link([plug: BenchPlug, scheme: scheme, port: port] ++ extra)
+IO.puts("READY bandit #{scheme} #{port}")
 Process.sleep(:infinity)

--- a/rebar.config
+++ b/rebar.config
@@ -6,9 +6,7 @@
 
 {deps, [
     {mimerl, "1.5.0"},
-    %% Pinned to the git tag for h1:respond/5 (single-write full responses);
-    %% switch back to the hex form once erlang_h1 0.5.0 is published.
-    {h1, {git, "https://github.com/benoitc/erlang_h1.git", {tag, "0.5.0"}}},
+    {h1, "0.5.0", {pkg, erlang_h1}},
     {h2, "0.8.0"},
     {quic, "1.6.3"},
     {ws, "0.3.0", {pkg, erlang_ws}},

--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,9 @@
 
 {deps, [
     {mimerl, "1.5.0"},
-    {h1, "0.4.0", {pkg, erlang_h1}},
+    %% Pinned to the git tag for h1:respond/5 (single-write full responses);
+    %% switch back to the hex form once erlang_h1 0.5.0 is published.
+    {h1, {git, "https://github.com/benoitc/erlang_h1.git", {tag, "0.5.0"}}},
     {h2, "0.8.0"},
     {quic, "1.6.3"},
     {ws, "0.3.0", {pkg, erlang_ws}},

--- a/src/livery_h1.erl
+++ b/src/livery_h1.erl
@@ -15,10 +15,11 @@ handler. For every inbound request the adapter:
    engine never blocks on the worker.
 
 Response emission goes through `livery:emit/3` and lands on the
-adapter callbacks (`send_headers/4`, `send_data/3`,
+adapter callbacks (`send_headers/4`, `send_full/5`, `send_data/3`,
 `send_trailers/2`, `reset/2`), which in turn call into
-`h1:send_response/4`, `h1:send_data/3,4`, and
-`h1:send_trailers/3`.
+`h1:send_response/4`, `h1:respond/5`, `h1:send_data/3,4`, and
+`h1:send_trailers/3`. Full bodies coalesce into a single
+content-length write via `send_full/5` -> `h1:respond/5`.
 """.
 
 -behaviour(livery_adapter).
@@ -38,6 +39,7 @@ adapter callbacks (`send_headers/4`, `send_data/3`,
     start/3,
     stop/1,
     send_headers/4,
+    send_full/5,
     send_data/3,
     send_trailers/2,
     reset/2,
@@ -127,6 +129,21 @@ send_headers({Conn, StreamId}, Status, Headers, Opts) ->
         Other ->
             Other
     end.
+
+-spec send_full(
+    stream(),
+    100..599,
+    [{binary(), binary()}],
+    iodata(),
+    livery_adapter:send_opts()
+) ->
+    livery_adapter:send_result().
+%% Coalesce a full response (headers + body) into a single content-length
+%% write via h1:respond/5, instead of the granular send_headers/send_data
+%% path which frames the body as chunked. livery:emit/3 picks this up
+%% because the callback is exported.
+send_full({Conn, StreamId}, Status, Headers, IoData, _Opts) ->
+    h1:respond(Conn, StreamId, Status, Headers, IoData).
 
 -spec send_data(stream(), iodata(), livery_adapter:send_opts()) ->
     livery_adapter:send_result().


### PR DESCRIPTION
Two things: the H1 response-coalescing optimization, and a benchmark that now compares H1 and H2.

## H1 coalescing

Adds `livery_h1:send_full/5`, the H1 counterpart to `livery_h2:send_full/5`. It sends a full response (headers + body) in a **single** socket write via `h1:respond/5` with `content-length`, instead of the granular `send_headers` + `send_data` path that framed the body as **chunked** over two writes. `livery:emit/3` already prefers `send_full/5` when the adapter exports it, so H2 and now H1 both coalesce; H3 is unchanged.

Uses erlang_h1 0.5.0 (adds `respond/5`, published to hex): https://github.com/benoitc/erlang_h1/pull/3.

## Benchmark: H1 + H2

`bench/compare.sh` now also benchmarks **HTTP/2 over TLS** (ALPN, via `h2load`) next to HTTP/1.1 (`wrk`). Added a TLS h2 listener to `livery_bench:serve/3` and a TLS mode to the bandit server.

Loopback, Apple silicon, 4t/64c/8s:

**HTTP/1.1 (cleartext)**

| Server | req/s | p50 | p99 |
|---|---|---|---|
| livery (before) | ~104k | 0.57 ms | 1.60 ms |
| livery (after) | ~130k | 0.45 ms | 1.26 ms |
| cowboy | ~142k | 0.36 ms | 1.11 ms |
| bandit | ~147k | 0.34 ms | 1.30 ms |

**HTTP/2 over TLS**

| Server | req/s | errors |
|---|---|---|
| livery | ~154k | 0 |
| bandit | ~139k | 0 |
| cowboy | ~80k | resets under load |

H1 coalescing lifts livery +24% (now ~92% of cowboy). Over TLS, livery H2 is the fastest of the three (its adapter already coalesces via `h2:respond/5`); cowboy's HTTP/2 resets a fraction of streams under h2load's churn.

## Checks

fmt, compile, lint, xref, dialyzer clean. eunit 417. Full ct 181 (parity suite green; H1 full responses now carry `content-length` instead of `transfer-encoding: chunked`).
