### PR TITLE
Release 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-06-05
+
+Maintenance release: an H1 throughput optimization and benchmark tooling.
+No API change.
+
+### Changed
+
+- H1 full responses coalesce into a single `content-length` socket write
+  (`livery_h1:send_full/5` via the new `h1:respond/5`) instead of chunked
+  framing over two writes, lifting H1 throughput about 24% in the loopback
+  benchmark. Requires erlang_h1 0.5.0 (bumped from 0.4.0).
+
+### Added
+
+- Cross-server benchmark (`bench/compare.sh`) comparing livery, cowboy,
+  and bandit over HTTP/1.1 (`wrk`) and HTTP/2 over TLS (`h2load`).
+
 ## [0.2.1] - 2026-06-04
 
 Maintenance release: tests, docs, and internal layout. No API or
@@ -145,6 +162,7 @@ release; the framework is still under active development.
   QUIC round trip because the client and server share one BEAM. Measure
   H3 with an external native QUIC client.
 
+[0.2.2]: https://github.com/benoitc/livery/releases/tag/v0.2.2
 [0.2.1]: https://github.com/benoitc/livery/releases/tag/v0.2.1
 [0.2.0]: https://github.com/benoitc/livery/releases/tag/v0.2.0
 [0.1.0]: https://github.com/benoitc/livery/releases/tag/v0.1.0

--- a/src/livery.app.src
+++ b/src/livery.app.src
@@ -1,6 +1,6 @@
 {application, livery, [
     {description, "Livery: a modern Erlang web framework over HTTP/1.1, HTTP/2, and HTTP/3"},
-    {vsn, "0.2.1"},
+    {vsn, "0.2.2"},
     {registered, [livery_sup]},
     {mod, {livery_app, []}},
     {applications, [


### PR DESCRIPTION
Patch release: an H1 throughput optimization and benchmark tooling since 0.2.1. No API change.

- `CHANGELOG.md`: new `[0.2.2]` section.
- `src/livery.app.src`: `vsn` 0.2.1 -> 0.2.2.

Covers the H1 full-response coalescing (#32, ~24% H1 throughput; needs erlang_h1 0.5.0) and the H1/H2 cross-server benchmark.