### PR TITLE
Bump h1 to 0.6.2 and webtransport to 0.4.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,12 +6,12 @@
 
 {deps, [
     {mimerl, "1.5.0"},
-    {h1, "0.6.1", {pkg, erlang_h1}},
+    {h1, "0.6.2", {pkg, erlang_h1}},
     {h2, "0.9.0"},
     {quic, "1.6.5"},
     {ws, "0.3.0", {pkg, erlang_ws}},
     {instrument, "1.1.3"},
-    {webtransport, "0.3.3"},
+    {webtransport, "0.4.0"},
     {hackney, "4.2.3"},
     {barrel_mcp, "2.2.2"}
 ]}.


### PR DESCRIPTION
## Summary

- `h1` 0.6.1 -> 0.6.2: linger-closes instead of sending RST on an early response with an unread request body.
- `webtransport` 0.3.3 -> 0.4.0: adds per-SNI certificate selection (h2+h3) and tracks `quic` 1.6.5, which Livery already pins.

Both are version-only. Livery's WT adapter accepts upgrades on Livery's own H2/H3 listeners (`accept_wt`), not standalone webtransport listeners, so the new `sni_callback` listener option needs no plumbing here: Livery's own H2/H3 SNI path already covers per-hostname certificates.

## Tests

- `fmt`, `compile`, `lint`, `xref`, `dialyzer` clean
- `eunit` (417), and `ct` for `livery_wt`, `livery_parity`, `livery_h1`, `livery_e2e` suites all pass