### PR TITLE
Bump quic/hackney/webtransport; add H3 to the benchmark

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -88,6 +88,19 @@ Indicative numbers (loopback, Apple silicon, 4t / 64c / 8s):
 | bandit | ~139k | 0 |
 | cowboy | ~80k | resets under load |
 
+**HTTP/3 (livery only, in-VM quic_h3)**
+
+| Server | req/s | p50 | p99 |
+|---|---|---|---|
+| livery | ~16k | 3.7 ms | 4.6 ms |
+
+Cowboy and bandit do not speak HTTP/3, and external h3 load tools
+(`h2load` QUIC) do not interoperate with the self-signed QUIC listener
+here, so H3 is measured with livery's own in-VM `quic_h3` driver and is
+not directly comparable to the external H1/H2 figures (different load
+path, and QUIC over loopback is bounded by the round trip - measure H3
+with a native client off-box for absolute numbers).
+
 Same-host, single run; absolute numbers are host-specific. Notes:
 
 - **H1**: livery now coalesces full responses into a single

--- a/bench/compare.sh
+++ b/bench/compare.sh
@@ -92,3 +92,15 @@ echo "##### HTTP/2 over TLS (h2load) #####"
 bench_beam h2 "livery" livery 9111
 bench_beam h2 "cowboy" cowboy 9112
 bench_bandit h2 9113
+
+# H3 is livery only: cowboy and bandit do not speak HTTP/3, and external
+# h3 load tools (h2load QUIC) do not interoperate with the self-signed
+# QUIC listener here, so H3 uses livery's own in-VM quic_h3 driver. The
+# number is not directly comparable to the external H1/H2 figures above.
+echo
+echo "##### HTTP/3 (livery only, in-VM quic_h3) #####"
+echo "=== livery (h3, ${DUR}s) ==="
+ERL_LIBS="$BENCH_LIBS" erl -noshell -pa "$BENCH_PA" \
+    -eval "livery_bench:run(#{protocol => h3, connections => $CONN, duration_ms => $((DUR * 1000)), warmup_ms => 500})" \
+    -eval "halt()" 2>/dev/null \
+    | grep -E "throughput|latency p50|latency p99"

--- a/rebar.config
+++ b/rebar.config
@@ -8,11 +8,11 @@
     {mimerl, "1.5.0"},
     {h1, "0.5.0", {pkg, erlang_h1}},
     {h2, "0.8.0"},
-    {quic, "1.6.3"},
+    {quic, "1.6.4"},
     {ws, "0.3.0", {pkg, erlang_ws}},
     {instrument, "1.1.3"},
-    {webtransport, "0.3.1"},
-    {hackney, "4.2.0"},
+    {webtransport, "0.3.2"},
+    {hackney, "4.2.1"},
     {barrel_mcp, "2.1.0"}
 ]}.
 


### PR DESCRIPTION
Bumps the wire deps to their latest patch releases and adds HTTP/3 to the benchmark.

## Dependency bumps
- quic 1.6.3 -> 1.6.4
- hackney 4.2.0 -> 4.2.1
- webtransport 0.3.1 -> 0.3.2

## H3 in the benchmark
`bench/compare.sh` now has an HTTP/3 section. H3 is **livery only** (cowboy and bandit don't speak H3, and external h3 load tools - `h2load` QUIC - don't interoperate with the self-signed QUIC listener here), so it uses livery's in-VM `quic_h3` driver and is reported separately from the external H1/H2 figures.

## Before/after the bumps (in-VM, 50c/4s)

| Protocol | before | after |
|---|---|---|
| H1 | ~76.7k req/s | ~77.0k req/s |
| H2 | ~73.2k req/s | ~74.6k req/s |
| H3 | ~16.2k req/s | ~16.1k req/s |

Unchanged within run-to-run variance - the bumps are patch releases, and only quic sits on a server hot path (H3). No regression.

## Checks
fmt, compile, lint, xref, dialyzer clean. eunit 417. Full ct 181 (all suites green against the bumped deps).