### PR TITLE
Bump h2 to 0.9.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
 {deps, [
     {mimerl, "1.5.0"},
     {h1, "0.6.0", {pkg, erlang_h1}},
-    {h2, "0.8.0"},
+    {h2, "0.9.0"},
     {quic, "1.6.4"},
     {ws, "0.3.0", {pkg, erlang_ws}},
     {instrument, "1.1.3"},


### PR DESCRIPTION
Bumps the `h2` dependency from 0.8.0 to 0.9.0.

0.9.0 coalesces a response's frames into one socket write (one `Transport:send` per flow-control-ready batch instead of one per frame), which roughly doubles large-body throughput over TLS and cuts per-frame gen_statem round-trips and AEAD passes. No API change.

Note: resolving this requires h2 0.9.0 on hex.