### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.8] - 2026-06-13
+## [0.3.0] - 2026-06-13
 
 Adds deferred responses, per-SNI certificate selection on HTTP/3, and
 per-listener TLS options, with wire-dependency bumps.
@@ -317,7 +317,7 @@ release; the framework is still under active development.
   QUIC round trip because the client and server share one BEAM. Measure
   H3 with an external native QUIC client.
 
-[0.2.8]: https://github.com/benoitc/livery/releases/tag/v0.2.8
+[0.3.0]: https://github.com/benoitc/livery/releases/tag/v0.3.0
 [0.2.7]: https://github.com/benoitc/livery/releases/tag/v0.2.7
 [0.2.6]: https://github.com/benoitc/livery/releases/tag/v0.2.6
 [0.2.5]: https://github.com/benoitc/livery/releases/tag/v0.2.5

--- a/src/livery.app.src
+++ b/src/livery.app.src
@@ -1,6 +1,6 @@
 {application, livery, [
     {description, "Livery: a modern Erlang web framework over HTTP/1.1, HTTP/2, and HTTP/3"},
-    {vsn, "0.2.8"},
+    {vsn, "0.3.0"},
     {registered, [livery_sup]},
     {mod, {livery_app, []}},
     {applications, [


### PR DESCRIPTION
Feature release: deferred responses (`livery_resp:stream_deferred/1`), per-SNI certificate selection on HTTP/3, and per-listener TLS `ssl_opts`, plus wire-dependency bumps (h1 0.6.2, quic 1.6.5, webtransport 0.4.0, hackney 4.3.0).

Bumps `vsn` to 0.3.0. Supersedes the untagged 0.2.8 (the feature surface and the webtransport 0.3 -> 0.4 bump warrant a minor version).