### PR TITLE
Bump barrel_mcp to 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `barrel_mcp` 2.1.0 -> 2.2.0. Arity-2 MCP tool handlers
+  (`Mod:Fun(Args, Ctx)`) now receive the authenticated principal in
+  `Ctx` under `auth_info`, so owner-scoped tools can identify the
+  caller. The handler passes it through unchanged; no Livery API change.
+
 ## [0.2.5] - 2026-06-07
 
 Maintenance release: HTTP client fixes and a `Retry-After`-aware retry

--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
     {instrument, "1.1.3"},
     {webtransport, "0.3.2"},
     {hackney, "4.2.2"},
-    {barrel_mcp, "2.1.0"}
+    {barrel_mcp, "2.2.0"}
 ]}.
 
 {profiles, [


### PR DESCRIPTION
Bumps `barrel_mcp` 2.1.0 -> 2.2.0.

2.2.0 threads the authenticated principal into arity-2 MCP tool handlers (`Mod:Fun(Args, Ctx)`) under `Ctx.auth_info`, so owner-scoped tools can identify the caller. `livery_mcp` delegates to the unchanged `barrel_mcp_http_engine:handle/6` API and passes the `auth` config through `init_auth/1`, so the principal flows through with no Livery code change.

Verified against 2.2.0: `compile` (warnings_as_errors), `xref`, `dialyzer` clean; `livery_mcp_SUITE` passes (3/3).