### PR TITLE
Bump hackney to 4.3.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
     {ws, "0.3.0", {pkg, erlang_ws}},
     {instrument, "1.1.3"},
     {webtransport, "0.4.0"},
-    {hackney, "4.2.3"},
+    {hackney, "4.3.0"},
     {barrel_mcp, "2.2.2"}
 ]}.
 


### PR DESCRIPTION
## Summary

Bump `hackney` 4.2.3 -> 4.3.0, the HTTP client backing `livery_client_hackney`.

## Tests

- `fmt`, `compile`, `lint`, `xref`, `dialyzer` clean
- `eunit` (417) and `ct` for `livery_client` and `livery_client_balance` suites pass