### PR TITLE
Bump h2 to 0.9.0 (coalesced response writes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `h2` to 0.9.0, which coalesces a response's frames into a single
+  socket write instead of one write per frame. On the loopback benchmark
+  this roughly doubles large HTTP/2 response throughput (100 KiB over TLS:
+  ~28k -> ~66k req/s) and lifts smaller bodies ~7-9%.
+
 ### Fixed
 
 - HTTP/2: a client that disconnects mid-response is reported as a normal

--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
 {deps, [
     {mimerl, "1.5.0"},
     {h1, "0.6.0", {pkg, erlang_h1}},
-    {h2, "0.8.0"},
+    {h2, "0.9.0"},
     {quic, "1.6.4"},
     {ws, "0.3.0", {pkg, erlang_ws}},
     {instrument, "1.1.3"},


### PR DESCRIPTION
`h2` 0.9.0 writes a response's frames in a **single socket write** instead of one `ssl:send` per frame - the optimization the H2 send-path profile pointed at (a 100 KiB response was doing ~8 `ssl:send` / ~15 AEAD encryptions / ~8 `gen_statem` round-trips; now one batched write).

## Benchmark (loopback, 4t/64c/8s, cached payloads), HTTP/2 over TLS

| Workload | livery before (0.8.0) | livery after (0.9.0) | cowboy | bandit |
|---|---|---|---|---|
| tiny | 128k | **137k** | 80k | 125k |
| 1 KiB | 122k | **133k** | 80k | 118k |
| 10 KiB | 114k | **123k** | 80k | 107k |
| **100 KiB** | **27.7k** | **66.3k** (2.4×) | 80k | 62k |
| echo | 108k | **118k** | 40k | 104k |

The large-body gap is closed: livery's H2 100 KiB now leads bandit and approaches cowboy's flat ~80k. H1 is unchanged (the bump doesn't touch it).

## Checks
fmt, compile, lint, xref, dialyzer clean. eunit 417. Full ct 182 (h2 + parity suites pass against 0.9.0).