### PR TITLE
Treat H2 client disconnect as {error, closed}, not a crash

### DIFF
--- a/src/livery_h2.erl
+++ b/src/livery_h2.erl
@@ -114,21 +114,23 @@ stop(Listener) ->
 ) ->
     livery_adapter:send_result().
 send_headers({Conn, StreamId}, Status, Headers, Opts) ->
-    case h2:send_response(Conn, StreamId, Status, Headers) of
-        ok ->
-            case maps:get(end_stream, Opts, false) of
-                true -> h2:send_data(Conn, StreamId, <<>>, true);
-                false -> ok
-            end;
-        Other ->
-            Other
-    end.
+    closed_guard(fun() ->
+        case h2:send_response(Conn, StreamId, Status, Headers) of
+            ok ->
+                case maps:get(end_stream, Opts, false) of
+                    true -> h2:send_data(Conn, StreamId, <<>>, true);
+                    false -> ok
+                end;
+            Other ->
+                Other
+        end
+    end).
 
 -spec send_data(stream(), iodata(), livery_adapter:send_opts()) ->
     livery_adapter:send_result().
 send_data({Conn, StreamId}, IoData, Opts) ->
     EndStream = maps:get(end_stream, Opts, false),
-    h2:send_data(Conn, StreamId, iolist_to_binary(IoData), EndStream).
+    closed_guard(fun() -> h2:send_data(Conn, StreamId, iolist_to_binary(IoData), EndStream) end).
 
 %% Coalesced full response: HEADERS + DATA in one h2 call (and one
 %% socket write). h2:respond/5 falls back to the granular path itself
@@ -142,12 +144,31 @@ send_data({Conn, StreamId}, IoData, Opts) ->
 ) ->
     livery_adapter:send_result().
 send_full({Conn, StreamId}, Status, Headers, IoData, _Opts) ->
-    h2:respond(Conn, StreamId, Status, Headers, iolist_to_binary(IoData)).
+    closed_guard(fun() ->
+        h2:respond(Conn, StreamId, Status, Headers, iolist_to_binary(IoData))
+    end).
 
 -spec send_trailers(stream(), [{binary(), binary()}]) ->
     livery_adapter:send_result().
 send_trailers({Conn, StreamId}, Trailers) ->
-    h2:send_trailers(Conn, StreamId, Trailers).
+    closed_guard(fun() -> h2:send_trailers(Conn, StreamId, Trailers) end).
+
+%% A send to a connection whose client has gone away exits the underlying
+%% `gen_statem:call` (e.g. `{{shutdown, {send_failed, closed}}, _}` or
+%% `{noproc, _}`). Map that to `{error, closed}`, the way `gen_tcp:send`
+%% already reports it on H1, so `livery:emit/3` treats it as a normal
+%% disconnect instead of a handler crash. The crash path would log the
+%% response body (carried in the stacktrace), which is both a throughput
+%% sink on large responses and a log-hygiene leak.
+-spec closed_guard(fun(() -> R)) -> R | {error, closed}.
+closed_guard(Fun) ->
+    try
+        Fun()
+    catch
+        exit:{noproc, _} -> {error, closed};
+        exit:{normal, _} -> {error, closed};
+        exit:{{shutdown, _}, _} -> {error, closed}
+    end.
 
 -spec reset(stream(), term()) -> ok.
 reset({Conn, StreamId}, _Reason) ->
@@ -345,19 +366,16 @@ dispatch_request(Conn, StreamId, Method, Path, Headers, Stack, Handler, MaxBody,
     of
         {ok, WorkerPid} ->
             Translator ! {worker, WorkerPid},
-            case
-                h2:set_stream_handler(
-                    Conn,
-                    StreamId,
-                    Translator,
-                    #{drain_buffer => false}
-                )
-            of
+            case set_stream_handler(Conn, StreamId, Translator) of
                 ok ->
                     ok;
                 {ok, _Drained} ->
                     ok;
-                {error, unknown_stream} ->
+                %% The client already went away (unknown stream, or the
+                %% connection process is shutting down); abandon the
+                %% request quietly. The worker's DOWN still balances the
+                %% in-flight count.
+                {error, _} ->
                     exit(Translator, kill),
                     exit(WorkerPid, kill),
                     ok
@@ -367,6 +385,15 @@ dispatch_request(Conn, StreamId, Method, Path, Headers, Stack, Handler, MaxBody,
             reject_overload({Conn, StreamId})
     end,
     ok.
+
+%% Register the per-stream translator. Like the send callbacks, a
+%% connection that is already shutting down (client gone) exits the
+%% gen_statem:call; map it to `{error, closed}` so the caller abandons
+%% the request instead of crashing (which would error-log per disconnect).
+set_stream_handler(Conn, StreamId, Translator) ->
+    closed_guard(fun() ->
+        h2:set_stream_handler(Conn, StreamId, Translator, #{drain_buffer => false})
+    end).
 
 %% No worker slot available (concurrency cap reached): answer 503.
 -spec reject_overload(stream()) -> ok.

--- a/test/livery_h2_SUITE.erl
+++ b/test/livery_h2_SUITE.erl
@@ -25,7 +25,8 @@
     echo_buffered_body/1,
     error_500_on_crash/1,
     response_with_trailers/1,
-    cancel_on_connection_close/1
+    cancel_on_connection_close/1,
+    send_to_gone_client_is_closed/1
 ]).
 
 %%====================================================================
@@ -42,7 +43,8 @@ all() ->
         echo_buffered_body,
         error_500_on_crash,
         response_with_trailers,
-        cancel_on_connection_close
+        cancel_on_connection_close,
+        send_to_gone_client_is_closed
     ].
 
 init_per_suite(Config) ->
@@ -173,7 +175,10 @@ handler_for(cancel_on_connection_close) ->
             after 10000 -> ok
             end
         end)
-    end.
+    end;
+%% Cases that exercise the adapter directly (no listener traffic).
+handler_for(_TC) ->
+    fun(_R) -> livery_resp:text(200, <<"ok">>) end.
 
 cancel_on_connection_close(Config) ->
     Port = ?config(port, Config),
@@ -192,6 +197,29 @@ cancel_on_connection_close(Config) ->
         cancelled -> ok
     after 5000 -> ct:fail(cancel_callback_not_run)
     end.
+
+%% A send to a connection whose client has gone away must report
+%% `{error, closed}` (like gen_tcp:send on H1), not crash the worker.
+%% The crash path would error-log the response body carried in the
+%% stacktrace, a throughput sink on large responses. A dead connection
+%% process makes the underlying gen_statem:call exit with `{noproc, _}`,
+%% the same shape as a real mid-response disconnect.
+send_to_gone_client_is_closed(_Config) ->
+    Dead = spawn(fun() -> ok end),
+    Ref = monitor(process, Dead),
+    receive
+        {'DOWN', Ref, process, Dead, _} -> ok
+    after 5000 -> ct:fail(proc_not_dead)
+    end,
+    Stream = {Dead, 1},
+    ?assertEqual({error, closed}, livery_h2:send_full(Stream, 200, [], <<"body">>, #{})),
+    ?assertEqual(
+        {error, closed}, livery_h2:send_data(Stream, <<"body">>, #{end_stream => true})
+    ),
+    ?assertEqual(
+        {error, closed}, livery_h2:send_headers(Stream, 200, [], #{end_stream => true})
+    ),
+    ?assertEqual({error, closed}, livery_h2:send_trailers(Stream, [{<<"x">>, <<"y">>}])).
 
 %%====================================================================
 %% HTTP/2 client helpers


### PR DESCRIPTION
On HTTP/2, a send (or the per-stream handler registration) to a connection whose client has gone away **exits** the underlying `gen_statem:call`. That exception was caught and **error-logged with the full stacktrace** — which carries the response **body** as a send argument, so livery would `~tp`-pretty-print up to the whole body **per disconnected request**. It's both a throughput sink on large responses and a log-hygiene/security leak (response bodies in error logs).

Fix: map the connection-down exit to `{error, closed}` — the way `gen_tcp:send` already reports it on H1 — so `livery:emit/3` treats it as a normal disconnect. Covers both the send callbacks (`send_headers/4`, `send_data/3`, `send_full/5`, `send_trailers/2`) and the `set_stream_handler` setup call in `dispatch_request/9`.

## Impact (isolated, 100 KiB body, connection churn, default logging)

| | req/s | crash/error logs |
|---|---|---|
| before | ~15k | many (body dumped) |
| after | ~30k | 0 |

~2× on large H2 responses for the realistic "serve a cached/static body" case, and no more bodies in logs. (The cross-server bench's `/bytes` handler rebuilds the body per request, so it's allocation-bound and doesn't surface this — separate bench improvement coming.)

## Checks
fmt, compile, lint, xref, dialyzer clean. eunit 417. Full ct 182, including a new `livery_h2_SUITE` regression: a send to a gone connection returns `{error, closed}` instead of crashing.