### PR TITLE
Bump h1 to 0.6.0; release 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-06-05
+
+Maintenance release: dependency bumps and benchmark tooling. No API change.
+
+### Changed
+
+- Bump wire dependencies: `h1` (erlang_h1) 0.5.0 -> 0.6.0 (cuts
+  per-request allocations, single-scan header parsing, one-pass response
+  header block, header-block size cap), `quic` 1.6.3 -> 1.6.4, `hackney`
+  4.2.0 -> 4.2.1, `webtransport` 0.3.1 -> 0.3.2.
+
+### Added
+
+- HTTP/3 in the cross-server benchmark (`bench/compare.sh`), measured with
+  livery's in-VM `quic_h3` driver (livery only; cowboy and bandit have no
+  HTTP/3), alongside the HTTP/1.1 (`wrk`) and HTTP/2-over-TLS (`h2load`)
+  comparisons.
+
 ## [0.2.2] - 2026-06-05
 
 Maintenance release: an H1 throughput optimization and benchmark tooling.
@@ -162,6 +180,7 @@ release; the framework is still under active development.
   QUIC round trip because the client and server share one BEAM. Measure
   H3 with an external native QUIC client.
 
+[0.2.3]: https://github.com/benoitc/livery/releases/tag/v0.2.3
 [0.2.2]: https://github.com/benoitc/livery/releases/tag/v0.2.2
 [0.2.1]: https://github.com/benoitc/livery/releases/tag/v0.2.1
 [0.2.0]: https://github.com/benoitc/livery/releases/tag/v0.2.0

--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 
 {deps, [
     {mimerl, "1.5.0"},
-    {h1, "0.5.0", {pkg, erlang_h1}},
+    {h1, "0.6.0", {pkg, erlang_h1}},
     {h2, "0.8.0"},
     {quic, "1.6.4"},
     {ws, "0.3.0", {pkg, erlang_ws}},

--- a/src/livery.app.src
+++ b/src/livery.app.src
@@ -1,6 +1,6 @@
 {application, livery, [
     {description, "Livery: a modern Erlang web framework over HTTP/1.1, HTTP/2, and HTTP/3"},
-    {vsn, "0.2.2"},
+    {vsn, "0.2.3"},
     {registered, [livery_sup]},
     {mod, {livery_app, []}},
     {applications, [


### PR DESCRIPTION
Bumps the h1 wire library and cuts the 0.2.3 patch release.

## h1 0.6.0
erlang_h1 0.5.0 -> 0.6.0: cuts per-request allocations, parses each header line in one scan, builds the response header block in one pass, and caps header-block size. No API change.

Before/after, cross-server (loopback, 4t/64c/8s):

**HTTP/1.1 (wrk)**

| Server | before (h1 0.5.0) | after (h1 0.6.0) |
|---|---|---|
| livery | ~132k | ~130k |
| cowboy | ~138k | ~143k |
| bandit | ~148k | ~152k |

livery H1 is flat within run-to-run variance (cowboy/bandit move the same amount, and their code is unchanged - that's the noise floor). H2/H3 are unaffected (they don't use the h1 lib). No regression; the 0.6.0 work targets allocation/GC pressure, which this small-GET loopback micro-benchmark doesn't surface.

## Release 0.2.3
- `CHANGELOG.md`: `[0.2.3]` section (this h1 bump plus the quic/hackney/webtransport bumps and the H3 benchmark from #35).
- `src/livery.app.src`: `vsn` 0.2.2 -> 0.2.3.

## Checks
fmt, compile, lint, xref, dialyzer clean. eunit 417. Full ct 181 (green against h1 0.6.0).