### PR TITLE
Release 0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-06-09
+
+Maintenance release: a `barrel_mcp` bump that threads the authenticated
+principal into MCP tool handlers. No Livery API change.
+
 ### Changed
 
 - Bump `barrel_mcp` 2.1.0 -> 2.2.0. Arity-2 MCP tool handlers
@@ -245,6 +250,7 @@ release; the framework is still under active development.
   QUIC round trip because the client and server share one BEAM. Measure
   H3 with an external native QUIC client.
 
+[0.2.6]: https://github.com/benoitc/livery/releases/tag/v0.2.6
 [0.2.5]: https://github.com/benoitc/livery/releases/tag/v0.2.5
 [0.2.4]: https://github.com/benoitc/livery/releases/tag/v0.2.4
 [0.2.3]: https://github.com/benoitc/livery/releases/tag/v0.2.3

--- a/src/livery.app.src
+++ b/src/livery.app.src
@@ -1,6 +1,6 @@
 {application, livery, [
     {description, "Livery: a modern Erlang web framework over HTTP/1.1, HTTP/2, and HTTP/3"},
-    {vsn, "0.2.5"},
+    {vsn, "0.2.6"},
     {registered, [livery_sup]},
     {mod, {livery_app, []}},
     {applications, [


### PR DESCRIPTION
Maintenance release: bumps `barrel_mcp` 2.1.0 -> 2.2.0, which threads the authenticated principal into arity-2 MCP tool handlers (`Ctx.auth_info`). No Livery API change.

Bumps `vsn` to 0.2.6 and moves the changelog entry under [0.2.6].