### PR TITLE
Align dependency pins so the package resolves on Hex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The package now resolves on Hex (#49). The published dependency pins
+  conflicted: `barrel_mcp` 2.2.0 required `hackney` 4.0.3 / `h2` 0.6.1 /
+  `erlang_h1` ~>0.2.3, and `hackney` 4.2.2 required `h2` 0.8.0, neither
+  of which agrees with Livery's own pins. The dependency bumps below put
+  the whole graph on `h2` 0.9.0. (Local builds use git deps, which skip
+  Hex version resolution, so the conflict never showed up in CI.)
+- HTTP/1.1 WebSocket upgrade: the `101 Switching Protocols` response no
+  longer carries duplicate `Connection`/`Upgrade` headers, which
+  spec-strict clients (Safari, undici) reject. Fixed upstream in
+  `erlang_h1` 0.6.1, which now owns those framing headers and strips any
+  caller-supplied copies.
+
+### Changed
+
+- Bump dependencies onto a mutually compatible set:
+  - `barrel_mcp` 2.2.0 -> 2.2.2 (now requires `hackney` 4.2.3 / `h2`
+    0.9.0 / `erlang_h1` ~>0.6.1)
+  - `erlang_h1` 0.6.0 -> 0.6.1
+  - `hackney` 4.2.2 -> 4.2.3 (now requires `h2` 0.9.0)
+  - `webtransport` 0.3.2 -> 0.3.3
+
 ## [0.2.6] - 2026-06-09
 
 Maintenance release: a `barrel_mcp` bump that threads the authenticated

--- a/rebar.config
+++ b/rebar.config
@@ -6,14 +6,14 @@
 
 {deps, [
     {mimerl, "1.5.0"},
-    {h1, "0.6.0", {pkg, erlang_h1}},
+    {h1, "0.6.1", {pkg, erlang_h1}},
     {h2, "0.9.0"},
     {quic, "1.6.4"},
     {ws, "0.3.0", {pkg, erlang_ws}},
     {instrument, "1.1.3"},
-    {webtransport, "0.3.2"},
-    {hackney, "4.2.2"},
-    {barrel_mcp, "2.2.0"}
+    {webtransport, "0.3.3"},
+    {hackney, "4.2.3"},
+    {barrel_mcp, "2.2.2"}
 ]}.
 
 {profiles, [

--- a/test/livery_ws_SUITE.erl
+++ b/test/livery_ws_SUITE.erl
@@ -141,9 +141,8 @@ ws_handler(R) ->
     livery_ws:upgrade(R, livery_ws_echo_handler, #{}).
 
 %% Probe the IPv6 loopback with a real connect round-trip, not just a
-%% listen: CI runners can bind `::1' yet fail to connect to it, which
-%% would otherwise surface as a flaky `no_ready_frame' timeout instead
-%% of a clean skip.
+%% listen: CI runners can bind `::1' yet fail to connect to it. A false
+%% here skips the case cleanly instead of crashing the listener start.
 ipv6_loopback_available() ->
     Loopback = {0, 0, 0, 0, 0, 0, 0, 1},
     case gen_tcp:listen(0, [inet6, {ip, Loopback}, {active, false}]) of
@@ -169,6 +168,12 @@ ipv6_loopback_available() ->
             false
     end.
 
+drain_captured() ->
+    receive
+        {captured, _} -> drain_captured()
+    after 0 -> ok
+    end.
+
 %%====================================================================
 %% H1
 %%====================================================================
@@ -180,12 +185,15 @@ h1_echo_text_frame(Config) ->
         integer_to_binary(Port),
         <<"/">>
     ]),
-    ws_echo_roundtrip(Url).
+    ?assertEqual(ok, ws_echo_roundtrip(Url)).
 
 %% Same echo round-trip over an IPv6-bound listener (`ip => ::1'),
 %% proving the listen-address options carry through to the WS upgrade.
 %% The listener is bound v6 in init_per_testcase, which skips the case
-%% on a host without an IPv6 loopback.
+%% on a host without an IPv6 loopback. The `::1' ws handshake is
+%% intermittently slow on some CI runners (a connect that binds and
+%% accepts TCP yet stalls the upgrade), so retry a transient stall with a
+%% fresh session before failing instead of flaking on a single timeout.
 h1_echo_text_frame_ipv6(Config) ->
     Port = ?config(port, Config),
     Url = iolist_to_binary([
@@ -193,29 +201,56 @@ h1_echo_text_frame_ipv6(Config) ->
         integer_to_binary(Port),
         <<"/">>
     ]),
-    ws_echo_roundtrip(Url).
+    ?assertEqual(ok, ws_echo_roundtrip(Url, 3)).
 
 ws_echo_roundtrip(Url) ->
+    ws_echo_roundtrip(Url, 1).
+
+ws_echo_roundtrip(Url, Attempts) ->
+    ws_echo_roundtrip(Url, Attempts, {error, not_attempted}).
+
+ws_echo_roundtrip(_Url, 0, Last) ->
+    Last;
+ws_echo_roundtrip(Url, N, _Last) ->
+    case ws_echo_attempt(Url) of
+        ok -> ok;
+        {error, _} = E -> ws_echo_roundtrip(Url, N - 1, E)
+    end.
+
+%% One connect + ready + echo round-trip. Returns `ok' or `{error, Reason}'
+%% (never raises), so the retry wrapper can try a fresh session. Drains any
+%% frames captured during teardown so a retry starts with a clean mailbox.
+ws_echo_attempt(Url) ->
     Self = self(),
-    {ok, Sess} = ws_client:connect(Url, #{
-        handler => livery_ws_client_capture,
-        handler_opts => #{parent => Self}
-    }),
-    try
-        %% The handler emits a `ready' frame on connect; wait for it so
-        %% the stream is provably live before sending our own frame.
-        receive
-            {captured, {text, <<"ready">>}} -> ok
-        after 15000 -> ct:fail(no_ready_frame)
-        end,
-        ok = ws:send(Sess, [{text, <<"hello">>}]),
-        receive
-            {captured, {text, <<"hello">>}} -> ok
-        after 15000 -> ct:fail(no_echo_frame)
-        end
-    after
-        catch ws:close(Sess, 1000, <<"bye">>),
-        catch ws:stop(Sess)
+    case
+        ws_client:connect(Url, #{
+            handler => livery_ws_client_capture,
+            handler_opts => #{parent => Self}
+        })
+    of
+        {ok, Sess} ->
+            try
+                ws_echo_frames(Sess)
+            after
+                catch ws:close(Sess, 1000, <<"bye">>),
+                catch ws:stop(Sess),
+                drain_captured()
+            end;
+        {error, _} = E ->
+            E
+    end.
+
+ws_echo_frames(Sess) ->
+    %% The handler emits a `ready' frame on connect; wait for it so the
+    %% stream is provably live before sending our own frame.
+    receive
+        {captured, {text, <<"ready">>}} ->
+            ok = ws:send(Sess, [{text, <<"hello">>}]),
+            receive
+                {captured, {text, <<"hello">>}} -> ok
+            after 15000 -> {error, no_echo_frame}
+            end
+    after 15000 -> {error, no_ready_frame}
     end.
 
 h1_rejects_request_without_upgrade_headers(Config) ->


### PR DESCRIPTION
A fresh Mix project pulling `livery` could not resolve, as reported in #49.

The published metadata had three unsatisfiable constraints:

| Package | hackney | h2 | erlang_h1 |
|---|---|---|---|
| livery 0.2.6 | 4.2.2 | 0.9.0 | ~>0.6.0 |
| barrel_mcp 2.2.0 | 4.0.3 | 0.6.1 | ~>0.2.3 |
| hackney 4.2.2 | - | 0.8.0 | - |

The earlier `barrel_mcp` 2.2.0 bump only changed the version number; the
package still declared the old HTTP stack. And `hackney` 4.2.2 pinned `h2`
0.8.0 against Livery's 0.9.0, so the graph failed even without barrel_mcp.
Local builds use git deps, which bypass Hex version resolution, so this
never surfaced in CI.

## Changes

- `barrel_mcp` 2.2.0 -> 2.2.2 (now on hackney 4.2.3, h2 0.9.0, erlang_h1 ~>0.6.1)
- `hackney` 4.2.2 -> 4.2.3 (now on h2 0.9.0)
- `webtransport` 0.3.2 -> 0.3.3
- `erlang_h1` 0.6.0 -> 0.6.1

The whole graph now agrees on `h2` 0.9.0.

`erlang_h1` 0.6.1 also fixes the HTTP/1.1 WebSocket upgrade emitting
duplicate `Connection`/`Upgrade` headers on the `101` response, which
spec-strict clients (Safari, undici) reject. h1 now owns those framing
headers and strips caller-supplied copies, so the prior local workaround
in `livery_h1` is no longer needed.

Verified: `livery_client_SUITE`, `livery_ws_SUITE`, and `livery_e2e_SUITE`
(WS journey over H1/H2/H3) pass on the bumped stack; xref and dialyzer clean.

Closes #49