### PR TITLE
Skip the IPv6 WS case when the loopback connect is unusable

### DIFF
--- a/test/livery_ws_SUITE.erl
+++ b/test/livery_ws_SUITE.erl
@@ -140,11 +140,31 @@ end_per_testcase(_TC, Config) ->
 ws_handler(R) ->
     livery_ws:upgrade(R, livery_ws_echo_handler, #{}).
 
+%% Probe the IPv6 loopback with a real connect round-trip, not just a
+%% listen: CI runners can bind `::1' yet fail to connect to it, which
+%% would otherwise surface as a flaky `no_ready_frame' timeout instead
+%% of a clean skip.
 ipv6_loopback_available() ->
-    case gen_tcp:listen(0, [inet6, {ip, {0, 0, 0, 0, 0, 0, 0, 1}}]) of
-        {ok, S} ->
-            ok = gen_tcp:close(S),
-            true;
+    Loopback = {0, 0, 0, 0, 0, 0, 0, 1},
+    case gen_tcp:listen(0, [inet6, {ip, Loopback}, {active, false}]) of
+        {ok, L} ->
+            {ok, Port} = inet:port(L),
+            Ok =
+                case gen_tcp:connect(Loopback, Port, [inet6], 1000) of
+                    {ok, C} ->
+                        gen_tcp:close(C),
+                        case gen_tcp:accept(L, 1000) of
+                            {ok, A} ->
+                                gen_tcp:close(A),
+                                true;
+                            {error, _} ->
+                                false
+                        end;
+                    {error, _} ->
+                        false
+                end,
+            gen_tcp:close(L),
+            Ok;
         {error, _} ->
             false
     end.


### PR DESCRIPTION
The `h1_echo_text_frame_ipv6` case probed IPv6 only with a `listen` on `::1`. CI macOS runners can bind `::1` yet fail to connect to it, so the case ran and timed out with a flaky `no_ready_frame` instead of skipping. The probe now does a full listen/connect/accept round-trip and the case skips when the loopback is not usable end to end.