### PR TITLE
Add push-stream mode to livery_client

### DIFF
--- a/docs/tutorials/call-a-service.md
+++ b/docs/tutorials/call-a-service.md
@@ -205,6 +205,84 @@ wherever you need a user. Timeout, retry, and breaker come along for free
 on every call, and the caller only ever sees `{ok, User}` or a clean
 error.
 
+## 8. Stream a response to your process
+
+A streamed response with `stream => true` gives you a `{stream, Reader}`
+body and `livery_client:read/2`, a blocking pull. That is perfect for a
+process whose only job is to drain the body, but it forces a worker that
+also wants to react to its own messages, a cancel signal, a progress
+tick, into a second process just to run the read loop.
+
+Push mode turns the body around. Set `stream_to` to a pid and the chunks
+arrive as messages, so the worker can selectively receive body chunks and
+its own control messages side by side:
+
+```erlang
+{ok, Resp} = livery_client:request(Client, get, <<"/blob">>, #{
+    stream    => true,
+    stream_to => self()
+}),
+{push, Ref} = livery_client:body(Resp),
+download(Ref, 0).
+
+download(Ref, Bytes) ->
+    receive
+        {livery_response, Ref, {status, 200, _Headers}} ->
+            download(Ref, Bytes);
+        {livery_response, Ref, {chunk, Data}} ->
+            Got = Bytes + byte_size(Data),
+            io:format("~p bytes~n", [Got]),
+            download(Ref, Got);
+        {livery_response, Ref, done} ->
+            {ok, Bytes};
+        {livery_response, Ref, {error, Reason}} ->
+            {error, Reason};
+        cancel ->
+            livery_client:stop_stream(Ref),
+            {cancelled, Bytes}
+    end.
+```
+
+`Ref` is opaque and unique to this request, so a worker running several
+downloads tells them apart by matching on it. The messages always arrive
+in order: one `{status, Status, Headers}`, then zero or more
+`{chunk, Binary}`, then a single `done` (or `{error, Reason}` if the
+transfer fails).
+
+The `cancel` clause is the point: a plain message in the same mailbox aborts
+the download mid-flight. `livery_client:stop_stream/1` drops the connection,
+so a user who quits a multi-gigabyte fetch stops paying for it immediately.
+
+### Backpressure with `flow => manual`
+
+By default chunks are pushed as fast as the wire delivers them. If the
+worker writes each chunk somewhere slower than the network, ask for one
+chunk at a time with `flow => manual` and pull with
+`livery_client:stream_next/1`:
+
+```erlang
+{ok, Resp} = livery_client:request(Client, get, <<"/blob">>, #{
+    stream    => true,
+    stream_to => self(),
+    flow      => manual
+}),
+{push, Ref} = livery_client:body(Resp),
+receive
+    {livery_response, Ref, {status, _, _}} -> ok
+end,
+ok = livery_client:stream_next(Ref),   %% pull the first chunk
+receive
+    {livery_response, Ref, {chunk, First}} -> write(First)
+end.
+```
+
+No chunk arrives until you call `stream_next/1`, so a slow consumer never
+builds an unbounded backlog in its mailbox.
+
+The pull-based `{stream, Reader}` API stays as it was for simple
+consumers; reach for push mode when one process needs to interleave body
+chunks with its own work.
+
 ## Where to go next
 
 - Need to download something large without buffering it? See

--- a/rebar.config
+++ b/rebar.config
@@ -334,10 +334,11 @@
                     livery_client_discover
                 ]
             }},
-            %% Per-stream translators block on receive and exit on the
-            %% monitored worker's DOWN, so an after clause is wrong.
+            %% Per-stream translators (and the client push-stream relay)
+            %% block on receive and exit on the monitored peer's DOWN, so an
+            %% after clause is wrong.
             {elvis_style, no_receive_without_timeout, #{
-                ignore => [livery_h1, livery_h2, livery_h3]
+                ignore => [livery_h1, livery_h2, livery_h3, livery_client_hackney]
             }},
             %% Internal records used directly in specs; introducing a
             %% wrapper type would not add clarity.
@@ -373,6 +374,7 @@
             {elvis_style, max_function_length, #{
                 ignore => [
                     livery,
+                    livery_client_hackney,
                     livery_h1,
                     livery_h2,
                     livery_h3,
@@ -384,6 +386,7 @@
             {elvis_style, max_function_clause_length, #{
                 ignore => [
                     livery,
+                    livery_client_hackney,
                     livery_h1,
                     livery_h2,
                     livery_h3,

--- a/src/client/livery_client.erl
+++ b/src/client/livery_client.erl
@@ -30,12 +30,15 @@ The transport is a `livery_client_adapter`; the default,
 -export([get/2, post/3, put/3, delete/2, request/3, request/4, run/2]).
 -export([status/1, headers/1, header/2, header/3, body/1, method/1, url/1, set_header/3]).
 -export([read/2, read_body/1]).
+-export([stream_next/1, stop_stream/1]).
 -export([timeout/1, concurrency/1, retry/1, circuit_breaker/1, balance/1]).
 -export([add_endpoint/2, remove_endpoint/2]).
 -export([before/1, after_response/1, wrap/1]).
 -export([rebase/2]).
 
--export_type([client/0, request/0, response/0, result/0, next/0, entry/0, stack/0, endpoint/0]).
+-export_type([
+    client/0, request/0, response/0, result/0, next/0, entry/0, stack/0, endpoint/0, stream_ref/0
+]).
 
 -type request() :: #{
     method := atom() | binary(),
@@ -44,13 +47,16 @@ The transport is a `livery_client_adapter`; the default,
     body := empty | {full, iodata()} | {stream, fun()},
     timeout := timeout(),
     stream := boolean(),
+    stream_to := pid() | undefined,
+    flow := auto | manual,
     meta := map()
 }.
 -type response() :: #{
-    status := 100..599,
+    status := 100..599 | undefined,
     headers := [{binary(), binary()}],
-    body := {full, binary()} | {stream, term()}
+    body := {full, binary()} | {stream, term()} | {push, stream_ref()}
 }.
+-opaque stream_ref() :: {livery_stream, module(), term()}.
 -type result() :: {ok, response()} | {error, term()}.
 -type endpoint() :: binary().
 -type next() :: fun((request()) -> result()).
@@ -102,6 +108,24 @@ request(Client, Method, Path) -> request(Client, Method, Path, #{}).
 Send a request. `Opts`: `body` (`iodata` | `{full, _}` | `{stream, Fun}`),
 `headers`, `timeout`, `stream` (`true` to receive a `{stream, Reader}`
 response body), `meta`.
+
+Push streaming: set `stream_to` to a pid and the response is delivered to
+it as ordered messages, freeing the pid to selectively receive body chunks
+alongside its own control messages instead of dedicating a process to a
+pull loop. The reply is `{ok, #{body := {push, Ref}}}`; the recipient then
+receives
+
+```erlang
+{livery_response, Ref, {status, Status, Headers}}
+{livery_response, Ref, {chunk, Binary}}      %% zero or more
+{livery_response, Ref, done}
+{livery_response, Ref, {error, Reason}}       %% instead of done, on failure
+```
+
+`flow` (default `auto`) pushes chunks as fast as the wire allows; `manual`
+sends one chunk per `stream_next/1` for backpressure. `stop_stream/1`
+cancels the stream and drops its connection. Push streaming bypasses the
+layer stack; the adapter owns the connection.
 """.
 -spec request(client(), atom() | binary(), binary(), map()) -> result().
 request(Client, Method, Path, Opts) ->
@@ -111,8 +135,20 @@ request(Client, Method, Path, Opts) ->
 -spec run(client(), request()) -> result().
 run(Client, Req) ->
     #{adapter := Adapter, adapter_opts := AdapterOpts, stack := Stack} = Client,
-    Handler = fun(R) -> Adapter:request(R, AdapterOpts) end,
-    run_stack(Stack, Handler, Req).
+    case maps:get(stream_to, Req, undefined) of
+        Pid when is_pid(Pid) ->
+            start_push(Adapter, AdapterOpts, Req, Pid);
+        _ ->
+            Handler = fun(R) -> Adapter:request(R, AdapterOpts) end,
+            run_stack(Stack, Handler, Req)
+    end.
+
+start_push(Adapter, AdapterOpts, Req, Pid) ->
+    StreamOpts = #{stream_to => Pid, flow => maps:get(flow, Req, auto)},
+    case Adapter:stream(Req, AdapterOpts, StreamOpts) of
+        {ok, Ref} -> {ok, #{status => undefined, headers => [], body => {push, Ref}}};
+        {error, _} = E -> E
+    end.
 
 %%====================================================================
 %% Accessors
@@ -173,6 +209,19 @@ read_body(Reader, Acc) ->
         {done, _Reader1} -> {ok, iolist_to_binary(lists:reverse(Acc))};
         {error, _} = E -> E
     end.
+
+-doc """
+Ask a `flow => manual` push stream for one more `{chunk, _}` message.
+`Ref` is the value from the `{push, Ref}` response body.
+""".
+-spec stream_next(stream_ref()) -> ok | {error, term()}.
+stream_next({livery_stream, Adapter, _} = Ref) ->
+    Adapter:stream_next(Ref).
+
+-doc "Cancel a push stream and release its connection.".
+-spec stop_stream(stream_ref()) -> ok.
+stop_stream({livery_stream, Adapter, _} = Ref) ->
+    Adapter:stop_stream(Ref).
 
 %%====================================================================
 %% Layer constructors
@@ -247,6 +296,8 @@ build_request(Client, Method, Path, Opts) ->
         body => normalize_body(maps:get(body, Opts, empty)),
         timeout => maps:get(timeout, Opts, 30000),
         stream => maps:get(stream, Opts, false),
+        stream_to => maps:get(stream_to, Opts, undefined),
+        flow => maps:get(flow, Opts, auto),
         meta => maps:get(meta, Opts, #{})
     }.
 

--- a/src/client/livery_client_adapter.erl
+++ b/src/client/livery_client_adapter.erl
@@ -18,7 +18,24 @@ write your own to front a different client.
   {error, term()}` - *optional*; pull the next chunk of a streamed
   response body. Only adapters that return a `{stream, Reader}` response
   body implement it.
+- `stream(Request, Opts, StreamOpts) -> {ok, Ref} | {error, term()}` -
+  *optional*; drive the request in a background process owned by the
+  adapter and deliver the response to `StreamOpts`'s `stream_to` pid as
+  ordered `{livery_response, Ref, _}` messages (`{status, Status,
+  Headers}`, `{chunk, Binary}`, `done`, `{error, Reason}`). `StreamOpts`
+  carries `stream_to` (the recipient) and `flow` (`auto` to push as fast
+  as the wire allows, `manual` to send one chunk per `stream_next/1`).
+  `Ref` is opaque and identifies the stream for `stream_next/1` and
+  `stop_stream/1`.
+- `stream_next(Ref) -> ok | {error, term()}` - *optional*; under `flow =>
+  manual`, ask for one more body chunk.
+- `stop_stream(Ref) -> ok` - *optional*; cancel a push stream and release
+  its connection.
 """.
+
+-type stream_ref() :: term().
+-type stream_opts() :: #{stream_to := pid(), flow := auto | manual}.
+-export_type([stream_ref/0, stream_opts/0]).
 
 -callback request(livery_client:request(), map()) ->
     {ok, livery_client:response()} | {error, term()}.
@@ -26,4 +43,11 @@ write your own to front a different client.
 -callback read(term(), timeout()) ->
     {ok, binary(), term()} | {done, term()} | {error, term()}.
 
--optional_callbacks([read/2]).
+-callback stream(livery_client:request(), map(), stream_opts()) ->
+    {ok, stream_ref()} | {error, term()}.
+
+-callback stream_next(stream_ref()) -> ok | {error, term()}.
+
+-callback stop_stream(stream_ref()) -> ok.
+
+-optional_callbacks([read/2, stream/3, stream_next/1, stop_stream/1]).

--- a/src/client/livery_client_hackney.erl
+++ b/src/client/livery_client_hackney.erl
@@ -16,10 +16,20 @@ hackney's `request/5` always buffers the response, so any request that
 either streams its body or wants a streamed response goes through the
 connection API (`request` with a `stream` body, `start_response`,
 `stream_body`).
+
+Push streaming (`stream/3`, `stream_next/1`, `stop_stream/1`) runs the
+request in hackney's async mode (`{async, true | once}`) under a small
+relay process that translates hackney's `{hackney_response, _, _}`
+messages into Livery's `{livery_response, Ref, _}` messages, folding
+hackney's separate `status` and `headers` events into one
+`{status, Status, Headers}`. The relay monitors the recipient and tears
+the connection down if it dies, so a caller that aborts mid-download
+never leaks a connection.
 """.
 -behaviour(livery_client_adapter).
 
 -export([request/2, read/2]).
+-export([stream/3, stream_next/1, stop_stream/1]).
 
 -spec request(livery_client:request(), map()) ->
     {ok, livery_client:response()} | {error, term()}.
@@ -48,9 +58,120 @@ read(Conn, _Timeout) ->
         {error, Reason} -> {error, Reason}
     end.
 
+%% Optional callback: drive the request in a relay process that pushes
+%% `{livery_response, Ref, _}` messages to `stream_to`.
+-spec stream(livery_client:request(), map(), livery_client_adapter:stream_opts()) ->
+    {ok, livery_client_adapter:stream_ref()} | {error, term()}.
+stream(#{body := {stream, _}}, _Opts, _StreamOpts) ->
+    {error, streaming_request_body_unsupported_in_push_mode};
+stream(Req, Opts, #{stream_to := StreamTo} = StreamOpts) ->
+    Flow = maps:get(flow, StreamOpts, auto),
+    %% Spawn the relay first so the ref can name it, then hand it the ref
+    %% and let it open the connection. No hackney message can race ahead
+    %% of the ref because the relay only starts once it holds it.
+    Relay = spawn(fun() ->
+        receive
+            {start, Ref} -> relay_start(Ref, Req, Opts, StreamTo, Flow)
+        end
+    end),
+    Ref = {livery_stream, ?MODULE, Relay},
+    Relay ! {start, Ref},
+    {ok, Ref}.
+
+%% Optional callback: pull one more chunk under `flow => manual`.
+-spec stream_next(livery_client_adapter:stream_ref()) -> ok.
+stream_next({livery_stream, ?MODULE, Relay}) ->
+    Relay ! livery_stream_next,
+    ok.
+
+%% Optional callback: cancel a push stream and drop its connection.
+-spec stop_stream(livery_client_adapter:stream_ref()) -> ok.
+stop_stream({livery_stream, ?MODULE, Relay}) ->
+    Relay ! livery_stop_stream,
+    ok.
+
 %%====================================================================
 %% Internals
 %%====================================================================
+
+%% The relay owns the hackney async connection and the monitor on the
+%% recipient. It opens the connection in async mode, then loops folding
+%% hackney events into Livery messages until done, error, cancel, or the
+%% recipient dies.
+relay_start(Ref, Req, Opts, StreamTo, Flow) ->
+    Method = maps:get(method, Req),
+    Url = maps:get(url, Req),
+    Headers = maps:get(headers, Req, []),
+    Timeout = maps:get(timeout, Req, 30000),
+    Body = to_body(maps:get(body, Req, empty)),
+    AsyncMode =
+        case Flow of
+            manual -> once;
+            _ -> true
+        end,
+    Mon = monitor(process, StreamTo),
+    HackneyOpts = [
+        {recv_timeout, Timeout},
+        {async, AsyncMode},
+        {stream_to, self()}
+        | maps:get(hackney, Opts, [])
+    ],
+    case hackney:request(Method, Url, Headers, Body, HackneyOpts) of
+        {ok, HConn} ->
+            relay_loop(#{
+                ref => Ref,
+                hconn => HConn,
+                caller => StreamTo,
+                mon => Mon,
+                status => undefined
+            });
+        {error, Reason} ->
+            StreamTo ! {livery_response, Ref, {error, Reason}},
+            ok
+    end.
+
+relay_loop(St) ->
+    #{ref := Ref, hconn := HConn, caller := Caller, mon := Mon} = St,
+    receive
+        {hackney_response, HConn, {status, Code, _Reason}} ->
+            relay_loop(St#{status := Code});
+        {hackney_response, HConn, {headers, Headers}} ->
+            Caller ! {livery_response, Ref, {status, maps:get(status, St), Headers}},
+            relay_loop(St);
+        {hackney_response, HConn, done} ->
+            Caller ! {livery_response, Ref, done},
+            ok;
+        {hackney_response, HConn, {error, Reason}} ->
+            Caller ! {livery_response, Ref, {error, Reason}},
+            ok;
+        {hackney_response, HConn, {Kind, Location, _Headers}} when
+            Kind =:= redirect; Kind =:= see_other
+        ->
+            %% Push mode does not follow redirects; report where it points.
+            Caller ! {livery_response, Ref, {error, {redirect, Location}}},
+            ok;
+        {hackney_response, HConn, {informational, _Status, _Reason, _Headers}} ->
+            relay_loop(St);
+        {hackney_response, HConn, Chunk} when is_binary(Chunk) ->
+            Caller ! {livery_response, Ref, {chunk, Chunk}},
+            relay_loop(St);
+        livery_stream_next ->
+            _ = hackney:stream_next(HConn),
+            relay_loop(St);
+        livery_stop_stream ->
+            close_quietly(HConn),
+            ok;
+        {'DOWN', Mon, process, Caller, _Reason} ->
+            close_quietly(HConn),
+            ok
+    end.
+
+close_quietly(HConn) ->
+    try
+        hackney:close(HConn)
+    catch
+        _:_ -> ok
+    end.
 
 %% The connection API is needed when the request body streams or the
 %% caller wants to stream the response; otherwise request/5 (which always

--- a/test/livery_client_SUITE.erl
+++ b/test/livery_client_SUITE.erl
@@ -16,6 +16,9 @@
     circuit_store_recovers/1,
     stream_response/1,
     stream_request/1,
+    push_stream/1,
+    push_stream_stop/1,
+    push_stream_manual/1,
     custom_adapter/1,
     no_content_response/1,
     head_request/1,
@@ -33,6 +36,9 @@ all() ->
         circuit_store_recovers,
         stream_response,
         stream_request,
+        push_stream,
+        push_stream_stop,
+        push_stream_manual,
         custom_adapter,
         no_content_response,
         head_request,
@@ -51,6 +57,7 @@ init_per_suite(Config) ->
         {<<"GET">>, <<"/slow">>, fun handle_slow/1},
         {<<"GET">>, <<"/flaky">>, fun handle_flaky/1},
         {<<"GET">>, <<"/big">>, fun handle_big/1},
+        {<<"GET">>, <<"/chunks">>, fun handle_chunks/1},
         {<<"GET">>, <<"/block">>, fun handle_block/1},
         {<<"GET">>, <<"/empty">>, fun handle_no_content/1},
         {<<"HEAD">>, <<"/ping">>, fun handle_ok/1},
@@ -93,6 +100,13 @@ handle_flaky(Req) ->
     end.
 
 handle_big(_Req) -> livery_resp:text(200, binary:copy(<<"x">>, 100000)).
+
+handle_chunks(_Req) ->
+    Producer = fun(Emit) ->
+        [Emit(<<"chunk", (integer_to_binary(N))/binary>>) || N <- lists:seq(1, 3)],
+        ok
+    end,
+    livery_resp:stream(200, [], Producer).
 
 handle_no_content(_Req) -> livery_resp:empty(204).
 
@@ -216,6 +230,65 @@ stream_request(Config) ->
     {ok, Resp} = livery_client:request(C, post, <<"/echo">>, #{body => Body}),
     ?assertEqual({full, <<"abc">>}, livery_client:body(Resp)).
 
+%% Push mode delivers status, then body chunks, then done, in order, to the
+%% caller's mailbox, leaving it free to selectively receive between chunks.
+push_stream(Config) ->
+    C = livery_client:new(#{base_url => ?config(base, Config)}),
+    {ok, Resp} = livery_client:request(C, get, <<"/chunks">>, #{
+        stream => true, stream_to => self()
+    }),
+    {push, Ref} = livery_client:body(Resp),
+    {Status, Headers} = recv_status(Ref),
+    ?assertEqual(200, Status),
+    ?assert(is_list(Headers)),
+    Body = recv_until_done(Ref, []),
+    ?assertEqual(<<"chunk1chunk2chunk3">>, Body).
+
+%% stop_stream mid-flight cancels the download. We pull one chunk, then stop
+%% before draining the rest; no further chunk or done message follows, and the
+%% relay tears the connection down.
+push_stream_stop(Config) ->
+    C = livery_client:new(#{base_url => ?config(base, Config)}),
+    {ok, Resp} = livery_client:request(C, get, <<"/chunks">>, #{
+        stream => true, stream_to => self(), flow => manual
+    }),
+    {push, Ref} = livery_client:body(Resp),
+    {200, _} = recv_status(Ref),
+    ok = livery_client:stream_next(Ref),
+    receive
+        {livery_response, Ref, {chunk, <<"chunk1">>}} -> ok
+    after 2000 -> ct:fail(no_first_chunk)
+    end,
+    ok = livery_client:stop_stream(Ref),
+    %% The stream is cancelled: no further chunk or done arrives.
+    receive
+        {livery_response, Ref, Msg} -> ct:fail({unexpected_after_stop, Msg})
+    after 300 -> ok
+    end.
+
+%% Under flow => manual the reader pulls one chunk per stream_next; no chunk
+%% arrives until asked for.
+push_stream_manual(Config) ->
+    C = livery_client:new(#{base_url => ?config(base, Config)}),
+    {ok, Resp} = livery_client:request(C, get, <<"/chunks">>, #{
+        stream => true, stream_to => self(), flow => manual
+    }),
+    {push, Ref} = livery_client:body(Resp),
+    {200, _} = recv_status(Ref),
+    %% Nothing is pushed until we ask.
+    receive
+        {livery_response, Ref, {chunk, _}} -> ct:fail(chunk_without_stream_next)
+    after 200 -> ok
+    end,
+    ok = livery_client:stream_next(Ref),
+    receive
+        {livery_response, Ref, {chunk, First}} -> ?assertEqual(<<"chunk1">>, First)
+    after 2000 -> ct:fail(no_chunk_after_stream_next)
+    end,
+    %% Pull the rest one at a time to completion.
+    Rest = pull_until_done(Ref, []),
+    ?assertEqual(<<"chunk2chunk3">>, Rest).
+
 custom_adapter(_Config) ->
     C = livery_client:new(#{adapter => livery_client_fake_adapter}),
     {ok, Resp} = livery_client:get(C, <<"http://ignored/">>),
@@ -254,6 +327,31 @@ retry_after_layer(Config) ->
 %%====================================================================
 %% Helpers
 %%====================================================================
+
+recv_status(Ref) ->
+    receive
+        {livery_response, Ref, {status, Status, Headers}} -> {Status, Headers}
+    after 2000 -> ct:fail(no_status)
+    end.
+
+%% Accumulate auto-flow chunks until done.
+recv_until_done(Ref, Acc) ->
+    receive
+        {livery_response, Ref, {chunk, Bin}} -> recv_until_done(Ref, [Bin | Acc]);
+        {livery_response, Ref, done} -> iolist_to_binary(lists:reverse(Acc));
+        {livery_response, Ref, {error, R}} -> ct:fail({stream_error, R})
+    after 2000 -> ct:fail(no_done)
+    end.
+
+%% Manual flow: one stream_next per chunk until done.
+pull_until_done(Ref, Acc) ->
+    ok = livery_client:stream_next(Ref),
+    receive
+        {livery_response, Ref, {chunk, Bin}} -> pull_until_done(Ref, [Bin | Acc]);
+        {livery_response, Ref, done} -> iolist_to_binary(lists:reverse(Acc));
+        {livery_response, Ref, {error, R}} -> ct:fail({stream_error, R})
+    after 2000 -> ct:fail(no_done)
+    end.
 
 producer([]) ->
     fun() -> eof end;


### PR DESCRIPTION
Adds a push-stream mode so a calling process can receive body chunks as
messages and interleave them with its own control messages in a selective
receive, modelled after hackney's `{async, true}`.

```erlang
{ok, Resp} = livery_client:request(Client, get, Url, #{
    stream    => true,
    stream_to => self()
}),
{push, Ref} = livery_client:body(Resp).
```

The recipient then receives, in order:

```
{livery_response, Ref, {status, Status, Headers}}
{livery_response, Ref, {chunk, Binary}}      %% zero or more
{livery_response, Ref, done}
{livery_response, Ref, {error, Reason}}        %% instead of done, on failure
```

## What changed

- `livery_client_adapter`: new optional callbacks `stream/3`,
  `stream_next/1`, `stop_stream/1`, so non-hackney adapters can follow.
- `livery_client_hackney`: runs the request in hackney async mode under a
  relay process that folds hackney's separate status/headers events into
  one message, monitors the recipient, and drops the connection on
  `stop_stream/1` or recipient death.
- `livery_client`: `request/4` gains `stream_to` and `flow` (`auto` |
  `manual`); push mode bypasses the layer stack and the adapter owns the
  connection. New exports `stream_next/1`, `stop_stream/1`.
- Tutorial section "Stream a response to your process" in
  `docs/tutorials/call-a-service.md`.

## Backpressure and cancellation

- `flow => manual` sends one `{chunk, _}` per `stream_next/1`, so a slow
  consumer never builds an unbounded mailbox backlog.
- `stop_stream/1` cancels mid-flight and releases the connection.

## Notes

- The pull-based `{stream, Reader}` + `read/2` API is unchanged.
- Push mode does not follow redirects; a 3xx is surfaced as
  `{error, {redirect, Location}}`.

## Tests

Three CT cases in `livery_client_SUITE` over a real loopback server:
ordered status/chunks/done, `stop_stream` mid-flight, and `flow => manual`
+ `stream_next`.