### PR TITLE
Select the WebSocket transport from the listener for HTTPS H1 upgrades

### DIFF
--- a/src/livery_h1.erl
+++ b/src/livery_h1.erl
@@ -240,7 +240,7 @@ accept_ws({Conn, StreamId}, Req, HandlerMod, Opts) ->
                 {ok, Socket, _BufferedBytes} ->
                     WsReq = build_ws_req(Req),
                     ws:accept(
-                        ws_transport_gen_tcp,
+                        ws_transport(Req),
                         Socket,
                         WsReq,
                         HandlerMod,
@@ -262,6 +262,18 @@ build_ws_req(Req) ->
         headers => livery_req:headers(Req)
     }.
 
+%% Pick the ws transport from the connection's security, which the
+%% listener records on the request (an ssl listener sets `tls'). This
+%% reads the listener's own configuration rather than inspecting the
+%% opaque socket representation. Mirrors `ws_client', which selects the
+%% transport from the `ws://' / `wss://' scheme.
+-spec ws_transport(livery_req:req()) -> ws_transport_gen_tcp | ws_transport_ssl.
+ws_transport(Req) ->
+    case livery_req:tls(Req) of
+        undefined -> ws_transport_gen_tcp;
+        _ -> ws_transport_ssl
+    end.
+
 %%====================================================================
 %% Internals: per-request dispatch
 %%====================================================================
@@ -273,9 +285,12 @@ build_ws_req(Req) ->
 ) -> map().
 build_h1_opts(Opts, Stack, Handler) ->
     MaxBody = maps:get(max_body, Opts, ?DEFAULT_MAX_BODY),
+    Transport = maps:get(transport, Opts, tcp),
     Base = #{
-        transport => maps:get(transport, Opts, tcp),
-        handler => make_handler_fun(Stack, Handler, MaxBody, maps:get(config, Opts, undefined))
+        transport => Transport,
+        handler => make_handler_fun(
+            Stack, Handler, MaxBody, maps:get(config, Opts, undefined), Transport
+        )
     },
     copy_keys(
         [
@@ -310,7 +325,8 @@ copy_keys([K | Rest], Src, Dst) ->
     livery_middleware:stack(),
     livery_middleware:handler(),
     non_neg_integer() | infinity,
-    term()
+    term(),
+    tcp | ssl
 ) ->
     fun(
         (
@@ -321,7 +337,7 @@ copy_keys([K | Rest], Src, Dst) ->
             h1:headers()
         ) -> ok
     ).
-make_handler_fun(Stack, Handler, MaxBody, Config) ->
+make_handler_fun(Stack, Handler, MaxBody, Config, Transport) ->
     fun(Conn, StreamId, Method, Path, Headers) ->
         dispatch_request(
             Conn,
@@ -332,7 +348,8 @@ make_handler_fun(Stack, Handler, MaxBody, Config) ->
             Stack,
             Handler,
             MaxBody,
-            Config
+            Config,
+            Transport
         )
     end.
 
@@ -345,9 +362,12 @@ make_handler_fun(Stack, Handler, MaxBody, Config) ->
     livery_middleware:stack(),
     livery_middleware:handler(),
     non_neg_integer() | infinity,
-    term()
+    term(),
+    tcp | ssl
 ) -> ok.
-dispatch_request(Conn, StreamId, Method, Path, Headers, Stack, Handler, MaxBody, Config) ->
+dispatch_request(
+    Conn, StreamId, Method, Path, Headers, Stack, Handler, MaxBody, Config, Transport
+) ->
     %% This function runs in the per-request worker spawned by
     %% h1_server. Body and trailer events arrive as
     %% `{h1_stream, StreamId, _}' messages in this process's
@@ -356,7 +376,7 @@ dispatch_request(Conn, StreamId, Method, Path, Headers, Stack, Handler, MaxBody,
     DiscRef = make_ref(),
     Reader = livery_body:new(BodyRef),
     {RawPath, RawQuery} = split_query(Path),
-    Req = build_req(Conn, StreamId, Method, RawPath, Headers, Reader),
+    Req = build_req(Conn, StreamId, Method, RawPath, Headers, Reader, Transport),
     %% The dispatch process (this one) runs the translator loop, so it
     %% is the disconnect notifier the handler registers with.
     Req1 = Req#livery_req{
@@ -405,9 +425,10 @@ reject_overload(Stream) ->
     binary(),
     binary(),
     h1:headers(),
-    livery_body:reader()
+    livery_body:reader(),
+    tcp | ssl
 ) -> livery_req:req().
-build_req(Conn, StreamId, Method, Path, Headers, Reader) ->
+build_req(Conn, StreamId, Method, Path, Headers, Reader, Transport) ->
     livery_req:new(#{
         protocol => h1,
         method => Method,
@@ -416,8 +437,16 @@ build_req(Conn, StreamId, Method, Path, Headers, Reader) ->
         body => {stream, Reader},
         adapter => ?MODULE,
         stream => {Conn, StreamId},
-        engine_pid => Conn
+        engine_pid => Conn,
+        tls => tls_info(Transport)
     }).
+
+%% Mark TLS connections so handlers and the WebSocket handoff can tell a
+%% secure listener from a plaintext one. h1 does not surface certificate
+%% details, so this is an empty map rather than undefined.
+-spec tls_info(tcp | ssl) -> undefined | map().
+tls_info(ssl) -> #{};
+tls_info(_) -> undefined.
 
 -spec split_query(binary()) -> {binary(), binary()}.
 split_query(Path) ->

--- a/test/livery_ws_SUITE.erl
+++ b/test/livery_ws_SUITE.erl
@@ -23,6 +23,7 @@
 
 -export([
     h1_echo_text_frame/1,
+    h1_ssl_echo_text_frame/1,
     h1_rejects_request_without_upgrade_headers/1,
     h2_echo_text_frame/1,
     h2_rejects_plain_get/1,
@@ -43,6 +44,7 @@ suite() ->
 all() ->
     [
         h1_echo_text_frame,
+        h1_ssl_echo_text_frame,
         h1_echo_text_frame_ipv6,
         h1_rejects_request_without_upgrade_headers,
         h2_echo_text_frame,
@@ -84,6 +86,22 @@ init_per_testcase(TC, Config) when
         {adapter, h2},
         {listener, Listener},
         {port, h2:server_port(Listener)}
+        | Config
+    ];
+init_per_testcase(h1_ssl_echo_text_frame, Config) ->
+    {CertFile, KeyFile} = livery_test_certs:paths(),
+    {ok, Listener} = livery_h1:start(#{
+        port => 0,
+        transport => ssl,
+        cert => CertFile,
+        key => KeyFile,
+        stack => [],
+        handler => fun ws_handler/1
+    }),
+    [
+        {adapter, h1},
+        {listener, Listener},
+        {port, h1:server_port(Listener)}
         | Config
     ];
 init_per_testcase(h1_echo_text_frame_ipv6, Config) ->
@@ -187,6 +205,19 @@ h1_echo_text_frame(Config) ->
     ]),
     ?assertEqual(ok, ws_echo_roundtrip(Url)).
 
+%% Same echo round-trip over TLS (`wss://'), proving the accepted SSL
+%% socket is handed to the ws session with the matching transport after
+%% the HTTP/1.1 upgrade. Retried like the IPv6 case, since the handshake
+%% can stall transiently under CI load.
+h1_ssl_echo_text_frame(Config) ->
+    Port = ?config(port, Config),
+    Url = iolist_to_binary([
+        <<"wss://127.0.0.1:">>,
+        integer_to_binary(Port),
+        <<"/">>
+    ]),
+    ?assertEqual(ok, ws_echo_roundtrip(Url, #{ssl_opts => [{verify, verify_none}]}, 3)).
+
 %% Same echo round-trip over an IPv6-bound listener (`ip => ::1'),
 %% proving the listen-address options carry through to the WS upgrade.
 %% The listener is bound v6 in init_per_testcase, which skips the case
@@ -201,33 +232,39 @@ h1_echo_text_frame_ipv6(Config) ->
         integer_to_binary(Port),
         <<"/">>
     ]),
-    ?assertEqual(ok, ws_echo_roundtrip(Url, 3)).
+    ?assertEqual(ok, ws_echo_roundtrip(Url, #{}, 3)).
 
+%% Connect opts default to none; a single attempt unless a case asks for
+%% retries. `Opts' is merged into the ws_client connect map (e.g. to pass
+%% `ssl_opts' for `wss://'); `Attempts' is how many fresh sessions to try
+%% before giving up.
 ws_echo_roundtrip(Url) ->
-    ws_echo_roundtrip(Url, 1).
+    ws_echo_roundtrip(Url, #{}, 1).
 
-ws_echo_roundtrip(Url, Attempts) ->
-    ws_echo_roundtrip(Url, Attempts, {error, not_attempted}).
+ws_echo_roundtrip(Url, Opts, Attempts) ->
+    ws_echo_roundtrip(Url, Opts, Attempts, {error, not_attempted}).
 
-ws_echo_roundtrip(_Url, 0, Last) ->
+ws_echo_roundtrip(_Url, _Opts, 0, Last) ->
     Last;
-ws_echo_roundtrip(Url, N, _Last) ->
-    case ws_echo_attempt(Url) of
+ws_echo_roundtrip(Url, Opts, N, _Last) ->
+    case ws_echo_attempt(Url, Opts) of
         ok -> ok;
-        {error, _} = E -> ws_echo_roundtrip(Url, N - 1, E)
+        {error, _} = E -> ws_echo_roundtrip(Url, Opts, N - 1, E)
     end.
 
 %% One connect + ready + echo round-trip. Returns `ok' or `{error, Reason}'
 %% (never raises), so the retry wrapper can try a fresh session. Drains any
 %% frames captured during teardown so a retry starts with a clean mailbox.
-ws_echo_attempt(Url) ->
+ws_echo_attempt(Url, Opts) ->
     Self = self(),
-    case
-        ws_client:connect(Url, #{
+    ConnectOpts = maps:merge(
+        #{
             handler => livery_ws_client_capture,
             handler_opts => #{parent => Self}
-        })
-    of
+        },
+        Opts
+    ),
+    case ws_client:connect(Url, ConnectOpts) of
         {ok, Sess} ->
             try
                 ws_echo_frames(Sess)


### PR DESCRIPTION
wss:// WebSocket upgrades on H1 were broken: a TLS listener hands the ws session an sslsocket, but the adapter always selected ws_transport_gen_tcp.

This records the listener's transport on the request and picks ws_transport_ssl from it, mirroring ws_client (which selects from the ws:// / wss:// scheme) rather than inspecting the socket. livery_req:tls/1 now reports TLS on H1 too.

Supersedes #63 by Danila Poyarkov (@dannote), taking a cleaner config-driven approach.