### PR TITLE
Forward H3 sni_callback for per-SNI certificate selection

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
     {mimerl, "1.5.0"},
     {h1, "0.6.1", {pkg, erlang_h1}},
     {h2, "0.9.0"},
-    {quic, "1.6.4"},
+    {quic, "1.6.5"},
     {ws, "0.3.0", {pkg, erlang_ws}},
     {instrument, "1.1.3"},
     {webtransport, "0.3.3"},

--- a/src/livery_h3.erl
+++ b/src/livery_h3.erl
@@ -56,6 +56,14 @@ adapter callbacks, which call into `quic_h3:send_response/4`,
     inet6 => boolean(),
     cert := binary(),
     key := term(),
+    %% Per-SNI certificate selection. Invoked per connection with the
+    %% ClientHello SNI; the returned cert/key override the static
+    %% `cert'/`key' for that handshake. Forwarded to `quic' (>= 1.6.5).
+    sni_callback => fun(
+        (binary() | undefined) ->
+            {ok, #{cert := binary(), key := term(), cert_chain => [binary()]}}
+            | {error, term()}
+    ),
     settings => map(),
     quic_opts => map(),
     max_body => non_neg_integer() | infinity,
@@ -275,18 +283,26 @@ build_h3_opts(Opts, Stack, Handler) ->
         Base
     ).
 
-%% Fold the `ip'/`inet6' bind options into `quic_opts.extra_socket_opts'.
-%% An IPv6 `ip' tuple (or `inet6 => true') selects the inet6 family;
-%% caller-supplied `extra_socket_opts' are preserved.
+%% Build the `quic_opts' map handed to `quic_h3'. Folds the `ip'/`inet6'
+%% bind options into `extra_socket_opts' (an IPv6 `ip' tuple or
+%% `inet6 => true' selects the inet6 family; caller-supplied
+%% `extra_socket_opts' are preserved) and carries `sni_callback' here so
+%% it reaches `quic:start_server' (`quic_h3' only lifts cert/key/cacerts
+%% from the top level).
 -spec quic_opts(listen_opts()) -> map().
 quic_opts(Opts) ->
-    QuicOpts = maps:get(quic_opts, Opts, #{}),
-    case livery_inet:socket_addr_opts(Opts) of
-        [] ->
-            QuicOpts;
-        Addr ->
-            Extra = maps:get(extra_socket_opts, QuicOpts, []),
-            QuicOpts#{extra_socket_opts => Addr ++ Extra}
+    QuicOpts0 = maps:get(quic_opts, Opts, #{}),
+    QuicOpts1 =
+        case livery_inet:socket_addr_opts(Opts) of
+            [] ->
+                QuicOpts0;
+            Addr ->
+                Extra = maps:get(extra_socket_opts, QuicOpts0, []),
+                QuicOpts0#{extra_socket_opts => Addr ++ Extra}
+        end,
+    case maps:find(sni_callback, Opts) of
+        {ok, Fun} -> QuicOpts1#{sni_callback => Fun};
+        error -> QuicOpts1
     end.
 
 -spec copy_keys([atom()], map(), map()) -> map().

--- a/src/livery_service.erl
+++ b/src/livery_service.erl
@@ -80,6 +80,12 @@ in-flight requests finish, use `livery:drain/1,2`.
     key => binary() | string() | term(),
     cacerts => [binary()],
     acceptors => pos_integer(),
+    %% H3 per-SNI certificate selection, forwarded to `quic' (>= 1.6.5).
+    sni_callback => fun(
+        (binary() | undefined) ->
+            {ok, #{cert := binary(), key := term(), cert_chain => [binary()]}}
+            | {error, term()}
+    ),
     settings => map(),
     quic_opts => map(),
     %% Per-listener config; overrides the service-wide `config'.

--- a/test/livery_service_SUITE.erl
+++ b/test/livery_service_SUITE.erl
@@ -23,6 +23,7 @@
     router_service_dispatches_routes/1,
     config_is_readable_in_handler/1,
     https_listener_forwards_ssl_opts/1,
+    http3_listener_forwards_sni_callback/1,
     service_without_handler_or_router_fails/1,
     stop_accepting_refuses_new_connections/1,
     drain_lets_inflight_finish/1,
@@ -41,6 +42,7 @@ all() ->
         router_service_dispatches_routes,
         config_is_readable_in_handler,
         https_listener_forwards_ssl_opts,
+        http3_listener_forwards_sni_callback,
         service_without_handler_or_router_fails,
         stop_accepting_refuses_new_connections,
         drain_lets_inflight_finish,
@@ -200,6 +202,37 @@ https_listener_forwards_ssl_opts(Config) ->
         ),
         receive
             {sni_seen, "localhost"} -> ok
+        after 1000 ->
+            ct:fail(sni_not_seen)
+        end
+    after
+        livery:stop_service(Pid)
+    end.
+
+http3_listener_forwards_sni_callback(Config) ->
+    Parent = self(),
+    CertDer = ?config(cert_der, Config),
+    KeyDer = ?config(key_der, Config),
+    SniCallback = fun(ServerName) ->
+        Parent ! {sni_seen, ServerName},
+        {ok, #{cert => CertDer, key => KeyDer}}
+    end,
+    {ok, Pid} = livery:start_service(#{
+        http3 => #{
+            port => 0,
+            cert => CertDer,
+            key => KeyDer,
+            sni_callback => SniCallback
+        },
+        handler => fun(_R) -> livery_resp:text(200, <<"ok">>) end
+    }),
+    try
+        ?assertEqual(
+            <<"ok">>,
+            body_via_h3(maps:get(h3, livery:which_listeners(Pid)), Config)
+        ),
+        receive
+            {sni_seen, <<"localhost">>} -> ok
         after 1000 ->
             ct:fail(sni_not_seen)
         end


### PR DESCRIPTION
## Summary

Follow-up to #54, which added per-SNI certificate selection for H1/H2 via `ssl_opts`/`sni_fun`. H3 was left out because it runs on the `quic` wire library's own TLS stack, not Erlang's `:ssl`.

quic 1.6.5 adds an `sni_callback` server option. This plumbs it through the H3 adapter so an HTTP/3 listener can pick its certificate per connection from the ClientHello SNI.

- Bump `quic` 1.6.4 -> 1.6.5.
- Add `sni_callback` to `livery_h3` and `livery_service` listener options. The callback rides inside `quic_opts` because `quic_h3` only lifts `cert`/`key`/`cacerts` from the top-level options.
- Add `http3_listener_forwards_sni_callback/1`, the H3 analogue of #54's `https_listener_forwards_ssl_opts/1`.

`cert`/`key` stay required on the H3 listener with `sni_callback` as an override, matching #54. quic 1.6.5 allows omitting them when `sni_callback` is set; a cert-less listener can be a later follow-up.

## Tests

- `rebar3 fmt`, `compile`, `lint`, `xref`, `dialyzer` clean
- `rebar3 ct --suite=test/livery_service_SUITE` (11 pass, incl. the new H3 test)