### PR TITLE
Forward TLS ssl_opts to H1 and H2 listeners

### DIFF
--- a/src/livery_h1.erl
+++ b/src/livery_h1.erl
@@ -62,6 +62,7 @@ content-length write via `send_full/5` -> `h1:respond/5`.
     cert => binary() | string(),
     key => binary() | string(),
     cacerts => [binary()],
+    ssl_opts => [ssl:tls_server_option()],
     acceptors => pos_integer(),
     max_body => non_neg_integer() | infinity,
     %% Slow-client guards, passed through to `h1'. They have finite
@@ -251,6 +252,7 @@ build_h1_opts(Opts, Stack, Handler) ->
             cert,
             key,
             cacerts,
+            ssl_opts,
             acceptors,
             handshake_timeout,
             idle_timeout,

--- a/src/livery_h2.erl
+++ b/src/livery_h2.erl
@@ -64,6 +64,7 @@ in `capabilities/1`.
     cert => binary() | string(),
     key => binary() | string(),
     cacerts => [binary()],
+    ssl_opts => [ssl:tls_server_option()],
     acceptors => pos_integer(),
     enable_connect_protocol => boolean(),
     max_body => non_neg_integer() | infinity,
@@ -279,6 +280,7 @@ build_h2_opts(Opts, Stack, Handler) ->
             cert,
             key,
             cacerts,
+            ssl_opts,
             acceptors,
             settings,
             enable_connect_protocol

--- a/test/livery_service_SUITE.erl
+++ b/test/livery_service_SUITE.erl
@@ -22,6 +22,7 @@
     which_listeners_reports_all_three/1,
     router_service_dispatches_routes/1,
     config_is_readable_in_handler/1,
+    https_listener_forwards_ssl_opts/1,
     service_without_handler_or_router_fails/1,
     stop_accepting_refuses_new_connections/1,
     drain_lets_inflight_finish/1,
@@ -39,6 +40,7 @@ all() ->
         which_listeners_reports_all_three,
         router_service_dispatches_routes,
         config_is_readable_in_handler,
+        https_listener_forwards_ssl_opts,
         service_without_handler_or_router_fails,
         stop_accepting_refuses_new_connections,
         drain_lets_inflight_finish,
@@ -172,6 +174,37 @@ config_is_readable_in_handler(_Config) ->
         )
     after
         livery:stop_service(P2)
+    end.
+
+https_listener_forwards_ssl_opts(Config) ->
+    Parent = self(),
+    CertFile = ?config(cert_file, Config),
+    KeyFile = ?config(key_file, Config),
+    SniFun = fun(ServerName) ->
+        Parent ! {sni_seen, ServerName},
+        [{certfile, CertFile}, {keyfile, KeyFile}]
+    end,
+    {ok, Pid} = livery:start_service(#{
+        https => #{
+            port => 0,
+            cert => CertFile,
+            key => KeyFile,
+            ssl_opts => [{sni_fun, SniFun}]
+        },
+        handler => fun(_R) -> livery_resp:text(200, <<"ok">>) end
+    }),
+    try
+        ?assertEqual(
+            <<"ok">>,
+            body_via_h2(maps:get(h2, livery:which_listeners(Pid)))
+        ),
+        receive
+            {sni_seen, "localhost"} -> ok
+        after 1000 ->
+            ct:fail(sni_not_seen)
+        end
+    after
+        livery:stop_service(Pid)
     end.
 
 service_without_handler_or_router_fails(_Config) ->


### PR DESCRIPTION
## Summary

- Forward per-listener `ssl_opts` through the Livery H1 and H2 adapters.
- Add Common Test coverage proving an Erlang/OTP `:ssl` SNI callback reaches the HTTPS listener.

## Tests

- `mise x rebar@3.27.0 erlang@29.0.1 -- rebar3 eunit`
- `mise x rebar@3.27.0 erlang@29.0.1 -- rebar3 ct --suite test/livery_service_SUITE.erl`
