### PR TITLE
Honor Retry-After in the retry layer

### DIFF
--- a/src/client/livery_client_retry.erl
+++ b/src/client/livery_client_retry.erl
@@ -10,9 +10,14 @@ methods (GET/HEAD/PUT/DELETE/OPTIONS) are retried unless
 body is never retried (the producer cannot be replayed). Add it with
 `livery_client:retry/1`.
 
+When a retryable response carries a `Retry-After` header (delta-seconds),
+that delay is honored instead of the computed backoff, capped by
+`retry_after_max` ms. An HTTP-date `Retry-After` falls back to backoff.
+
 `Opts`: `max` (default 2), `backoff` (`{BaseMs, Factor}`, default
 `{200, 2.0}`), `statuses` (default `[502, 503, 504]`),
-`retry_non_idempotent` (default `false`).
+`retry_non_idempotent` (default `false`), `retry_after_max` (default
+120000).
 """.
 
 -export([call/3]).
@@ -27,7 +32,7 @@ loop(Req, Next, Opts, Max, Attempt) ->
     Result = Next(Req),
     case retry(Result, Req, Opts, Attempt, Max) of
         true ->
-            timer:sleep(backoff(Opts, Attempt)),
+            timer:sleep(delay(Result, Opts, Attempt)),
             loop(Req, Next, Opts, Max, Attempt + 1);
         false ->
             Result
@@ -60,6 +65,43 @@ retryable({error, _Reason}, _Opts) ->
     true;
 retryable({ok, #{status := Status}}, Opts) ->
     lists:member(Status, maps:get(statuses, Opts, [502, 503, 504])).
+
+%% Honor a Retry-After header (delta-seconds) when present, capped by
+%% `retry_after_max`; otherwise fall back to exponential backoff.
+delay(Result, Opts, Attempt) ->
+    case retry_after_ms(Result) of
+        undefined -> backoff(Opts, Attempt);
+        Ms -> min(Ms, maps:get(retry_after_max, Opts, 120000))
+    end.
+
+retry_after_ms({ok, #{headers := Headers}}) ->
+    case find_header(<<"retry-after">>, Headers) of
+        undefined -> undefined;
+        Value -> parse_delay_seconds(Value)
+    end;
+retry_after_ms(_Result) ->
+    undefined.
+
+%% Only the delta-seconds form is supported; an HTTP-date returns undefined
+%% (the caller falls back to backoff).
+parse_delay_seconds(Value) ->
+    case string:to_integer(string:trim(Value)) of
+        {Secs, Rest} when is_integer(Secs), Secs >= 0 ->
+            case string:trim(Rest) of
+                <<>> -> Secs * 1000;
+                "" -> Secs * 1000;
+                _ -> undefined
+            end;
+        _ ->
+            undefined
+    end.
+
+find_header(Name, Headers) ->
+    L = string:lowercase(Name),
+    case lists:search(fun({K, _}) -> string:lowercase(K) =:= L end, Headers) of
+        {value, {_, V}} -> V;
+        false -> undefined
+    end.
 
 backoff(Opts, Attempt) ->
     {Base, Factor} = maps:get(backoff, Opts, {200, 2.0}),

--- a/test/livery_client_SUITE.erl
+++ b/test/livery_client_SUITE.erl
@@ -18,7 +18,8 @@
     stream_request/1,
     custom_adapter/1,
     no_content_response/1,
-    head_request/1
+    head_request/1,
+    retry_after_layer/1
 ]).
 
 all() ->
@@ -34,7 +35,8 @@ all() ->
         stream_request,
         custom_adapter,
         no_content_response,
-        head_request
+        head_request,
+        retry_after_layer
     ].
 
 init_per_suite(Config) ->
@@ -51,7 +53,8 @@ init_per_suite(Config) ->
         {<<"GET">>, <<"/big">>, fun handle_big/1},
         {<<"GET">>, <<"/block">>, fun handle_block/1},
         {<<"GET">>, <<"/empty">>, fun handle_no_content/1},
-        {<<"HEAD">>, <<"/ping">>, fun handle_ok/1}
+        {<<"HEAD">>, <<"/ping">>, fun handle_ok/1},
+        {<<"GET">>, <<"/retry_after">>, fun handle_retry_after/1}
     ]),
     {ok, Pid} = livery:start_service(#{
         http => #{port => 0},
@@ -92,6 +95,14 @@ handle_flaky(Req) ->
 handle_big(_Req) -> livery_resp:text(200, binary:copy(<<"x">>, 100000)).
 
 handle_no_content(_Req) -> livery_resp:empty(204).
+
+%% First call: 503 with Retry-After: 1 second. Then: 200.
+handle_retry_after(Req) ->
+    Ref = livery_req:config(counter, Req),
+    case atomics:add_get(Ref, 1, 1) of
+        1 -> livery_resp:text(503, [{<<"retry-after">>, <<"1">>}], <<"slow">>);
+        _ -> livery_resp:text(200, <<"ok">>)
+    end.
 
 handle_block(_Req) ->
     timer:sleep(200),
@@ -225,6 +236,20 @@ head_request(Config) ->
     {ok, Resp} = livery_client:request(C, head, <<"/ping">>, #{}),
     ?assertEqual(200, livery_client:status(Resp)),
     ?assertEqual({full, <<>>}, livery_client:body(Resp)).
+
+%% A retryable response with `Retry-After: 1` is honored (the 1s delay dwarfs
+%% the ~50ms backoff), then the retry succeeds.
+retry_after_layer(Config) ->
+    atomics:put(?config(counter, Config), 1, 0),
+    C = livery_client:new(#{
+        base_url => ?config(base, Config),
+        stack => [livery_client:retry(#{max => 2, backoff => {50, 1.0}})]
+    }),
+    T0 = erlang:monotonic_time(millisecond),
+    {ok, Resp} = livery_client:get(C, <<"/retry_after">>),
+    Elapsed = erlang:monotonic_time(millisecond) - T0,
+    ?assertEqual(200, livery_client:status(Resp)),
+    ?assert(Elapsed >= 900).
 
 %%====================================================================
 %% Helpers


### PR DESCRIPTION
The retry layer ignored the `Retry-After` header. Now a retryable response carrying `Retry-After` (delta-seconds) is honored as the inter-attempt delay, capped by `retry_after_max` (default 120000 ms); HTTP-date values fall back to exponential backoff. Backward compatible (no header = unchanged). Covered by a client-suite test.