### PR TITLE
Add a cookie jar client layer

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -70,6 +70,7 @@ solution.
 **Calling out**
 - [Make outbound HTTP requests](guides/make-http-requests.md)
 - [Load-balance outbound requests](guides/load-balance-requests.md)
+- [Use a cookie jar](guides/use-a-cookie-jar.md)
 
 **Operations**
 - [Shut down gracefully](guides/graceful-shutdown.md)

--- a/docs/guides/use-a-cookie-jar.md
+++ b/docs/guides/use-a-cookie-jar.md
@@ -1,0 +1,117 @@
+# How to use a cookie jar
+
+The `cookie_jar` layer is the outbound twin of a browser's cookie store:
+it keeps the cookies a response sets and sends the matching ones back on
+later requests, so you never touch the `Cookie` header by hand. You need
+it when the service you call uses cookies to carry state across requests,
+a login that sets a session cookie, a CSRF token, an API that hands you a
+cookie on the first call and expects it on the rest.
+
+## Add a cookie jar
+
+Put `cookie_jar()` in the stack and reuse the same client across the
+calls that should share cookies. A response that sets a cookie fills the
+jar; the next request through that client carries it.
+
+```erlang
+Client = livery_client:new(#{
+    base_url => <<"https://api.example.com">>,
+    stack    => [livery_client:cookie_jar()]
+}),
+
+%% Log in: the response sets a session cookie, the jar keeps it.
+{ok, _} = livery_client:post(Client, <<"/login">>, json:encode(#{user => U, pass => P})),
+
+%% Later calls through the same client send that cookie automatically.
+{ok, Resp} = livery_client:get(Client, <<"/account">>),
+200 = livery_client:status(Resp).
+```
+
+It stacks with the other layers like any of them, outermost-first:
+
+```erlang
+stack => [
+    livery_client:timeout(5000),
+    livery_client:retry(#{max => 3}),
+    livery_client:cookie_jar()
+]
+```
+
+## What the jar sends, and what it drops
+
+The jar follows the client-side rules of RFC 6265, so it sends a stored
+cookie only when it genuinely belongs on the request:
+
+- host: a cookie set without a `Domain` is sent back only to the exact
+  host that set it; a `Domain` cookie also reaches its sub-domains.
+- path: a cookie scoped to `/admin` goes to `/admin` and below, not to
+  `/`.
+- secure: a `Secure` cookie is sent over `https` only, never plain
+  `http`.
+
+When several cookies match, they are ordered longest-path-first in the
+one `Cookie` header. A `Cookie` header you set yourself is kept, the jar
+appends to it rather than clobbering it. Cookies expire on their own:
+a `Max-Age` of `0` or a past `Expires` deletes the cookie, and expired
+ones are dropped before each send.
+
+## Tune the jar
+
+`cookie_jar/1` takes options:
+
+```erlang
+livery_client:cookie_jar(#{max_cookies => 500}).
+```
+
+- `max_cookies` caps how many cookies the jar holds (default 3000); past
+  the cap the oldest are evicted.
+- `store` names the backing store module (default
+  `livery_client_cookie_store_ets`); see below.
+
+## Build the client where it will live
+
+The default store is a public ETS table created by the constructor and
+owned by the process that calls it. That table lives as long as its
+owner, so build the client in a process that outlives the requests, your
+supervision tree, a long-lived worker, an application's setup, not a
+short-lived request process that takes the jar down with it when it
+exits. Once built, the client value is safe to share: the table is
+public, so any number of processes can issue requests through the same
+jar at once.
+
+## Back the jar with something else
+
+The jar keeps no cookies of its own. It reads and writes through the
+`livery_client_cookie_store` behaviour, four callbacks over an opaque
+handle:
+
+```erlang
+-callback init(Opts :: map()) -> store().
+-callback get(store()) -> [cookie()].
+-callback put(store(), key(), cookie()) -> ok.
+-callback delete(store(), key()) -> ok.
+```
+
+The default is the per-jar ETS table. To survive the building process,
+share one store across clients, or push cookies into an external cache,
+implement the behaviour over a supervised process and name it:
+
+```erlang
+livery_client:cookie_jar(#{store => my_cookie_store}).
+```
+
+Cookies and keys are opaque to the store, it persists and returns them
+without looking inside, so a custom store is only the four callbacks.
+
+## What it does not do
+
+This is a deliberate subset for talking to services: no public suffix
+list, no third-party-cookie policy, no persistence to disk. `SameSite`
+is parsed but not enforced. For browser-grade behaviour you would layer
+those on top.
+
+## See also
+
+- Guide: [Make outbound HTTP requests](make-http-requests.md)
+- Guide: [Use signed session cookies](session-cookies.md) (the server side)
+- Reference: `livery_client`, `livery_client_cookie`, `livery_client_cookie_store`

--- a/rebar.config
+++ b/rebar.config
@@ -331,7 +331,8 @@
             %% The adapter behaviour is dispatched dynamically by
             %% design (Adapter:send_*, accept_ws/accept_wt).
             %% livery_client dispatches to the configured client adapter;
-            %% livery_client_discover dispatches to the discovery provider.
+            %% livery_client_discover dispatches to the discovery provider;
+            %% livery_client_cookie dispatches to the cookie store module.
             {elvis_style, invalid_dynamic_call, #{
                 ignore => [
                     livery,
@@ -340,7 +341,8 @@
                     livery_wt,
                     livery_compress,
                     livery_client,
-                    livery_client_discover
+                    livery_client_discover,
+                    livery_client_cookie
                 ]
             }},
             %% Per-stream translators (and the client push-stream relay)

--- a/rebar.config
+++ b/rebar.config
@@ -134,6 +134,7 @@
         {"docs/guides/load-balance-requests.md", #{
             title => <<"Load-balance outbound requests">>
         }},
+        {"docs/guides/use-a-cookie-jar.md", #{title => <<"Use a cookie jar">>}},
         {"docs/guides/propagate-request-ids.md", #{title => <<"Propagate request IDs">>}},
         {"docs/guides/handler-errors.md", #{title => <<"Catch handler errors">>}},
         {"docs/guides/cancel-on-disconnect.md", #{
@@ -209,6 +210,7 @@
             <<"docs/guides/log-requests.md">>,
             <<"docs/guides/make-http-requests.md">>,
             <<"docs/guides/load-balance-requests.md">>,
+            <<"docs/guides/use-a-cookie-jar.md">>,
             <<"docs/guides/propagate-request-ids.md">>,
             <<"docs/guides/handler-errors.md">>,
             <<"docs/guides/cancel-on-disconnect.md">>,

--- a/src/client/livery_client.erl
+++ b/src/client/livery_client.erl
@@ -32,6 +32,7 @@ The transport is a `livery_client_adapter`; the default,
 -export([read/2, read_body/1]).
 -export([stream_next/1, stop_stream/1]).
 -export([timeout/1, concurrency/1, retry/1, circuit_breaker/1, balance/1]).
+-export([cookie_jar/0, cookie_jar/1]).
 -export([add_endpoint/2, remove_endpoint/2]).
 -export([before/1, after_response/1, wrap/1]).
 -export([rebase/2]).
@@ -248,6 +249,19 @@ With `balance` you pass paths; the chosen endpoint supplies the host.
 """.
 -spec balance(map()) -> entry().
 balance(Opts) -> {livery_client_balance, Opts}.
+
+-doc """
+A cookie jar (RFC 6265 client subset). Stores the `Set-Cookie` cookies a
+response carries and sends the matching ones (host, path, secure) on later
+requests through this layer, in an in-memory per-jar store shared across
+the client's request processes. `Opts`: `max_cookies` (default 3000),
+`store` (a `livery_client_cookie_store` callback module; default ETS).
+""".
+-spec cookie_jar() -> entry().
+cookie_jar() -> {livery_client_cookie, livery_client_cookie:jar()}.
+
+-spec cookie_jar(map()) -> entry().
+cookie_jar(Opts) -> {livery_client_cookie, livery_client_cookie:jar(Opts)}.
 
 -doc "Add an endpoint to a balance pool at runtime.".
 -spec add_endpoint(term(), endpoint()) -> ok.

--- a/src/client/livery_client_cookie.erl
+++ b/src/client/livery_client_cookie.erl
@@ -1,0 +1,484 @@
+-module(livery_client_cookie).
+-moduledoc """
+Client layer: a cookie jar (RFC 6265, client side).
+
+Before each request it picks the stored cookies that match the target
+(host, path, secure) and merges them into one `Cookie` header, keeping any
+`Cookie` the caller already set. After the response it parses every
+`Set-Cookie` header and updates the jar: a new cookie replaces the one
+under the same `(domain, path, name)` key, and an expired one (a past
+`Expires`, or `Max-Age` <= 0) deletes it. Add it with
+`livery_client:cookie_jar/0,1`.
+
+The jar keeps no cookies of its own; it reads and writes them through a
+`livery_client_cookie_store` (default `livery_client_cookie_store_ets`),
+an in-memory per-jar store shared across the request processes that run
+the client.
+
+This is a subset: no public suffix list, no third-party-cookie policy,
+no persistence. `SameSite` is parsed but not enforced.
+""".
+
+-export([jar/0, jar/1, call/3]).
+
+-export_type([state/0]).
+
+-define(DEFAULT_MAX_COOKIES, 3000).
+%% Seconds between the gregorian epoch (year 0) and the Unix epoch (1970).
+-define(UNIX_EPOCH, 62167219200).
+
+-opaque state() :: #{
+    module := module(),
+    store := livery_client_cookie_store:store(),
+    max_cookies := pos_integer()
+}.
+
+%% A stored cookie. Opaque to the store; the layer owns this shape.
+-type cookie() :: #{
+    name := binary(),
+    value := binary(),
+    domain := binary(),
+    path := binary(),
+    secure := boolean(),
+    http_only := boolean(),
+    same_site := binary() | undefined,
+    host_only := boolean(),
+    expires := non_neg_integer() | session,
+    created := integer()
+}.
+
+%%====================================================================
+%% Constructor
+%%====================================================================
+
+-doc "Build a jar with the default ETS store and cookie cap.".
+-spec jar() -> state().
+jar() -> jar(#{}).
+
+-doc """
+Build a jar. `Opts`: `max_cookies` (total cap before the oldest are
+evicted, default 3000), `store` (a `livery_client_cookie_store` callback
+module, default `livery_client_cookie_store_ets`). Any other keys are
+passed through to the store's `init/1`.
+""".
+-spec jar(map()) -> state().
+jar(Opts) ->
+    Module = maps:get(store, Opts, livery_client_cookie_store_ets),
+    Store = Module:init(Opts),
+    #{
+        module => Module,
+        store => Store,
+        max_cookies => maps:get(max_cookies, Opts, ?DEFAULT_MAX_COOKIES)
+    }.
+
+%%====================================================================
+%% Layer
+%%====================================================================
+
+-spec call(livery_client:request(), livery_client:next(), state()) ->
+    {ok, livery_client:response()} | {error, term()}.
+call(Req, Next, State) ->
+    case parse_url(livery_client:url(Req)) of
+        {ok, Scheme, Host, Path} ->
+            Req1 = attach_cookies(Req, State, Scheme, Host, Path),
+            Result = Next(Req1),
+            store_response(Result, State, Host, Path),
+            Result;
+        error ->
+            Next(Req)
+    end.
+
+%%====================================================================
+%% Outbound: select and merge cookies
+%%====================================================================
+
+attach_cookies(Req, #{module := Module, store := Store}, Scheme, Host, Path) ->
+    Now = erlang:system_time(second),
+    Live = drop_expired(Module:get(Store), Now, Module, Store),
+    Matching = [C || C <- Live, send_match(C, Scheme, Host, Path)],
+    Pairs = [<<N/binary, "=", V/binary>> || #{name := N, value := V} <- sort_cookies(Matching)],
+    merge_cookie_header(Req, Pairs).
+
+merge_cookie_header(Req, []) ->
+    Req;
+merge_cookie_header(Req, Pairs) ->
+    Jar = iolist_to_binary(lists:join(<<"; ">>, Pairs)),
+    case livery_client:header(<<"cookie">>, Req) of
+        undefined ->
+            livery_client:set_header(<<"cookie">>, Jar, Req);
+        Existing ->
+            livery_client:set_header(<<"cookie">>, <<Existing/binary, "; ", Jar/binary>>, Req)
+    end.
+
+%% Longest path first; ties broken by earliest creation (RFC 6265 5.4).
+sort_cookies(Cookies) ->
+    lists:sort(fun(A, B) -> order(A) =< order(B) end, Cookies).
+
+order(#{path := P, created := C}) -> {-byte_size(P), C}.
+
+send_match(#{secure := Secure} = Cookie, Scheme, Host, Path) ->
+    secure_ok(Secure, Scheme) andalso
+        domain_match(Host, Cookie) andalso
+        path_match(Path, maps:get(path, Cookie)).
+
+secure_ok(false, _Scheme) -> true;
+secure_ok(true, Scheme) -> Scheme =:= <<"https">>.
+
+domain_match(Host, #{host_only := true, domain := Domain}) ->
+    Host =:= Domain;
+domain_match(Host, #{host_only := false, domain := Domain}) ->
+    Host =:= Domain orelse suffix_match(Host, Domain).
+
+%% Host ends with "." ++ Domain (a proper sub-domain), per RFC 6265 5.1.3.
+suffix_match(Host, Domain) ->
+    DS = byte_size(Domain),
+    HS = byte_size(Host),
+    HS > DS andalso
+        binary:part(Host, HS - DS, DS) =:= Domain andalso
+        binary:at(Host, HS - DS - 1) =:= $..
+
+path_match(Path, Path) ->
+    true;
+path_match(ReqPath, CookiePath) ->
+    PS = byte_size(CookiePath),
+    case ReqPath of
+        <<CookiePath:PS/binary, $/, _/binary>> -> true;
+        <<CookiePath:PS/binary, _/binary>> -> binary:last(CookiePath) =:= $/;
+        _ -> false
+    end.
+
+%%====================================================================
+%% Inbound: parse Set-Cookie and update the jar
+%%====================================================================
+
+store_response({ok, Resp}, State, Host, Path) ->
+    Values = [V || {N, V} <- livery_client:headers(Resp), string:lowercase(N) =:= <<"set-cookie">>],
+    lists:foreach(fun(V) -> ingest(V, State, Host, Path) end, Values),
+    enforce_max(State);
+store_response(_Other, _State, _Host, _Path) ->
+    ok.
+
+ingest(Value, #{module := Module, store := Store}, Host, Path) ->
+    case parse_set_cookie(Value, Host, Path) of
+        ignore ->
+            ok;
+        Cookie ->
+            Key = key(Cookie),
+            case expired(Cookie, erlang:system_time(second)) of
+                true -> Module:delete(Store, Key);
+                false -> Module:put(Store, Key, Cookie)
+            end
+    end.
+
+enforce_max(#{module := Module, store := Store, max_cookies := Max}) ->
+    All = Module:get(Store),
+    case length(All) - Max of
+        Excess when Excess =< 0 ->
+            ok;
+        Excess ->
+            Oldest = lists:sublist(lists:sort(fun by_created/2, All), Excess),
+            lists:foreach(fun(C) -> Module:delete(Store, key(C)) end, Oldest)
+    end.
+
+by_created(#{created := A}, #{created := B}) -> A =< B.
+
+key(#{domain := D, path := P, name := N}) -> {D, P, N}.
+
+expired(#{expires := session}, _Now) -> false;
+expired(#{expires := E}, Now) -> E =< Now.
+
+drop_expired(Cookies, Now, Module, Store) ->
+    lists:filter(
+        fun(C) ->
+            case expired(C, Now) of
+                true ->
+                    Module:delete(Store, key(C)),
+                    false;
+                false ->
+                    true
+            end
+        end,
+        Cookies
+    ).
+
+%%====================================================================
+%% Set-Cookie parsing (RFC 6265 5.2)
+%%====================================================================
+
+-spec parse_set_cookie(binary(), binary(), binary()) -> cookie() | ignore.
+parse_set_cookie(Bin, Host, ReqPath) ->
+    [NameValue | AttrParts] = binary:split(Bin, <<";">>, [global]),
+    case parse_nv(string:trim(NameValue)) of
+        ignore -> ignore;
+        {Name, Value} -> build_cookie(Name, Value, parse_attrs(AttrParts), Host, ReqPath)
+    end.
+
+parse_nv(Seg) ->
+    case binary:split(Seg, <<"=">>) of
+        [Name0, Value0] ->
+            case string:trim(Name0) of
+                <<>> -> ignore;
+                Name -> {Name, string:trim(Value0)}
+            end;
+        _ ->
+            ignore
+    end.
+
+%% Later attributes win: fold prepends, so the head is the last occurrence
+%% and keyfind returns it first.
+parse_attrs(Parts) ->
+    lists:foldl(
+        fun(Part, Acc) ->
+            case parse_attr(string:trim(Part)) of
+                skip -> Acc;
+                KV -> [KV | Acc]
+            end
+        end,
+        [],
+        Parts
+    ).
+
+parse_attr(<<>>) ->
+    skip;
+parse_attr(Part) ->
+    case binary:split(Part, <<"=">>) of
+        [K, V] -> {string:lowercase(string:trim(K)), string:trim(V)};
+        [K] -> {string:lowercase(string:trim(K)), <<>>}
+    end.
+
+build_cookie(Name, Value, Attrs, Host, ReqPath) ->
+    Now = erlang:system_time(second),
+    {Domain, HostOnly} = domain_attr(attr(<<"domain">>, Attrs), Host),
+    #{
+        name => Name,
+        value => Value,
+        domain => Domain,
+        path => path_attr(attr(<<"path">>, Attrs), ReqPath),
+        secure => has_attr(<<"secure">>, Attrs),
+        http_only => has_attr(<<"httponly">>, Attrs),
+        same_site => attr(<<"samesite">>, Attrs),
+        host_only => HostOnly,
+        expires => expiry(Attrs, Now),
+        created => Now
+    }.
+
+attr(Key, Attrs) ->
+    case lists:keyfind(Key, 1, Attrs) of
+        {Key, V} -> V;
+        false -> undefined
+    end.
+
+has_attr(Key, Attrs) -> lists:keymember(Key, 1, Attrs).
+
+%% No Domain => host-only, scoped to the exact request host. With a Domain,
+%% strip a leading dot; an IP host ignores any Domain that is not itself.
+domain_attr(undefined, Host) ->
+    {Host, true};
+domain_attr(<<>>, Host) ->
+    {Host, true};
+domain_attr(Domain0, Host) ->
+    Domain = string:lowercase(strip_dot(Domain0)),
+    case is_ip(Host) andalso Domain =/= Host of
+        true -> {Host, true};
+        false -> {Domain, false}
+    end.
+
+strip_dot(<<".", Rest/binary>>) -> Rest;
+strip_dot(Domain) -> Domain.
+
+is_ip(Host) ->
+    case inet:parse_address(binary_to_list(Host)) of
+        {ok, _} -> true;
+        {error, _} -> false
+    end.
+
+path_attr(undefined, ReqPath) -> default_path(ReqPath);
+path_attr(<<"/", _/binary>> = Path, _ReqPath) -> Path;
+path_attr(_Other, ReqPath) -> default_path(ReqPath).
+
+%% RFC 6265 5.1.4: the request path up to but not including the rightmost
+%% slash, or "/" when there is only the leading slash.
+default_path(<<"/", _/binary>> = Path) ->
+    case binary:matches(Path, <<"/">>) of
+        [_] ->
+            <<"/">>;
+        Matches ->
+            case lists:last(Matches) of
+                {0, _} -> <<"/">>;
+                {Pos, _} -> binary:part(Path, 0, Pos)
+            end
+    end;
+default_path(_Other) ->
+    <<"/">>.
+
+%% Max-Age wins over Expires (RFC 6265 5.3). Max-Age <= 0 expires now
+%% (sentinel 0, always <= the current time).
+expiry(Attrs, Now) ->
+    case max_age(attr(<<"max-age">>, Attrs)) of
+        {ok, Secs} when Secs =< 0 -> 0;
+        {ok, Secs} -> Now + Secs;
+        none -> expires(attr(<<"expires">>, Attrs))
+    end.
+
+max_age(undefined) ->
+    none;
+max_age(Bin) ->
+    try
+        {ok, binary_to_integer(string:trim(Bin))}
+    catch
+        error:badarg -> none
+    end.
+
+expires(undefined) ->
+    session;
+expires(DateBin) ->
+    case parse_http_date(DateBin) of
+        {ok, Secs} -> Secs;
+        error -> session
+    end.
+
+%%====================================================================
+%% HTTP-date parsing (RFC 6265 5.1.1: IMF-fixdate, RFC 850, asctime)
+%%====================================================================
+
+-spec parse_http_date(binary()) -> {ok, non_neg_integer()} | error.
+parse_http_date(Bin) ->
+    finalize_date(lists:foldl(fun classify_token/2, #{}, date_tokens(Bin))).
+
+%% Split on the cookie-date delimiter set; ":" is kept so the time stays
+%% one token.
+date_tokens(Bin) -> date_tokens(Bin, [], []).
+
+date_tokens(<<>>, [], Acc) ->
+    lists:reverse(Acc);
+date_tokens(<<>>, Cur, Acc) ->
+    lists:reverse([lists:reverse(Cur) | Acc]);
+date_tokens(<<C, Rest/binary>>, Cur, Acc) ->
+    case is_delim(C) of
+        true when Cur =:= [] -> date_tokens(Rest, [], Acc);
+        true -> date_tokens(Rest, [], [lists:reverse(Cur) | Acc]);
+        false -> date_tokens(Rest, [C | Cur], Acc)
+    end.
+
+is_delim(C) ->
+    C =:= 16#09 orelse
+        (C >= 16#20 andalso C =< 16#2F) orelse
+        (C >= 16#3B andalso C =< 16#40) orelse
+        (C >= 16#5B andalso C =< 16#60) orelse
+        (C >= 16#7B andalso C =< 16#7E).
+
+classify_token(Tok, Fields) ->
+    case parse_time(Tok) of
+        {ok, H, Mi, S} when not is_map_key(time, Fields) ->
+            Fields#{time => true, h => H, mi => Mi, s => S};
+        _ ->
+            classify_dmy(Tok, Fields)
+    end.
+
+classify_dmy(Tok, Fields) ->
+    case day(Tok) of
+        {ok, D} when not is_map_key(day, Fields) -> Fields#{day => D};
+        _ -> classify_my(Tok, Fields)
+    end.
+
+classify_my(Tok, Fields) ->
+    case month(Tok) of
+        {ok, M} when not is_map_key(month, Fields) -> Fields#{month => M};
+        _ -> classify_year(Tok, Fields)
+    end.
+
+classify_year(Tok, Fields) ->
+    case year(Tok) of
+        {ok, Y} when not is_map_key(year, Fields) -> Fields#{year => Y};
+        _ -> Fields
+    end.
+
+parse_time(Tok) ->
+    case string:lexemes(Tok, ":") of
+        [H, Mi, S] ->
+            case {num(H), num(Mi), num(S)} of
+                {{ok, Hn}, {ok, Min}, {ok, Sn}} when Hn =< 23, Min =< 59, Sn =< 60 ->
+                    {ok, Hn, Min, Sn};
+                _ ->
+                    error
+            end;
+        _ ->
+            error
+    end.
+
+day(Tok) when length(Tok) =< 2 ->
+    case num(Tok) of
+        {ok, D} when D >= 1, D =< 31 -> {ok, D};
+        _ -> error
+    end;
+day(_Tok) ->
+    error.
+
+year(Tok) when length(Tok) =< 4 ->
+    case num(Tok) of
+        {ok, Y} -> {ok, fix_year(Y)};
+        error -> error
+    end;
+year(_Tok) ->
+    error.
+
+fix_year(Y) when Y >= 70, Y =< 99 -> Y + 1900;
+fix_year(Y) when Y >= 0, Y =< 69 -> Y + 2000;
+fix_year(Y) -> Y.
+
+month(Tok) when length(Tok) >= 3 ->
+    month_num(string:lowercase(string:slice(Tok, 0, 3)));
+month(_Tok) ->
+    error.
+
+month_num("jan") -> {ok, 1};
+month_num("feb") -> {ok, 2};
+month_num("mar") -> {ok, 3};
+month_num("apr") -> {ok, 4};
+month_num("may") -> {ok, 5};
+month_num("jun") -> {ok, 6};
+month_num("jul") -> {ok, 7};
+month_num("aug") -> {ok, 8};
+month_num("sep") -> {ok, 9};
+month_num("oct") -> {ok, 10};
+month_num("nov") -> {ok, 11};
+month_num("dec") -> {ok, 12};
+month_num(_Other) -> error.
+
+num([]) ->
+    error;
+num(Str) ->
+    case lists:all(fun(C) -> C >= $0 andalso C =< $9 end, Str) of
+        true -> {ok, list_to_integer(Str)};
+        false -> error
+    end.
+
+finalize_date(#{day := D, month := Mo, year := Y, h := H, mi := Mi, s := S}) ->
+    case calendar:valid_date(Y, Mo, D) of
+        true ->
+            Greg = calendar:datetime_to_gregorian_seconds({{Y, Mo, D}, {H, Mi, S}}),
+            {ok, Greg - ?UNIX_EPOCH};
+        false ->
+            error
+    end;
+finalize_date(_Incomplete) ->
+    error.
+
+%%====================================================================
+%% URL parsing
+%%====================================================================
+
+parse_url(Url) ->
+    case uri_string:parse(Url) of
+        #{host := Host} = Map ->
+            {ok, scheme(Map), string:lowercase(Host), path(Map)};
+        _ ->
+            error
+    end.
+
+scheme(#{scheme := S}) -> string:lowercase(S);
+scheme(_Map) -> <<>>.
+
+path(#{path := <<>>}) -> <<"/">>;
+path(#{path := P}) -> P;
+path(_Map) -> <<"/">>.

--- a/src/client/livery_client_cookie_store.erl
+++ b/src/client/livery_client_cookie_store.erl
@@ -1,0 +1,32 @@
+-module(livery_client_cookie_store).
+-moduledoc """
+Behaviour for the cookie jar's backing store.
+
+`livery_client_cookie` keeps no cookies of its own; it reads and writes
+them through this behaviour. The default, `livery_client_cookie_store_ets`,
+holds them in a public ETS table created by the jar constructor and shared
+across the concurrent request processes that run the client. Implement the
+four callbacks to back a jar with something else (a shared process, an
+external cache); the jar stays in-memory and per-jar either way.
+
+Cookies and keys are opaque to the store: it persists and returns them
+without looking inside.
+
+- `init(Opts) -> Store` - build the store from the `jar/1` opts and return
+  an opaque handle.
+- `get(Store) -> [Cookie]` - every cookie currently held, in any order.
+- `put(Store, Key, Cookie) -> ok` - store `Cookie` under `Key`, replacing
+  any cookie already there.
+- `delete(Store, Key) -> ok` - forget the cookie under `Key`.
+""".
+
+-export_type([store/0, cookie/0, key/0]).
+
+-type store() :: term().
+-type cookie() :: term().
+-type key() :: term().
+
+-callback init(Opts :: map()) -> store().
+-callback get(store()) -> [cookie()].
+-callback put(store(), key(), cookie()) -> ok.
+-callback delete(store(), key()) -> ok.

--- a/src/client/livery_client_cookie_store_ets.erl
+++ b/src/client/livery_client_cookie_store_ets.erl
@@ -1,0 +1,37 @@
+-module(livery_client_cookie_store_ets).
+-moduledoc """
+The default cookie jar store: a public ETS table.
+
+`livery_client:cookie_jar/0,1` uses it implicitly, so you rarely name it
+directly. The constructor creates one unnamed `public` table per jar and
+hands it back as the opaque store handle; every request process that runs
+the client reads and writes the same table. The table is owned by the
+process that built the jar, so build the jar under a process that outlives
+its requests.
+""".
+-behaviour(livery_client_cookie_store).
+
+-export([init/1, get/1, put/3, delete/2]).
+
+-spec init(map()) -> ets:tid().
+init(_Opts) ->
+    ets:new(livery_client_cookies, [
+        public,
+        set,
+        {read_concurrency, true},
+        {write_concurrency, true}
+    ]).
+
+-spec get(ets:tid()) -> [livery_client_cookie_store:cookie()].
+get(Tab) ->
+    [Cookie || {_Key, Cookie} <- ets:tab2list(Tab)].
+
+-spec put(ets:tid(), livery_client_cookie_store:key(), livery_client_cookie_store:cookie()) -> ok.
+put(Tab, Key, Cookie) ->
+    true = ets:insert(Tab, {Key, Cookie}),
+    ok.
+
+-spec delete(ets:tid(), livery_client_cookie_store:key()) -> ok.
+delete(Tab, Key) ->
+    true = ets:delete(Tab, Key),
+    ok.

--- a/test/livery_client_cookie_SUITE.erl
+++ b/test/livery_client_cookie_SUITE.erl
@@ -1,0 +1,134 @@
+%% @doc Drives the cookie jar layer against a real loopback Livery server
+%% (real hackney over the loopback, no external network): a handler sets
+%% cookies, a later request through the same jar carries them back.
+-module(livery_client_cookie_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([
+    set_then_echo/1,
+    path_scoping/1,
+    multiple_cookies/1,
+    deletion/1,
+    host_only_isolation/1,
+    no_prior_cookies/1
+]).
+
+all() ->
+    [
+        set_then_echo,
+        path_scoping,
+        multiple_cookies,
+        deletion,
+        host_only_isolation,
+        no_prior_cookies
+    ].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(livery),
+    {ok, _} = application:ensure_all_started(hackney),
+    Router = livery_router:compile([
+        {<<"GET">>, <<"/set">>, fun handle_set/1},
+        {<<"GET">>, <<"/echo">>, fun handle_echo/1},
+        {<<"GET">>, <<"/set-foo">>, fun handle_set_foo/1},
+        {<<"GET">>, <<"/foo/echo">>, fun handle_echo/1},
+        {<<"GET">>, <<"/bar/echo">>, fun handle_echo/1},
+        {<<"GET">>, <<"/set-multi">>, fun handle_set_multi/1},
+        {<<"GET">>, <<"/del">>, fun handle_del/1}
+    ]),
+    {ok, Pid} = livery:start_service(#{http => #{port => 0}, router => Router}),
+    true = unlink(Pid),
+    Port = maps:get(h1, livery:which_listeners(Pid)),
+    Base = iolist_to_binary([<<"http://127.0.0.1:">>, integer_to_binary(Port)]),
+    [{service, Pid}, {port, Port}, {base, Base} | Config].
+
+end_per_suite(Config) ->
+    livery:stop_service(?config(service, Config)),
+    ok.
+
+%%====================================================================
+%% Handlers
+%%====================================================================
+
+handle_set(_Req) ->
+    livery_resp:text(200, [{<<"Set-Cookie">>, <<"a=1; Path=/">>}], <<"set">>).
+
+handle_set_foo(_Req) ->
+    livery_resp:text(200, [{<<"Set-Cookie">>, <<"p=1; Path=/foo">>}], <<"set">>).
+
+handle_del(_Req) ->
+    livery_resp:text(200, [{<<"Set-Cookie">>, <<"a=1; Path=/; Max-Age=0">>}], <<"del">>).
+
+handle_set_multi(_Req) ->
+    R0 = livery_resp:text(200, <<"set">>),
+    R1 = livery_resp:append_header(<<"Set-Cookie">>, <<"m=1; Path=/">>, R0),
+    livery_resp:append_header(<<"Set-Cookie">>, <<"n=2; Path=/">>, R1).
+
+handle_echo(Req) ->
+    livery_resp:text(200, livery_req:header(<<"cookie">>, Req, <<"none">>)).
+
+%%====================================================================
+%% Cases
+%%====================================================================
+
+set_then_echo(Config) ->
+    C = client(Config),
+    {ok, _} = livery_client:get(C, <<"/set">>),
+    {ok, Resp} = livery_client:get(C, <<"/echo">>),
+    ?assertEqual({full, <<"a=1">>}, livery_client:body(Resp)).
+
+path_scoping(Config) ->
+    C = client(Config),
+    {ok, _} = livery_client:get(C, <<"/set-foo">>),
+    {ok, InScope} = livery_client:get(C, <<"/foo/echo">>),
+    ?assertEqual({full, <<"p=1">>}, livery_client:body(InScope)),
+    {ok, OutOfScope} = livery_client:get(C, <<"/bar/echo">>),
+    ?assertEqual({full, <<"none">>}, livery_client:body(OutOfScope)).
+
+multiple_cookies(Config) ->
+    C = client(Config),
+    {ok, _} = livery_client:get(C, <<"/set-multi">>),
+    {ok, Resp} = livery_client:get(C, <<"/echo">>),
+    {full, Body} = livery_client:body(Resp),
+    ?assertMatch({_, _}, binary:match(Body, <<"m=1">>)),
+    ?assertMatch({_, _}, binary:match(Body, <<"n=2">>)).
+
+deletion(Config) ->
+    C = client(Config),
+    {ok, _} = livery_client:get(C, <<"/set">>),
+    {ok, Before} = livery_client:get(C, <<"/echo">>),
+    ?assertEqual({full, <<"a=1">>}, livery_client:body(Before)),
+    {ok, _} = livery_client:get(C, <<"/del">>),
+    {ok, After} = livery_client:get(C, <<"/echo">>),
+    ?assertEqual({full, <<"none">>}, livery_client:body(After)).
+
+%% A host-only cookie set via 127.0.0.1 must not leak to "localhost", even
+%% though both reach the same loopback server. Both clients share one jar.
+host_only_isolation(Config) ->
+    Port = ?config(port, Config),
+    Local = iolist_to_binary([<<"http://localhost:">>, integer_to_binary(Port)]),
+    Jar = livery_client:cookie_jar(),
+    OnIp = livery_client:new(#{base_url => ?config(base, Config), stack => [Jar]}),
+    OnName = livery_client:new(#{base_url => Local, stack => [Jar]}),
+    {ok, _} = livery_client:get(OnIp, <<"/set">>),
+    {ok, Other} = livery_client:get(OnName, <<"/echo">>),
+    ?assertEqual({full, <<"none">>}, livery_client:body(Other)),
+    {ok, Same} = livery_client:get(OnIp, <<"/echo">>),
+    ?assertEqual({full, <<"a=1">>}, livery_client:body(Same)).
+
+no_prior_cookies(Config) ->
+    C = client(Config),
+    {ok, Resp} = livery_client:get(C, <<"/echo">>),
+    ?assertEqual({full, <<"none">>}, livery_client:body(Resp)).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+client(Config) ->
+    livery_client:new(#{
+        base_url => ?config(base, Config),
+        stack => [livery_client:cookie_jar()]
+    }).

--- a/test/livery_client_cookie_tests.erl
+++ b/test/livery_client_cookie_tests.erl
@@ -1,0 +1,141 @@
+%% @doc Drives the cookie jar layer directly with a synthetic `Next`, so
+%% host, scheme, and path can be set freely without a socket. Pins the
+%% RFC 6265 matching/parsing rules the loopback SUITE cannot reach.
+-module(livery_client_cookie_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(FAR_FUTURE, <<"Tue, 19 Jan 2038 03:14:07 GMT">>).
+-define(PAST, <<"Thu, 01 Jan 1970 00:00:00 GMT">>).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+new_jar() -> new_jar(#{}).
+
+new_jar(Opts) ->
+    {livery_client_cookie, State} = livery_client:cookie_jar(Opts),
+    State.
+
+req(Url) -> req(Url, []).
+
+req(Url, Headers) -> #{method => get, url => Url, headers => Headers}.
+
+%% Seed the jar with the given Set-Cookie values, as if a response carried
+%% them for a request to Url.
+set(State, Url, SetCookies) ->
+    Next = fun(_Req) ->
+        {ok, #{
+            status => 200,
+            headers => [{<<"set-cookie">>, V} || V <- SetCookies],
+            body => {full, <<>>}
+        }}
+    end,
+    {ok, _} = livery_client_cookie:call(req(Url), Next, State),
+    ok.
+
+%% The Cookie header the jar would attach to a request to Url.
+sent(State, Url) -> sent(State, Url, []).
+
+sent(State, Url, Headers) ->
+    Self = self(),
+    Next = fun(R) ->
+        Self ! {cookie, livery_client:header(<<"cookie">>, R)},
+        {ok, #{status => 200, headers => [], body => {full, <<>>}}}
+    end,
+    {ok, _} = livery_client_cookie:call(req(Url, Headers), Next, State),
+    receive
+        {cookie, V} -> V
+    after 1000 -> error(no_capture)
+    end.
+
+count(#{module := M, store := S}) -> length(M:get(S)).
+
+%%====================================================================
+%% Cases
+%%====================================================================
+
+host_only_isolation_test() ->
+    J = new_jar(),
+    set(J, <<"http://example.com/">>, [<<"a=1">>]),
+    ?assertEqual(<<"a=1">>, sent(J, <<"http://example.com/">>)),
+    ?assertEqual(undefined, sent(J, <<"http://other.com/">>)).
+
+domain_subdomain_test() ->
+    J = new_jar(),
+    set(J, <<"http://example.com/">>, [<<"a=1; Domain=example.com">>]),
+    ?assertEqual(<<"a=1">>, sent(J, <<"http://example.com/">>)),
+    ?assertEqual(<<"a=1">>, sent(J, <<"http://sub.example.com/">>)),
+    ?assertEqual(undefined, sent(J, <<"http://other.com/">>)).
+
+secure_scheme_test() ->
+    J = new_jar(),
+    set(J, <<"https://h.test/">>, [<<"s=1; Secure">>]),
+    ?assertEqual(<<"s=1">>, sent(J, <<"https://h.test/">>)),
+    ?assertEqual(undefined, sent(J, <<"http://h.test/">>)).
+
+path_scoping_test() ->
+    J = new_jar(),
+    set(J, <<"http://h.test/">>, [<<"p=1; Path=/admin">>]),
+    ?assertEqual(<<"p=1">>, sent(J, <<"http://h.test/admin">>)),
+    ?assertEqual(<<"p=1">>, sent(J, <<"http://h.test/admin/sub">>)),
+    ?assertEqual(undefined, sent(J, <<"http://h.test/admins">>)),
+    ?assertEqual(undefined, sent(J, <<"http://h.test/other">>)).
+
+max_age_overrides_expires_test() ->
+    J = new_jar(),
+    set(J, <<"http://h.test/">>, [
+        %% Max-Age 0 wins over a far-future Expires: never stored.
+        <<"m=1; Max-Age=0; Expires=", ?FAR_FUTURE/binary>>,
+        %% Max-Age wins over a past Expires: stored and live.
+        <<"n=2; Max-Age=1000; Expires=", ?PAST/binary>>
+    ]),
+    ?assertEqual(<<"n=2">>, sent(J, <<"http://h.test/">>)).
+
+expires_past_deletes_test() ->
+    J = new_jar(),
+    set(J, <<"http://h.test/">>, [<<"e=1">>]),
+    ?assertEqual(<<"e=1">>, sent(J, <<"http://h.test/">>)),
+    set(J, <<"http://h.test/">>, [<<"e=1; Expires=", ?PAST/binary>>]),
+    ?assertEqual(undefined, sent(J, <<"http://h.test/">>)).
+
+longest_path_first_test() ->
+    J = new_jar(),
+    set(J, <<"http://h.test/foo">>, [<<"a=1; Path=/">>, <<"b=2; Path=/foo">>]),
+    ?assertEqual(<<"b=2; a=1">>, sent(J, <<"http://h.test/foo/bar">>)).
+
+merge_preserves_caller_cookie_test() ->
+    J = new_jar(),
+    set(J, <<"http://h.test/">>, [<<"a=1">>]),
+    ?assertEqual(
+        <<"x=9; a=1">>,
+        sent(J, <<"http://h.test/">>, [{<<"Cookie">>, <<"x=9">>}])
+    ).
+
+no_cookie_no_header_test() ->
+    J = new_jar(),
+    ?assertEqual(undefined, sent(J, <<"http://h.test/">>)).
+
+multiple_cookies_test() ->
+    J = new_jar(),
+    set(J, <<"http://h.test/">>, [<<"a=1">>, <<"b=2">>]),
+    Header = sent(J, <<"http://h.test/">>),
+    ?assertMatch({_, _}, binary:match(Header, <<"a=1">>)),
+    ?assertMatch({_, _}, binary:match(Header, <<"b=2">>)).
+
+replace_same_key_test() ->
+    J = new_jar(),
+    set(J, <<"http://h.test/">>, [<<"a=1">>]),
+    set(J, <<"http://h.test/">>, [<<"a=2">>]),
+    ?assertEqual(<<"a=2">>, sent(J, <<"http://h.test/">>)).
+
+eviction_test() ->
+    J = new_jar(#{max_cookies => 2}),
+    set(J, <<"http://h.test/">>, [<<"a=1">>, <<"b=2">>, <<"c=3">>]),
+    ?assertEqual(2, count(J)).
+
+ignore_nameless_test() ->
+    J = new_jar(),
+    set(J, <<"http://h.test/">>, [<<"=novalue">>, <<"justtext">>]),
+    ?assertEqual(undefined, sent(J, <<"http://h.test/">>)).


### PR DESCRIPTION
Adds a cookie jar as a composable client layer, the outbound twin of a browser cookie store. Before each request it selects the stored cookies that match the target (host, path, secure) and merges them into one Cookie header, keeping any the caller already set; after the response it parses every Set-Cookie and updates the jar. Add it with livery_client:cookie_jar/0,1.

The layer holds no cookies itself. It reads and writes through the existing livery_client_cookie_store behaviour, defaulting to a per-jar public ETS table created by the constructor and shared across the client's request processes, so a different backing store (a supervised process, an external cache) is a drop-in via the store option. This follows the same opaque-handle pattern as the concurrency layer, while a name-keyed supervised store stays available for whoever needs survival across the building process, exactly as the circuit and balance layers do.

It implements the RFC 6265 client subset: Max-Age wins over Expires, host-only vs Domain matching, path scoping, Secure cookies over https only, longest-path-first ordering in the Cookie header, expiry dropped on read, and oldest-eviction past max_cookies. Non-goals: no public suffix list, no third-party-cookie policy, no persistence; SameSite is parsed but not enforced.

Tests cover the full round-trip over a loopback server (set then echo, path scoping, multiple cookies, deletion, host-only isolation across 127.0.0.1 vs localhost) plus a unit matrix driving the layer directly for the rules loopback cannot reach (Domain subdomain matching, Secure http vs https, Max-Age precedence, Expires deletion, ordering, caller-cookie merge, eviction).