### PR TITLE
Add realistic workloads and a summary to the benchmark

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -51,68 +51,73 @@ not as cross-environment targets.
 
 ## Cross-server comparison (livery vs cowboy vs bandit)
 
-`bench/compare.sh` benchmarks the same `GET / -> {"ok":true}` endpoint on
-**livery**, **cowboy**, and **bandit** over HTTP/1.1 (cleartext) and
-HTTP/2 (over TLS, ALPN-negotiated - the way h2 is actually deployed). Each
-server runs out of process on its own port and is driven by an external
-client ([`wrk`](https://github.com/wg/wrk) for H1,
+`bench/compare.sh` benchmarks **livery**, **cowboy**, and **bandit** over
+HTTP/1.1 (cleartext) and HTTP/2 (over TLS, ALPN-negotiated - the way h2 is
+actually deployed), across a few realistic workloads rather than one
+static GET:
+
+| Workload | request | what it stresses |
+|---|---|---|
+| `tiny` | `GET /` | accept + framing overhead |
+| `bytes1k`/`10k`/`100k` | `GET /bytes/<n>` | response write path at 1/10/100 KiB |
+| `echo` | `POST /echo` | body read + decode + encode (the common API path) |
+
+Each server runs out of process on its own port and is driven by an
+external client ([`wrk`](https://github.com/wg/wrk) for H1,
 [`h2load`](https://nghttp2.org/documentation/h2load-howto.html) for H2),
 so all three are treated identically and the load generator never shares a
-VM with the server under test. Livery and cowboy boot under one BEAM (via
+VM with the server. Livery and cowboy boot under one BEAM (via
 `livery_bench:serve/3`); bandit boots under Elixir, pulling itself in with
 `Mix.install` on first run (needs network and a one-time compile). TLS uses
-the vendored self-signed test certs.
+the vendored self-signed test certs. The script prints a per-run line and a
+summary table per protocol.
 
 ```
-bench/compare.sh                       # 4 threads, 64 conns, 10s
-DUR=20 CONN=128 THREADS=8 bench/compare.sh
+bench/compare.sh                       # full matrix, 4 threads, 64 conns, 10s
+DUR=20 CONN=128 bench/compare.sh
+SWEEP=1 bench/compare.sh               # also a concurrency sweep (16/64/256/1024)
 ```
 
 Requires `wrk`, `h2load`, `elixir`, `rebar3`, and `curl` on the PATH.
 
-Indicative numbers (loopback, Apple silicon, 4t / 64c / 8s):
+Indicative numbers (loopback, Apple silicon, 4t / 64c, req/s):
 
 **HTTP/1.1 (cleartext, wrk)**
 
-| Server | req/s | p50 | p99 |
-|---|---|---|---|
-| livery | ~130k | 0.45 ms | 1.26 ms |
-| cowboy | ~142k | 0.36 ms | 1.11 ms |
-| bandit | ~147k | 0.34 ms | 1.30 ms |
+| Server | tiny | 1 KiB | 10 KiB | 100 KiB | echo |
+|---|---|---|---|---|---|
+| livery | ~119k | ~115k | ~81k | ~17.5k | ~113k |
+| cowboy | ~138k | ~137k | ~94k | ~17.6k | ~132k |
+| bandit | ~144k | ~146k | ~105k | ~17.6k | ~145k |
 
 **HTTP/2 over TLS (h2load, 32 streams/conn)**
 
-| Server | req/s | errors |
-|---|---|---|
-| livery | ~154k | 0 |
-| bandit | ~139k | 0 |
-| cowboy | ~80k | resets under load |
+| Server | tiny | 1 KiB | 10 KiB | 100 KiB | echo |
+|---|---|---|---|---|---|
+| livery | ~138k | ~127k | ~81k | ~12k | ~110k |
+| cowboy | ~160k | ~160k | ~99k | ~17k | ~80k |
+| bandit | ~122k | ~109k | ~73k | ~16k | ~112k |
 
-**HTTP/3 (livery only, in-VM quic_h3)**
+**HTTP/3 (livery only, in-VM quic_h3)**: ~15k req/s. Cowboy and bandit do
+not speak HTTP/3, and external h3 load tools (`h2load` QUIC) do not
+interoperate with the self-signed QUIC listener here, so H3 uses livery's
+own in-VM `quic_h3` driver and is not comparable to the external H1/H2
+figures (different load path; QUIC over loopback is bounded by the round
+trip - measure off-box with a native client for absolute numbers).
 
-| Server | req/s | p50 | p99 |
-|---|---|---|---|
-| livery | ~16k | 3.7 ms | 4.6 ms |
+Same-host, single runs; absolute numbers are host-specific and vary run to
+run (cowboy's HTTP/2 in particular swings and resets a fraction of streams
+under `h2load`'s churn). What holds across runs:
 
-Cowboy and bandit do not speak HTTP/3, and external h3 load tools
-(`h2load` QUIC) do not interoperate with the self-signed QUIC listener
-here, so H3 is measured with livery's own in-VM `quic_h3` driver and is
-not directly comparable to the external H1/H2 figures (different load
-path, and QUIC over loopback is bounded by the round trip - measure H3
-with a native client off-box for absolute numbers).
-
-Same-host, single run; absolute numbers are host-specific. Notes:
-
-- **H1**: livery now coalesces full responses into a single
-  `content-length` write (`livery_h1:send_full/5` -> `h1:respond/5`);
-  earlier it sent them chunked over two writes, which cost ~20% here. The
-  small remaining gap is largely livery's worker process per request (the
-  `cowboy_loop` analogue), traded for the ability to block/`receive` in a
-  handler.
-- **H2**: livery is fastest of the three over TLS (its H2 adapter already
-  coalesces via `h2:respond/5`). Cowboy's HTTP/2 returns fewer req/s and
-  resets a fraction of streams under `h2load`'s stream churn (its built-in
-  HTTP/2 flow-rate protection), so its number is noisier.
+- **Payload size dominates.** At 100 KiB all three converge (~17k H1) - the
+  write path and loopback bandwidth, not the framework, set the ceiling.
+- **livery is competitive and closes the gap on larger bodies and on the
+  `echo` (POST) path**; the tiny-GET gap is mostly livery's worker process
+  per request (the `cowboy_loop` analogue, traded for the ability to
+  block/`receive` in a handler) plus, on H1, was helped by `send_full/5`
+  coalescing into one `content-length` write.
+- **livery's HTTP/2 `echo` beats cowboy's** (~110k vs ~80k): cowboy's h2
+  POST path is its weak spot here.
 
 ## p99 regression gate
 

--- a/bench/bench_cowboy_h.erl
+++ b/bench/bench_cowboy_h.erl
@@ -1,16 +1,28 @@
 %% @doc Cowboy reference handler for the livery_bench comparison.
-%% Mirrors livery_bench:ref_handler/0 byte-for-byte: a 200 with
-%% content-type application/json and body {"ok":true}.
+%% Mirrors livery_bench:ref_handler/0: a tiny JSON GET on `/', a sized
+%% response on `GET /bytes/<n>', and a JSON echo on `POST /echo'.
 -module(bench_cowboy_h).
 -behaviour(cowboy_handler).
 
 -export([init/2]).
 
 init(Req0, State) ->
-    Req = cowboy_req:reply(
-        200,
-        #{<<"content-type">> => <<"application/json">>},
-        <<"{\"ok\":true}">>,
-        Req0
-    ),
+    Req = route(cowboy_req:method(Req0), cowboy_req:path(Req0), Req0),
     {ok, Req, State}.
+
+route(<<"POST">>, <<"/echo">>, Req0) ->
+    {Body, Req1} = read_body(Req0, <<>>),
+    cowboy_req:reply(200, #{<<"content-type">> => <<"application/json">>}, Body, Req1);
+route(<<"GET">>, <<"/bytes/", N/binary>>, Req0) ->
+    Payload = binary:copy(<<"x">>, binary_to_integer(N)),
+    cowboy_req:reply(200, #{<<"content-type">> => <<"text/plain">>}, Payload, Req0);
+route(_Method, _Path, Req0) ->
+    cowboy_req:reply(
+        200, #{<<"content-type">> => <<"application/json">>}, <<"{\"ok\":true}">>, Req0
+    ).
+
+read_body(Req0, Acc) ->
+    case cowboy_req:read_body(Req0) of
+        {ok, Data, Req1} -> {<<Acc/binary, Data/binary>>, Req1};
+        {more, Data, Req1} -> read_body(Req1, <<Acc/binary, Data/binary>>)
+    end.

--- a/bench/compare.sh
+++ b/bench/compare.sh
@@ -1,21 +1,29 @@
 #!/usr/bin/env bash
 #
-# Fair cross-server benchmark: livery vs cowboy vs bandit, over HTTP/1.1
-# (cleartext) and HTTP/2 (over TLS, ALPN-negotiated - the way h2 is
-# actually deployed).
+# Cross-server benchmark: livery vs cowboy vs bandit, over HTTP/1.1
+# (cleartext, wrk) and HTTP/2 (over TLS, h2load), across a few realistic
+# workloads:
 #
-# Each server runs out of process on its own port and is driven by an
-# external client (`wrk` for H1, `h2load` for H2), so all three are
-# treated identically and the load generator never shares a VM with the
-# server under test. Livery and cowboy boot under one BEAM (via
-# livery_bench:serve/3); bandit boots under Elixir (Mix.install on first
-# run, needs network). TLS uses the vendored self-signed test certs.
+#   tiny       GET  /            tiny JSON response
+#   bytes1k    GET  /bytes/1024  1 KiB body
+#   bytes10k   GET  /bytes/10240 10 KiB body
+#   bytes100k  GET  /bytes/102400  100 KiB body
+#   echo       POST /echo        decode + echo a small JSON body
+#
+# Each server runs out of process on its own port; an external client
+# drives it, so all three are treated identically and the load generator
+# never shares a VM with the server. Livery and cowboy boot under one BEAM
+# (livery_bench:serve/3); bandit boots under Elixir (Mix.install on first
+# run, needs network). H3 is livery only (cowboy/bandit have no HTTP/3, and
+# external h3 load tools do not interoperate with the QUIC listener), so it
+# is reported separately via livery's in-VM quic_h3 driver.
 #
 # Usage:
-#   bench/compare.sh                 # 4 threads, 64 conns, 10s
-#   DUR=20 CONN=128 THREADS=8 bench/compare.sh
+#   bench/compare.sh                       # full matrix, 4t/64c/10s
+#   DUR=20 CONN=128 bench/compare.sh
+#   SWEEP=1 bench/compare.sh               # also run a concurrency sweep
 #
-# Requires: wrk, h2load, elixir, rebar3 (and curl).
+# Requires: wrk, h2load, elixir, rebar3, curl.
 
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -23,9 +31,20 @@ cd "$(dirname "$0")/.."
 DUR="${DUR:-10}"
 CONN="${CONN:-64}"
 THREADS="${THREADS:-4}"
-STREAMS="${STREAMS:-32}"   # h2 max concurrent streams per connection
+STREAMS="${STREAMS:-32}"
+SWEEP="${SWEEP:-0}"
 CERT="$PWD/test/certs/cert.pem"
 KEY="$PWD/test/certs/key.pem"
+
+# name:method:path for each workload. echo carries a JSON body.
+WORKLOADS=(
+    "tiny:GET:/"
+    "bytes1k:GET:/bytes/1024"
+    "bytes10k:GET:/bytes/10240"
+    "bytes100k:GET:/bytes/102400"
+    "echo:POST:/echo"
+)
+ECHO_BODY='{"name":"ada","tags":["one","two","three"],"n":42,"ok":true}'
 
 for tool in wrk h2load curl elixir rebar3; do
     command -v "$tool" >/dev/null 2>&1 || { echo "missing required tool: $tool" >&2; exit 1; }
@@ -33,74 +52,135 @@ done
 
 echo "Compiling bench profile..."
 rebar3 as bench compile >/dev/null
-# App ebins (deps + livery) come from ERL_LIBS; the bench modules
-# (livery_bench, bench_cowboy_h) compile to livery/bench, added with -pa.
 BENCH_LIBS="$PWD/_build/bench/lib"
 BENCH_PA="$BENCH_LIBS/livery/bench"
 
-# The server-side listener protocol for each benchmark mode.
+TMP="$(mktemp -d)"
+RESULTS="$TMP/results"
+: >"$RESULTS"
+printf '%s' "$ECHO_BODY" >"$TMP/body.json"
+cat >"$TMP/post.lua" <<LUA
+wrk.method = "POST"
+wrk.body   = [[$ECHO_BODY]]
+wrk.headers["Content-Type"] = "application/json"
+LUA
+
+cleanup() { [ -n "${SERVER_PID:-}" ] && kill "$SERVER_PID" 2>/dev/null || true; rm -rf "$TMP"; }
+trap cleanup EXIT
+SERVER_PID=""
+
 serve_proto() { case "$1" in h1) echo h1 ;; h2) echo h2tls ;; esac; }
 
 wait_ready() { # mode port
     local url
     case "$1" in h1) url="http://127.0.0.1:$2/" ;; h2) url="https://127.0.0.1:$2/" ;; esac
-    for _ in $(seq 1 100); do
-        curl -fskS "$url" >/dev/null 2>&1 && return 0
-        sleep 0.2
-    done
+    for _ in $(seq 1 100); do curl -fskS "$url" >/dev/null 2>&1 && return 0; sleep 0.2; done
     return 1
 }
 
-drive() { # mode label port
-    echo
-    echo "=== $2 ($1, ${DUR}s) ==="
-    case "$1" in
-        h1) wrk -t"$THREADS" -c"$CONN" -d"${DUR}s" --latency "http://127.0.0.1:$3/" ;;
-        h2) h2load -t"$THREADS" -c"$CONN" -m"$STREAMS" -D"$DUR" "https://127.0.0.1:$3/" \
-                | grep -iE "Application protocol|finished|requests:|status codes" ;;
-    esac
+# Run one workload and echo "req/s" (a bare number), printing the raw line.
+drive_rps() { # mode port method path conns
+    local mode="$1" port="$2" method="$3" path="$4" conns="$5" out rps
+    if [ "$mode" = h1 ]; then
+        if [ "$method" = POST ]; then
+            out=$(wrk -t"$THREADS" -c"$conns" -d"${DUR}s" -s "$TMP/post.lua" "http://127.0.0.1:$port$path" 2>&1)
+        else
+            out=$(wrk -t"$THREADS" -c"$conns" -d"${DUR}s" "http://127.0.0.1:$port$path" 2>&1)
+        fi
+        rps=$(printf '%s\n' "$out" | grep -oE 'Requests/sec: *[0-9.]+' | grep -oE '[0-9.]+$' | head -1)
+    else
+        if [ "$method" = POST ]; then
+            out=$(h2load -t"$THREADS" -c"$conns" -m"$STREAMS" -D"$DUR" -d "$TMP/body.json" "https://127.0.0.1:$port$path" 2>&1)
+        else
+            out=$(h2load -t"$THREADS" -c"$conns" -m"$STREAMS" -D"$DUR" "https://127.0.0.1:$port$path" 2>&1)
+        fi
+        rps=$(printf '%s\n' "$out" | grep -oE '[0-9.]+ req/s' | grep -oE '^[0-9.]+' | head -1)
+    fi
+    echo "${rps:-0}"
 }
 
-bench_beam() { # mode label server port
-    ERL_LIBS="$BENCH_LIBS" erl -noshell -pa "$BENCH_PA" \
-        -eval "livery_bench:serve($3, $(serve_proto "$1"), $4)" >/dev/null 2>&1 &
-    local pid=$!
-    if wait_ready "$1" "$4"; then drive "$1" "$2" "$4"; else echo "$2 did not become ready" >&2; fi
-    kill "$pid" 2>/dev/null || true
-    wait "$pid" 2>/dev/null || true
+start_server() { # mode server port
+    case "$2" in
+        bandit)
+            case "$1" in
+                h1) elixir bench/servers/bandit_server.exs "$3" >/dev/null 2>&1 & ;;
+                h2) elixir bench/servers/bandit_server.exs "$3" "$CERT" "$KEY" >/dev/null 2>&1 & ;;
+            esac ;;
+        *)
+            ERL_LIBS="$BENCH_LIBS" erl -noshell -pa "$BENCH_PA" \
+                -eval "livery_bench:serve($2, $(serve_proto "$1"), $3)" >/dev/null 2>&1 & ;;
+    esac
+    SERVER_PID=$!
 }
 
-bench_bandit() { # mode port
-    case "$1" in
-        h1) elixir bench/servers/bandit_server.exs "$2" >/dev/null 2>&1 & ;;
-        h2) elixir bench/servers/bandit_server.exs "$2" "$CERT" "$KEY" >/dev/null 2>&1 & ;;
-    esac
-    local pid=$!
-    if wait_ready "$1" "$2"; then drive "$1" "bandit" "$2"; else echo "bandit did not become ready (first run needs network for Mix.install)" >&2; fi
-    kill "$pid" 2>/dev/null || true
-    wait "$pid" 2>/dev/null || true
+stop_server() { kill "$SERVER_PID" 2>/dev/null || true; wait "$SERVER_PID" 2>/dev/null || true; SERVER_PID=""; }
+
+run_matrix() { # mode servers...
+    local mode="$1"; shift
+    local base=9100; [ "$mode" = h2 ] && base=9110
+    local i=0 server port wl name method path rps
+    for server in "$@"; do
+        port=$((base + i)); i=$((i + 1))
+        start_server "$mode" "$server" "$port"
+        if ! wait_ready "$mode" "$port"; then echo "$server ($mode) not ready" >&2; stop_server; continue; fi
+        for wl in "${WORKLOADS[@]}"; do
+            name="${wl%%:*}"; method="$(echo "$wl" | cut -d: -f2)"; path="${wl##*:}"
+            rps=$(drive_rps "$mode" "$port" "$method" "$path" "$CONN")
+            printf '%-8s %-10s %-10s %12s req/s\n' "$mode" "$server" "$name" "$rps"
+            echo "$mode $server $name $rps" >>"$RESULTS"
+        done
+        stop_server
+    done
 }
 
 echo
-echo "##### HTTP/1.1 cleartext (wrk) #####"
-bench_beam h1 "livery" livery 9101
-bench_beam h1 "cowboy" cowboy 9102
-bench_bandit h1 9103
-
+echo "##### HTTP/1.1 cleartext (wrk), ${THREADS}t/${CONN}c/${DUR}s #####"
+run_matrix h1 livery cowboy bandit
 echo
-echo "##### HTTP/2 over TLS (h2load) #####"
-bench_beam h2 "livery" livery 9111
-bench_beam h2 "cowboy" cowboy 9112
-bench_bandit h2 9113
+echo "##### HTTP/2 over TLS (h2load, ${STREAMS} streams/conn) #####"
+run_matrix h2 livery cowboy bandit
 
-# H3 is livery only: cowboy and bandit do not speak HTTP/3, and external
-# h3 load tools (h2load QUIC) do not interoperate with the self-signed
-# QUIC listener here, so H3 uses livery's own in-VM quic_h3 driver. The
-# number is not directly comparable to the external H1/H2 figures above.
 echo
 echo "##### HTTP/3 (livery only, in-VM quic_h3) #####"
 echo "=== livery (h3, ${DUR}s) ==="
 ERL_LIBS="$BENCH_LIBS" erl -noshell -pa "$BENCH_PA" \
     -eval "livery_bench:run(#{protocol => h3, connections => $CONN, duration_ms => $((DUR * 1000)), warmup_ms => 500})" \
-    -eval "halt()" 2>/dev/null \
-    | grep -E "throughput|latency p50|latency p99"
+    -eval "halt()" 2>/dev/null | grep -E "throughput|latency p50|latency p99"
+
+if [ "$SWEEP" = 1 ]; then
+    echo
+    echo "##### Concurrency sweep (tiny GET, HTTP/1.1, wrk) #####"
+    for server in livery cowboy bandit; do
+        start_server h1 "$server" 9140
+        if wait_ready h1 9140; then
+            for c in 16 64 256 1024; do
+                rps=$(drive_rps h1 9140 GET / "$c")
+                printf '%-8s c=%-5s %12s req/s\n' "$server" "$c" "$rps"
+            done
+        fi
+        stop_server
+    done
+fi
+
+# Summary tables, one per protocol: rows = servers, columns = workloads.
+echo
+echo "##### Summary (req/s) #####"
+awk '
+{ rps[$1","$2","$3]=$4; servers[$2]=1; wl[$3]=1; modes[$1]=1 }
+END {
+    norder="tiny bytes1k bytes10k bytes100k echo"; nw=split(norder, W, " ")
+    sorder="livery cowboy bandit"; ns=split(sorder, S, " ")
+    morder="h1 h2"; nm=split(morder, M, " ")
+    for (mi=1; mi<=nm; mi++) {
+        m=M[mi]; if (!(m in modes)) continue
+        printf "\n[%s]\n", (m=="h1" ? "HTTP/1.1" : "HTTP/2 over TLS")
+        printf "%-9s", "server"
+        for (wi=1; wi<=nw; wi++) printf "%12s", W[wi]
+        printf "\n"
+        for (si=1; si<=ns; si++) {
+            s=S[si]; printf "%-9s", s
+            for (wi=1; wi<=nw; wi++) { k=m","s","W[wi]; printf "%12s", (k in rps ? rps[k] : "-") }
+            printf "\n"
+        }
+    }
+}' "$RESULTS"

--- a/bench/livery_bench.erl
+++ b/bench/livery_bench.erl
@@ -235,8 +235,31 @@ ensure_started(livery, h3) ->
 ensure_started(cowboy, _Protocol) ->
     application:ensure_all_started(cowboy).
 
+%% The reference handler covers three workloads so the benchmark can
+%% exercise more than a static GET: a tiny JSON GET (`/`), a sized
+%% response (`GET /bytes/<n>`), and a JSON echo (`POST /echo`).
 ref_handler() ->
-    fun(_Req) -> livery_resp:json(200, <<"{\"ok\":true}">>) end.
+    fun(Req) ->
+        case {livery_req:method(Req), livery_req:path(Req)} of
+            {<<"POST">>, <<"/echo">>} ->
+                livery_resp:json(200, ref_read_body(Req));
+            {<<"GET">>, <<"/bytes/", N/binary>>} ->
+                livery_resp:text(200, binary:copy(<<"x">>, binary_to_integer(N)));
+            _ ->
+                livery_resp:json(200, <<"{\"ok\":true}">>)
+        end
+    end.
+
+ref_read_body(Req) ->
+    case livery_req:body(Req) of
+        {stream, Reader} ->
+            {ok, Bin, _} = livery_body:read_all(Reader),
+            Bin;
+        {buffered, IoData} ->
+            iolist_to_binary(IoData);
+        empty ->
+            <<>>
+    end.
 
 start_listener(livery, h1, Opts) ->
     livery_h1:start(#{
@@ -277,7 +300,7 @@ start_listener(livery, h3, Opts) ->
 %% exercises exactly the protocol under test.
 start_listener(cowboy, Protocol, Opts) when Protocol =:= h1; Protocol =:= h2 ->
     Ref = cowboy_ref(Protocol),
-    Dispatch = cowboy_router:compile([{'_', [{"/", bench_cowboy_h, []}]}]),
+    Dispatch = cowboy_router:compile([{'_', [{"/[...]", bench_cowboy_h, []}]}]),
     Protocols =
         case Protocol of
             h1 -> [http];
@@ -293,7 +316,7 @@ start_listener(cowboy, Protocol, Opts) when Protocol =:= h1; Protocol =:= h2 ->
 start_listener(cowboy, h2tls, Opts) ->
     Ref = bench_cowboy_h2tls,
     {CertFile, KeyFile} = certfiles(),
-    Dispatch = cowboy_router:compile([{'_', [{"/", bench_cowboy_h, []}]}]),
+    Dispatch = cowboy_router:compile([{'_', [{"/[...]", bench_cowboy_h, []}]}]),
     {ok, _} = cowboy:start_tls(
         Ref,
         [{port, maps:get(port, Opts, 0)}, {certfile, CertFile}, {keyfile, KeyFile}],

--- a/bench/servers/bandit_server.exs
+++ b/bench/servers/bandit_server.exs
@@ -1,7 +1,9 @@
 # Reference Bandit server for the cross-server benchmark.
 #
-# Serves the same endpoint as the livery/cowboy reference handlers:
-# GET / -> 200 application/json {"ok":true}.
+# Mirrors the livery/cowboy reference handlers:
+#   GET  /            -> 200 application/json {"ok":true}
+#   GET  /bytes/<n>   -> 200 text/plain, n bytes
+#   POST /echo        -> 200 application/json, the request body echoed
 #
 # Run:
 #   elixir bench/servers/bandit_server.exs <port>                  # HTTP/1.1
@@ -26,15 +28,25 @@ Mix.install([:bandit])
 
 defmodule BenchPlug do
   @behaviour Plug
+  import Plug.Conn
 
   @impl true
   def init(opts), do: opts
 
   @impl true
-  def call(conn, _opts) do
+  def call(%Plug.Conn{method: "POST", request_path: "/echo"} = conn, _opts) do
+    {:ok, body, conn} = read_body(conn, length: 16_000_000)
+    conn |> put_resp_content_type("application/json") |> send_resp(200, body)
+  end
+
+  def call(%Plug.Conn{method: "GET", request_path: "/bytes/" <> n} = conn, _opts) do
     conn
-    |> Plug.Conn.put_resp_content_type("application/json")
-    |> Plug.Conn.send_resp(200, ~s({"ok":true}))
+    |> put_resp_content_type("text/plain")
+    |> send_resp(200, String.duplicate("x", String.to_integer(n)))
+  end
+
+  def call(conn, _opts) do
+    conn |> put_resp_content_type("application/json") |> send_resp(200, ~s({"ok":true}))
   end
 end
 


### PR DESCRIPTION
The cross-server benchmark only hit a static tiny GET, which mostly measures framing/accept overhead. This adds workloads that exercise real work and a summary table.

## Workloads
| Workload | request | stresses |
|---|---|---|
| tiny | GET / | accept + framing |
| bytes1k/10k/100k | GET /bytes/<n> | response write path |
| echo | POST /echo | body read + decode + encode |

The reference handler in all three servers (livery / cowboy / bandit) now routes these. `bench/compare.sh` runs the matrix over H1 (`wrk`) and H2 (`h2load`), prints a per-protocol **summary table**, and takes `SWEEP=1` for a concurrency sweep (16/64/256/1024). H3 stays livery-only/in-VM.

## Indicative numbers (loopback, 4t/64c, req/s)

**HTTP/1.1**

| Server | tiny | 1 KiB | 10 KiB | 100 KiB | echo |
|---|---|---|---|---|---|
| livery | ~119k | ~115k | ~81k | ~17.5k | ~113k |
| cowboy | ~138k | ~137k | ~94k | ~17.6k | ~132k |
| bandit | ~144k | ~146k | ~105k | ~17.6k | ~145k |

**HTTP/2 over TLS**

| Server | tiny | 1 KiB | 10 KiB | 100 KiB | echo |
|---|---|---|---|---|---|
| livery | ~138k | ~127k | ~81k | ~12k | ~110k |
| cowboy | ~160k | ~160k | ~99k | ~17k | ~80k |
| bandit | ~122k | ~109k | ~73k | ~16k | ~112k |

What holds across runs: payload size sets the ceiling (all converge at 100 KiB), livery closes the gap on larger bodies and the echo path, and livery's H2 echo beats cowboy's (~110k vs ~80k - cowboy's h2 POST is its weak spot).

Bench-profile only; no `src/` change.