### PR TITLE
Populate authority in HTTP/2 requests

### DIFF
--- a/src/livery_h2.erl
+++ b/src/livery_h2.erl
@@ -415,16 +415,28 @@ reject_overload(Stream) ->
     livery_body:reader()
 ) -> livery_req:req().
 build_req(Conn, StreamId, Method, Path, Headers, Reader) ->
+    Authority = proplists:get_value(<<":authority">>, Headers, <<>>),
+    Headers1 = normalize_authority_headers(Authority, Headers),
     livery_req:new(#{
         protocol => h2,
         method => Method,
+        authority => Authority,
         path => Path,
-        headers => Headers,
+        headers => Headers1,
         body => {stream, Reader},
         adapter => ?MODULE,
         stream => {Conn, StreamId},
         engine_pid => Conn
     }).
+
+-spec normalize_authority_headers(binary(), h2:headers()) -> h2:headers().
+normalize_authority_headers(Authority, Headers) ->
+    Headers1 = lists:filter(fun({Name, _Value}) -> Name =/= <<":authority">> end, Headers),
+    case {Authority, proplists:is_defined(<<"host">>, Headers1)} of
+        {<<>>, _} -> Headers1;
+        {_, true} -> Headers1;
+        {_, false} -> [{<<"host">>, Authority} | Headers1]
+    end.
 
 -spec split_query(binary()) -> {binary(), binary()}.
 split_query(Path) ->

--- a/test/livery_h2_SUITE.erl
+++ b/test/livery_h2_SUITE.erl
@@ -23,6 +23,7 @@
     streaming_chunked_response/1,
     sse_response/1,
     echo_buffered_body/1,
+    authority_request/1,
     error_500_on_crash/1,
     response_with_trailers/1,
     cancel_on_connection_close/1,
@@ -41,6 +42,7 @@ all() ->
         streaming_chunked_response,
         sse_response,
         echo_buffered_body,
+        authority_request,
         error_500_on_crash,
         response_with_trailers,
         cancel_on_connection_close,
@@ -115,6 +117,10 @@ echo_buffered_body(Config) ->
     {200, _, Body, _} = post(Config, <<"/">>, <<"echo me">>),
     ?assertEqual(<<"echo me">>, Body).
 
+authority_request(Config) ->
+    {200, _, Body, _} = get_authority(Config, <<"example.localhost">>),
+    ?assertEqual(<<"example.localhost|example.localhost|none">>, Body).
+
 error_500_on_crash(Config) ->
     {Status, _, Body, _} = get(Config, <<"/">>),
     ?assertEqual(500, Status),
@@ -155,6 +161,13 @@ handler_for(echo_buffered_body) ->
         {stream, Reader} = livery_req:body(R),
         {ok, Bytes, _} = livery_body:read_all(Reader, 5000),
         livery_resp:text(200, Bytes)
+    end;
+handler_for(authority_request) ->
+    fun(R) ->
+        Authority = livery_req:authority(R),
+        Host = livery_req:header(<<"host">>, R, <<>>),
+        PseudoAuthority = livery_req:header(<<":authority">>, R, <<"none">>),
+        livery_resp:text(200, [Authority, <<"|">>, Host, <<"|">>, PseudoAuthority])
     end;
 handler_for(error_500_on_crash) ->
     fun(_R) -> error(boom) end;
@@ -229,6 +242,19 @@ send_to_gone_client_is_closed(_Config) ->
 
 get(Config, Path) ->
     request(<<"GET">>, Config, Path, <<>>).
+
+get_authority(Config, Authority) ->
+    Port = ?config(port, Config),
+    {ok, Conn} = h2:connect("127.0.0.1", Port, #{transport => tcp}),
+    {ok, StreamId} = h2:request(Conn, [
+        {<<":method">>, <<"GET">>},
+        {<<":path">>, <<"/">>},
+        {<<":scheme">>, <<"http">>},
+        {<<":authority">>, Authority}
+    ]),
+    Result = collect_response(Conn, StreamId, undefined, [], [], undefined),
+    h2:close(Conn),
+    Result.
 
 post(Config, Path, Body) ->
     request(<<"POST">>, Config, Path, Body).


### PR DESCRIPTION
## Motivation

Livery has an `authority` field on `#livery_req{}` so handlers and middleware can access the request authority/host independently of ordinary headers. The HTTP/2 adapter currently leaves this field empty because the underlying h2 callback does not expose `:authority` after pseudo-header filtering.

That breaks virtual-host and reverse-proxy use cases where routing depends on the request authority, especially for HTTP/2/TLS local development and edge proxying.

## Change

When h2 exposes `:authority`, the HTTP/2 adapter now:

- populates `livery_req:authority/1`
- synthesizes a regular `host` header from `:authority` when no `host` header was sent
- removes `:authority` from application-visible headers

The test asserts that the handler sees the request authority and host, but not the pseudo-header.

## Dependency

Draft until the matching erlang_h2 change lands/releases:

- https://github.com/benoitc/erlang_h2/pull/18

This PR intentionally does not point `rebar.config` at a fork. Once h2 is merged/released, this branch can bump the h2 dependency normally if needed.