### PR TITLE
Drive h1 early-response drain from handler responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,43 @@ events(_Req) ->
 Chunked bodies, NDJSON, file responses with byte ranges, WebSocket and
 WebTransport over H2/H3 work the same way.
 
+## Early-response semantics
+
+Sometimes a handler answers before it has read the request body, like
+rejecting an oversized upload with a `413`. On HTTP/1.1 the connection
+would normally close right after the response, and with a large upload
+still in flight the close can reach the client before it reads your
+`413`, so the client sees a reset instead.
+
+Livery handles this for you. When you return a full response before the
+body is drained, it reads and discards the rest of the inbound body
+before closing, so the client gets the response:
+
+```erlang
+reject(_Req) ->
+    livery_resp:json(413, [], <<"{\"error\":\"too_big\"}">>).
+```
+
+The drain is bounded by a budget you set per listener (defaults to no
+byte cap and a 30 s deadline):
+
+```erlang
+{ok, _} = livery:start_listener(livery_h1, #{
+    port => 8080,
+    early_response_drain => {16#400000, 5000},  %% 4 MiB / 5 s
+    handler => fun reject/1
+}).
+```
+
+Override it for a single response, or disable the drain with `none`:
+
+```erlang
+livery_resp:json(413, [], Body, #{early_response_drain => {16#400000, 5000}}).
+```
+
+The per-response override applies to full responses. Streaming responses
+(SSE, NDJSON, chunked, files) use the listener budget.
+
 ## Features
 
 - **One handler, three wires** — write a handler once; serve it over

--- a/include/livery.hrl
+++ b/include/livery.hrl
@@ -42,7 +42,18 @@
     trailers ::
         undefined
         | [{binary(), binary()}]
-        | fun(() -> [{binary(), binary()}])
+        | fun(() -> [{binary(), binary()}]),
+    %% Early-response inbound-drain budget for HTTP/1.1. When a handler
+    %% commits this response before the request body is fully read, h1
+    %% drains the leftover inbound body before closing so the client
+    %% reads the response. `default' uses the listener budget; `none'
+    %% disables the drain (close immediately); `{MaxBytes, MaxMs}' (either
+    %% component `infinity') bounds it for this response only. Honored on
+    %% full responses; streaming responses use the listener budget.
+    early_response_drain = default ::
+        default
+        | none
+        | {non_neg_integer() | infinity, non_neg_integer() | infinity}
 }).
 
 -endif.

--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 
 {deps, [
     {mimerl, "1.5.0"},
-    {h1, "~> 0.6.2", {pkg, erlang_h1}},
+    {h1, "~> 0.7.0", {pkg, erlang_h1}},
     {h2, "~> 0.10.1"},
     {quic, "~> 1.6.5"},
     {ws, "~> 0.3.0", {pkg, erlang_ws}},

--- a/src/livery.erl
+++ b/src/livery.erl
@@ -211,19 +211,27 @@ emit(Adapter, Stream, #livery_resp{} = Resp) ->
     Headers = livery_resp:headers(Resp),
     Body = livery_resp:body(Resp),
     Trailers = livery_resp:trailers(Resp),
-    emit_body(Adapter, Stream, Status, Headers, Body, Trailers).
+    EndOpts = drain_opts(livery_resp:early_response_drain(Resp)),
+    emit_body(Adapter, Stream, Status, Headers, Body, Trailers, EndOpts).
 
-emit_body(_Adapter, _Stream, _Status, _Hs, taken_over, _Trailers) ->
+%% Base send-opts carrying the per-response early-response drain budget.
+%% `default' adds nothing, so the adapter falls back to the listener
+%% budget; any other value is passed through for the adapter to honor on
+%% the stream-terminating call.
+drain_opts(default) -> #{};
+drain_opts(Drain) -> #{early_response_drain => Drain}.
+
+emit_body(_Adapter, _Stream, _Status, _Hs, taken_over, _Trailers, _EndOpts) ->
     %% Stream/socket was handed off (e.g. via livery_ws:upgrade/3).
     %% The adapter no longer owns it; nothing more to emit.
     ok;
-emit_body(Adapter, Stream, Status, Hs, empty, _Trailers) ->
-    Adapter:send_headers(Stream, Status, Hs, #{end_stream => true});
-emit_body(Adapter, Stream, Status, Hs, {full, IoData}, Trailers) ->
+emit_body(Adapter, Stream, Status, Hs, empty, _Trailers, EndOpts) ->
+    Adapter:send_headers(Stream, Status, Hs, EndOpts#{end_stream => true});
+emit_body(Adapter, Stream, Status, Hs, {full, IoData}, Trailers, EndOpts) ->
     HasTrailers = Trailers =/= undefined,
     case iolist_size(IoData) of
         0 when not HasTrailers ->
-            Adapter:send_headers(Stream, Status, Hs, #{end_stream => true});
+            Adapter:send_headers(Stream, Status, Hs, EndOpts#{end_stream => true});
         0 ->
             case Adapter:send_headers(Stream, Status, Hs, #{end_stream => false}) of
                 ok -> emit_trailers(Adapter, Stream, Trailers);
@@ -237,12 +245,12 @@ emit_body(Adapter, Stream, Status, Hs, {full, IoData}, Trailers) ->
                 true ->
                     %% Coalesce headers + body into one adapter call (and
                     %% one socket write) when the adapter supports it.
-                    Adapter:send_full(Stream, Status, Hs, IoData, #{end_stream => true});
+                    Adapter:send_full(Stream, Status, Hs, IoData, EndOpts#{end_stream => true});
                 false ->
                     emit_full_granular(Adapter, Stream, Status, Hs, IoData, Trailers)
             end
     end;
-emit_body(Adapter, Stream, Status, Hs, {chunked, Producer}, Trailers) ->
+emit_body(Adapter, Stream, Status, Hs, {chunked, Producer}, Trailers, _EndOpts) ->
     case Adapter:send_headers(Stream, Status, Hs, #{end_stream => false}) of
         ok ->
             Emit = fun(Chunk) ->
@@ -252,7 +260,7 @@ emit_body(Adapter, Stream, Status, Hs, {chunked, Producer}, Trailers) ->
         Other ->
             Other
     end;
-emit_body(Adapter, Stream, Status, Hs, {sse, Producer}, Trailers) ->
+emit_body(Adapter, Stream, Status, Hs, {sse, Producer}, Trailers, _EndOpts) ->
     case Adapter:send_headers(Stream, Status, Hs, #{end_stream => false}) of
         ok ->
             Emit = fun(Event) ->
@@ -266,14 +274,14 @@ emit_body(Adapter, Stream, Status, Hs, {sse, Producer}, Trailers) ->
         Other ->
             Other
     end;
-emit_body(Adapter, Stream, _Status, Hs, {deferred, Resolver}, _Trailers) ->
+emit_body(Adapter, Stream, _Status, Hs, {deferred, Resolver}, _Trailers, _EndOpts) ->
     %% The resolver runs here, in the worker, before any header write,
     %% so it can still choose the status and body shape. The outer Hs
     %% carries any headers added by wrapping middleware; the decision
     %% wins on a name conflict.
     Resolved = livery_resp:resolve_deferred(Hs, Resolver()),
     emit(Adapter, Stream, Resolved);
-emit_body(Adapter, Stream, Status, Hs, {file, Path, Range}, Trailers) ->
+emit_body(Adapter, Stream, Status, Hs, {file, Path, Range}, Trailers, _EndOpts) ->
     case file_segment(Path, Range) of
         {error, enoent} ->
             Adapter:send_headers(Stream, 404, [], #{end_stream => true});
@@ -335,7 +343,7 @@ emit_body(Adapter, Stream, Status, Hs, {file, Path, Range}, Trailers) ->
                     end
             end
     end;
-emit_body(Adapter, Stream, _Status, _Hs, {upgrade, _Kind, _State}, _Trailers) ->
+emit_body(Adapter, Stream, _Status, _Hs, {upgrade, _Kind, _State}, _Trailers, _EndOpts) ->
     %% Upgrades are handled at the adapter level (livery_ws, livery_wt).
     Adapter:reset(Stream, upgrade_not_handled_at_emit),
     {error, not_implemented}.

--- a/src/livery_adapter.erl
+++ b/src/livery_adapter.erl
@@ -55,7 +55,11 @@ here.
 
 -type send_opts() :: #{
     end_stream => boolean(),
-    flush => boolean()
+    flush => boolean(),
+    %% Per-response early-response inbound-drain budget. Honored by the
+    %% HTTP/1.1 adapter on the stream-terminating call; ignored by
+    %% adapters that read only `end_stream'.
+    early_response_drain => livery_resp:drain()
 }.
 
 -type capabilities() :: #{

--- a/src/livery_h1.erl
+++ b/src/livery_h1.erl
@@ -72,6 +72,14 @@ content-length write via `send_full/5` -> `h1:respond/5`.
     idle_timeout => timeout(),
     request_timeout => timeout(),
     handshake_timeout => timeout(),
+    %% Early-response inbound-drain budget (lingering close): when a
+    %% handler responds before the request body is fully read, h1 drains
+    %% the leftover body before closing so the client reads the response.
+    %% `{MaxBytes, MaxMs}' (either component `infinity'), `0' disables.
+    %% Defaults to h1's `{infinity, 30000}'. `lingering_timeout => Ms' is
+    %% the time-only form.
+    early_response_drain => 0 | {non_neg_integer() | infinity, non_neg_integer() | infinity},
+    lingering_timeout => timeout(),
     max_keepalive_requests => pos_integer() | infinity,
     %% Shared service config, readable in handlers via livery_req:config/1.
     config => term(),
@@ -121,14 +129,17 @@ stop(Listener) ->
 ) ->
     livery_adapter:send_result().
 send_headers({Conn, StreamId}, Status, Headers, Opts) ->
-    case h1:send_response(Conn, StreamId, Status, Headers) of
-        ok ->
-            case maps:get(end_stream, Opts, false) of
-                true -> h1:send_data(Conn, StreamId, <<>>, true);
-                false -> ok
-            end;
-        Other ->
-            Other
+    case {maps:get(end_stream, Opts, false), drain_opts(Opts)} of
+        {true, {ok, RespOpts}} ->
+            %% Empty-body early response with a per-response drain budget:
+            %% commit it via respond/6 so h1 honors the budget on close.
+            h1:respond(Conn, StreamId, Status, Headers, <<>>, RespOpts);
+        {EndStream, _} ->
+            case h1:send_response(Conn, StreamId, Status, Headers) of
+                ok when EndStream -> h1:send_data(Conn, StreamId, <<>>, true);
+                ok -> ok;
+                Other -> Other
+            end
     end.
 
 -spec send_full(
@@ -142,9 +153,13 @@ send_headers({Conn, StreamId}, Status, Headers, Opts) ->
 %% Coalesce a full response (headers + body) into a single content-length
 %% write via h1:respond/5, instead of the granular send_headers/send_data
 %% path which frames the body as chunked. livery:emit/3 picks this up
-%% because the callback is exported.
-send_full({Conn, StreamId}, Status, Headers, IoData, _Opts) ->
-    h1:respond(Conn, StreamId, Status, Headers, IoData).
+%% because the callback is exported. A per-response early-response drain
+%% budget routes through respond/6 so h1 honors it on an early close.
+send_full({Conn, StreamId}, Status, Headers, IoData, Opts) ->
+    case drain_opts(Opts) of
+        {ok, RespOpts} -> h1:respond(Conn, StreamId, Status, Headers, IoData, RespOpts);
+        none -> h1:respond(Conn, StreamId, Status, Headers, IoData)
+    end.
 
 -spec send_data(stream(), iodata(), livery_adapter:send_opts()) ->
     livery_adapter:send_result().
@@ -176,6 +191,23 @@ capabilities(_Listener) ->
         datagrams => false,
         capsules => false
     }.
+
+%% Translate the per-response `early_response_drain' send-opt into the
+%% h1:respond/6 options map. Absent or `default' yields `none' (h1 uses
+%% the listener budget); any other value produces the per-response map.
+-spec drain_opts(livery_adapter:send_opts()) -> {ok, h1:respond_opts()} | none.
+drain_opts(Opts) ->
+    case maps:get(early_response_drain, Opts, default) of
+        default -> none;
+        Drain -> {ok, #{early_response_drain => to_h1(Drain)}}
+    end.
+
+%% `none' disables the drain (h1's `0'); a `{MaxBytes, MaxMs}' budget
+%% passes straight through.
+-spec to_h1(none | {non_neg_integer() | infinity, non_neg_integer() | infinity}) ->
+    h1:early_response_drain().
+to_h1(none) -> 0;
+to_h1({MaxBytes, MaxMs}) -> {MaxBytes, MaxMs}.
 
 %%====================================================================
 %% WebSocket handoff (called by livery_ws:upgrade/3)
@@ -257,6 +289,8 @@ build_h1_opts(Opts, Stack, Handler) ->
             handshake_timeout,
             idle_timeout,
             request_timeout,
+            early_response_drain,
+            lingering_timeout,
             max_keepalive_requests
         ],
         Opts,
@@ -432,7 +466,7 @@ translate_until_done(
                     WorkerPid ! {livery_body, BodyRef, eof},
                     Loop(Cbs, Fired, Bytes1);
                 _ ->
-                    abort_body({Conn, StreamId}, WorkerPid, BodyRef),
+                    abort_body(WorkerPid, BodyRef),
                     Loop(Cbs, Fired, aborted)
             end;
         {h1_stream, StreamId, {data, Chunk, false}} ->
@@ -443,7 +477,7 @@ translate_until_done(
                 aborted ->
                     Loop(Cbs, Fired, aborted);
                 over ->
-                    abort_body({Conn, StreamId}, WorkerPid, BodyRef),
+                    abort_body(WorkerPid, BodyRef),
                     Loop(Cbs, Fired, aborted)
             end;
         {h1_stream, StreamId, {trailers, Headers}} ->
@@ -466,10 +500,15 @@ translate_until_done(
             ok
     end.
 
-%% Signal the worker that the body exceeded `max_body' and cut the
-%% stream so the client stops sending. Bounds the worker mailbox.
--spec abort_body(stream(), pid(), reference()) -> ok.
-abort_body(Stream, WorkerPid, BodyRef) ->
+%% Signal the worker that the body exceeded `max_body' and switch the
+%% translator to drop-mode (the caller loops with `aborted'), which
+%% bounds the worker mailbox. We deliberately do NOT reset the stream:
+%% the handler can still commit a response (typically 413) and h1's
+%% early-response drain reads and discards the rest of the inbound body
+%% before closing, so the client reads the response instead of an RST.
+%% The leftover inbound is bounded by h1's drain budget and the
+%% request timeout; the worker mailbox is bounded by drop-mode.
+-spec abort_body(pid(), reference()) -> ok.
+abort_body(WorkerPid, BodyRef) ->
     WorkerPid ! {livery_body, BodyRef, {error, body_too_large}},
-    _ = reset(Stream, body_too_large),
     ok.

--- a/src/livery_resp.erl
+++ b/src/livery_resp.erl
@@ -23,6 +23,7 @@ error after the handler returns but before anything is written.
     headers/1,
     body/1,
     trailers/1,
+    early_response_drain/1,
 
     with_status/2,
     with_header/3,
@@ -32,13 +33,16 @@ error after the handler returns but before anything is written.
     with_body/2,
     with_etag/2,
     with_cache_control/2,
+    with_early_response_drain/2,
 
     text/2,
     text/3,
+    text/4,
     html/2,
     html/3,
     json/2,
     json/3,
+    json/4,
 
     empty/1,
 
@@ -61,7 +65,18 @@ error after the handler returns but before anything is written.
     upgrade/2
 ]).
 
--export_type([resp/0, body/0, deferred_decision/0, cache_directive/0]).
+-export_type([resp/0, body/0, deferred_decision/0, cache_directive/0, drain/0, resp_opts/0]).
+
+%% Early-response inbound-drain budget. `default' keeps the listener's
+%% budget, `none' disables the drain (close immediately), and a
+%% `{MaxBytes, MaxMs}' tuple (either component `infinity') bounds it for
+%% this one response.
+-type drain() ::
+    default
+    | none
+    | {non_neg_integer() | infinity, non_neg_integer() | infinity}.
+
+-type resp_opts() :: #{early_response_drain => drain()}.
 
 -type cache_directive() ::
     no_cache
@@ -136,6 +151,10 @@ body(#livery_resp{body = B}) -> B.
     | fun(() -> [{header_name(), header_value()}]).
 trailers(#livery_resp{trailers = T}) -> T.
 
+-doc "The response's early-response inbound-drain budget. See `with_early_response_drain/2`.".
+-spec early_response_drain(resp()) -> drain().
+early_response_drain(#livery_resp{early_response_drain = D}) -> D.
+
 -spec with_status(100..599, resp()) -> resp().
 with_status(Status, Resp) -> Resp#livery_resp{status = Status}.
 
@@ -205,6 +224,21 @@ Pass a verbatim binary, or a list of directives: the atoms `no_cache`,
 with_cache_control(Value, Resp) ->
     with_header(<<"cache-control">>, format_cache_control(Value), Resp).
 
+-doc """
+Set the early-response inbound-drain budget for this response.
+
+When a handler commits a response before reading the request body
+(e.g. rejecting an oversized upload with 413), HTTP/1.1 drains the
+leftover inbound body before closing so the client reads the
+response. `default` keeps the listener's budget; `none` disables the
+drain and closes immediately; `{MaxBytes, MaxMs}` (either component
+`infinity`) bounds it for this response only. Honored on full
+responses; streaming responses use the listener budget.
+""".
+-spec with_early_response_drain(drain(), resp()) -> resp().
+with_early_response_drain(Drain, Resp) ->
+    Resp#livery_resp{early_response_drain = Drain}.
+
 %%====================================================================
 %% Convenience builders
 %%====================================================================
@@ -225,6 +259,11 @@ text(Status, ExtraHeaders, Body) ->
         ),
         {full, Body}
     ).
+
+-doc "`text/3` with response options (e.g. `early_response_drain`).".
+-spec text(100..599, [{header_name(), header_value()}], iodata(), resp_opts()) -> resp().
+text(Status, ExtraHeaders, Body, Opts) ->
+    apply_opts(text(Status, ExtraHeaders, Body), Opts).
 
 -doc "`text/html; charset=utf-8` response.".
 -spec html(100..599, iodata()) -> resp().
@@ -265,6 +304,17 @@ json(Status, ExtraHeaders, Body) ->
         ),
         {full, Body}
     ).
+
+-doc """
+`json/3` with response options.
+
+Use the `early_response_drain` key to tune the inbound drain for an
+early reject, e.g.
+`json(413, [], Body, #{early_response_drain => {16#400000, 5000}})`.
+""".
+-spec json(100..599, [{header_name(), header_value()}], iodata(), resp_opts()) -> resp().
+json(Status, ExtraHeaders, Body, Opts) ->
+    apply_opts(json(Status, ExtraHeaders, Body), Opts).
 
 -doc "Headers-only response.".
 -spec empty(100..599) -> resp().
@@ -467,6 +517,13 @@ upgrade(Kind, State) when Kind =:= ws; Kind =:= wt ->
 %%====================================================================
 %% Helpers
 %%====================================================================
+
+-spec apply_opts(resp(), resp_opts()) -> resp().
+apply_opts(Resp, Opts) ->
+    case maps:find(early_response_drain, Opts) of
+        {ok, Drain} -> with_early_response_drain(Drain, Resp);
+        error -> Resp
+    end.
 
 -spec with_default(
     header_name(),

--- a/src/livery_service.erl
+++ b/src/livery_service.erl
@@ -88,6 +88,11 @@ in-flight requests finish, use `livery:drain/1,2`.
     ),
     settings => map(),
     quic_opts => map(),
+    %% HTTP/1.1 early-response inbound-drain budget (lingering close).
+    %% See `livery_h1' `listen_opts()'. `lingering_timeout => Ms' is the
+    %% time-only form. Ignored by the H2/H3 listeners.
+    early_response_drain => 0 | {non_neg_integer() | infinity, non_neg_integer() | infinity},
+    lingering_timeout => timeout(),
     %% Per-listener config; overrides the service-wide `config'.
     config => term()
 }.

--- a/test/livery_h1_SUITE.erl
+++ b/test/livery_h1_SUITE.erl
@@ -26,6 +26,8 @@
     sse_response/1,
     echo_buffered_body/1,
     body_ceiling_rejects_oversize/1,
+    oversize_upload_delivers_413/1,
+    early_response_no_read_delivers_413/1,
     error_500_on_crash/1,
     cancel_on_client_disconnect/1
 ]).
@@ -45,6 +47,8 @@ all() ->
         sse_response,
         echo_buffered_body,
         body_ceiling_rejects_oversize,
+        oversize_upload_delivers_413,
+        early_response_no_read_delivers_413,
         error_500_on_crash,
         cancel_on_client_disconnect
     ].
@@ -141,6 +145,33 @@ body_ceiling_rejects_oversize(Config) ->
     {ok, Over, _, _} = post(Config, <<"/">>, binary:copy(<<"x">>, 256)),
     ?assertEqual(413, Over).
 
+%% A large upload past the listener's `max_body' cap must still deliver the
+%% handler's 413: the cap aborts the body read, the handler responds, and
+%% h1's early-response drain reads the rest before closing so the client
+%% reads the response instead of a reset. Looped to shake the race.
+oversize_upload_delivers_413(Config) ->
+    %% max_body is 1 MiB for this case; the body is 2 MiB.
+    Body = binary:copy(<<"x">>, 2 * 1024 * 1024),
+    lists:foreach(
+        fun(_) ->
+            {ok, Status, _, RBody} = post_no_pool(Config, <<"/">>, Body),
+            ?assertEqual(413, Status),
+            ?assertEqual(<<"{\"error\":\"too_big\"}">>, RBody)
+        end,
+        lists:seq(1, 25)
+    ).
+
+%% A handler that commits a 413 without reading the (large, in-flight) body
+%% must still deliver it. h1 drains the leftover inbound body before closing.
+early_response_no_read_delivers_413(Config) ->
+    Body = binary:copy(<<"x">>, 2 * 1024 * 1024),
+    lists:foreach(
+        fun(_) ->
+            ?assertMatch({ok, 413, _, _}, post_no_pool(Config, <<"/">>, Body))
+        end,
+        lists:seq(1, 25)
+    ).
+
 error_500_on_crash(Config) ->
     {ok, Status, _Headers, Body} = get(Config, <<"/">>),
     ?assertEqual(500, Status),
@@ -177,6 +208,7 @@ stack_for(_TC) -> [].
 
 %% Small ceiling for the over-size case; default for everything else.
 max_body_for(body_ceiling_rejects_oversize) -> 64;
+max_body_for(oversize_upload_delivers_413) -> 1024 * 1024;
 max_body_for(_TC) -> 16 * 1024 * 1024.
 
 handler_for(text_response) ->
@@ -227,6 +259,17 @@ handler_for(body_ceiling_rejects_oversize) ->
             {error, body_too_large, _} -> livery_resp:text(413, <<"too large">>)
         end
     end;
+handler_for(oversize_upload_delivers_413) ->
+    fun(R) ->
+        {stream, Reader} = livery_req:body(R),
+        case livery_body:read_all(Reader, 5000) of
+            {ok, Bytes, _} -> livery_resp:text(200, Bytes);
+            {error, body_too_large, _} -> livery_resp:json(413, <<"{\"error\":\"too_big\"}">>)
+        end
+    end;
+handler_for(early_response_no_read_delivers_413) ->
+    %% Commit a 413 without reading the body at all.
+    fun(_R) -> livery_resp:json(413, <<"{\"error\":\"too_big\"}">>) end;
 handler_for(error_500_on_crash) ->
     fun(_R) -> error(boom) end;
 handler_for(cancel_on_client_disconnect) ->
@@ -268,6 +311,29 @@ request(Method, Config, Path, Body) ->
             [with_body, {recv_timeout, ?REQUEST_TIMEOUT}]
         ),
     {ok, Status, normalize(RespHeaders), RespBody}.
+
+%% POST without hackney's connection pool so each request rides a fresh
+%% socket. Used by the early-response cases, where the server closes the
+%% connection after delivering the response. Returns hackney's error tuple
+%% verbatim so a lost response (the bug) fails the assertion clearly.
+post_no_pool(Config, Path, Body) ->
+    Port = ?config(port, Config),
+    Url = iolist_to_binary([<<"http://127.0.0.1:">>, integer_to_binary(Port), Path]),
+    Headers = [{<<"Content-Length">>, integer_to_binary(byte_size(Body))}],
+    case
+        hackney:request(
+            <<"POST">>,
+            Url,
+            Headers,
+            Body,
+            [with_body, {pool, false}, {recv_timeout, ?REQUEST_TIMEOUT}]
+        )
+    of
+        {ok, Status, RespHeaders, RespBody} ->
+            {ok, Status, normalize(RespHeaders), RespBody};
+        {error, _} = Error ->
+            Error
+    end.
 
 normalize(Headers) ->
     [{string:lowercase(N), V} || {N, V} <- Headers].

--- a/test/livery_resp_tests.erl
+++ b/test/livery_resp_tests.erl
@@ -161,6 +161,35 @@ resolve_deferred_merges_outer_headers_decision_wins_test() ->
     ?assertEqual(<<"application/json">>, header(R, <<"content-type">>)).
 
 %%====================================================================
+%% Early-response drain
+%%====================================================================
+
+early_response_drain_defaults_to_default_test() ->
+    R = livery_resp:json(200, <<"{}">>),
+    ?assertEqual(default, livery_resp:early_response_drain(R)).
+
+with_early_response_drain_sets_field_test() ->
+    R0 = livery_resp:json(413, <<"{}">>),
+    R1 = livery_resp:with_early_response_drain({16#400000, 5000}, R0),
+    ?assertEqual({16#400000, 5000}, livery_resp:early_response_drain(R1)),
+    R2 = livery_resp:with_early_response_drain(none, R0),
+    ?assertEqual(none, livery_resp:early_response_drain(R2)).
+
+json_opts_sets_drain_and_keeps_content_type_test() ->
+    R = livery_resp:json(413, [], <<"{}">>, #{early_response_drain => {16#400000, 5000}}),
+    ?assertEqual({16#400000, 5000}, livery_resp:early_response_drain(R)),
+    ?assertEqual(<<"application/json">>, header(R, <<"content-type">>)).
+
+text_opts_sets_drain_test() ->
+    R = livery_resp:text(413, [], <<"too big">>, #{early_response_drain => none}),
+    ?assertEqual(none, livery_resp:early_response_drain(R)),
+    ?assertEqual({full, <<"too big">>}, livery_resp:body(R)).
+
+opts_without_drain_key_keeps_default_test() ->
+    R = livery_resp:json(200, [], <<"{}">>, #{}),
+    ?assertEqual(default, livery_resp:early_response_drain(R)).
+
+%%====================================================================
 %% Helpers
 %%====================================================================
 


### PR DESCRIPTION
When a handler commits a full response before the request body is read (e.g. rejecting an oversized upload with a 413), HTTP/1.1 closes the connection right after, and with a large upload still in flight the close can reach the client before it reads the response, so the client sees a reset instead of the 413.

This bumps h1 to 0.7.0 and drives its early-response inbound drain from the framework. A new `early_response_drain` field on `#livery_resp{}` (`default | none | {MaxBytes, MaxMs}`) threads through `emit/3` to `h1:respond/6`, with `livery_resp:with_early_response_drain/2` and `json/4` / `text/4` opts-map sugar. The same knob is exposed as `early_response_drain` / `lingering_timeout` listener options, defaulting to h1's `{infinity, 30000}`. The `max_body` abort no longer resets the stream: the handler responds and h1 drains the leftover body before closing.

The per-response override applies to full responses; streaming responses use the listener budget, since h1 0.7.0 carries the option only on `respond/6`.