### PR TITLE
Handle peer disconnect mid-response gracefully

### DIFF
--- a/src/livery_h1.erl
+++ b/src/livery_h1.erl
@@ -129,18 +129,20 @@ stop(Listener) ->
 ) ->
     livery_adapter:send_result().
 send_headers({Conn, StreamId}, Status, Headers, Opts) ->
-    case {maps:get(end_stream, Opts, false), drain_opts(Opts)} of
-        {true, {ok, RespOpts}} ->
-            %% Empty-body early response with a per-response drain budget:
-            %% commit it via respond/6 so h1 honors the budget on close.
-            h1:respond(Conn, StreamId, Status, Headers, <<>>, RespOpts);
-        {EndStream, _} ->
-            case h1:send_response(Conn, StreamId, Status, Headers) of
-                ok when EndStream -> h1:send_data(Conn, StreamId, <<>>, true);
-                ok -> ok;
-                Other -> Other
-            end
-    end.
+    closed_guard(fun() ->
+        case {maps:get(end_stream, Opts, false), drain_opts(Opts)} of
+            {true, {ok, RespOpts}} ->
+                %% Empty-body early response with a per-response drain budget:
+                %% commit it via respond/6 so h1 honors the budget on close.
+                h1:respond(Conn, StreamId, Status, Headers, <<>>, RespOpts);
+            {EndStream, _} ->
+                case h1:send_response(Conn, StreamId, Status, Headers) of
+                    ok when EndStream -> h1:send_data(Conn, StreamId, <<>>, true);
+                    ok -> ok;
+                    Other -> Other
+                end
+        end
+    end).
 
 -spec send_full(
     stream(),
@@ -156,21 +158,37 @@ send_headers({Conn, StreamId}, Status, Headers, Opts) ->
 %% because the callback is exported. A per-response early-response drain
 %% budget routes through respond/6 so h1 honors it on an early close.
 send_full({Conn, StreamId}, Status, Headers, IoData, Opts) ->
-    case drain_opts(Opts) of
-        {ok, RespOpts} -> h1:respond(Conn, StreamId, Status, Headers, IoData, RespOpts);
-        none -> h1:respond(Conn, StreamId, Status, Headers, IoData)
-    end.
+    closed_guard(fun() ->
+        case drain_opts(Opts) of
+            {ok, RespOpts} -> h1:respond(Conn, StreamId, Status, Headers, IoData, RespOpts);
+            none -> h1:respond(Conn, StreamId, Status, Headers, IoData)
+        end
+    end).
 
 -spec send_data(stream(), iodata(), livery_adapter:send_opts()) ->
     livery_adapter:send_result().
 send_data({Conn, StreamId}, IoData, Opts) ->
     EndStream = maps:get(end_stream, Opts, false),
-    h1:send_data(Conn, StreamId, IoData, EndStream).
+    closed_guard(fun() -> h1:send_data(Conn, StreamId, IoData, EndStream) end).
 
 -spec send_trailers(stream(), [{binary(), binary()}]) ->
     livery_adapter:send_result().
 send_trailers({Conn, StreamId}, Trailers) ->
-    h1:send_trailers(Conn, StreamId, Trailers).
+    closed_guard(fun() -> h1:send_trailers(Conn, StreamId, Trailers) end).
+
+%% A send to a connection whose process has gone away (peer closed) exits
+%% the underlying gen_statem:call with noproc/normal/shutdown. Map that to
+%% {error, closed} so livery:emit/3 treats it as a normal disconnect, not a
+%% handler crash. See livery_h2:closed_guard/1 for the full rationale.
+-spec closed_guard(fun(() -> R)) -> R | {error, closed}.
+closed_guard(Fun) ->
+    try
+        Fun()
+    catch
+        exit:{noproc, _} -> {error, closed};
+        exit:{normal, _} -> {error, closed};
+        exit:{{shutdown, _}, _} -> {error, closed}
+    end.
 
 -spec reset(stream(), term()) -> ok.
 reset({Conn, StreamId}, Reason) ->

--- a/src/livery_h3.erl
+++ b/src/livery_h3.erl
@@ -128,26 +128,43 @@ stop(Name) when is_atom(Name) ->
 ) ->
     livery_adapter:send_result().
 send_headers({Conn, StreamId}, Status, Headers, Opts) ->
-    case quic_h3:send_response(Conn, StreamId, Status, Headers) of
-        ok ->
-            case maps:get(end_stream, Opts, false) of
-                true -> quic_h3:send_data(Conn, StreamId, <<>>, true);
-                false -> ok
-            end;
-        Other ->
-            Other
-    end.
+    closed_guard(fun() ->
+        case quic_h3:send_response(Conn, StreamId, Status, Headers) of
+            ok ->
+                case maps:get(end_stream, Opts, false) of
+                    true -> quic_h3:send_data(Conn, StreamId, <<>>, true);
+                    false -> ok
+                end;
+            Other ->
+                Other
+        end
+    end).
 
 -spec send_data(stream(), iodata(), livery_adapter:send_opts()) ->
     livery_adapter:send_result().
 send_data({Conn, StreamId}, IoData, Opts) ->
     EndStream = maps:get(end_stream, Opts, false),
-    quic_h3:send_data(Conn, StreamId, iolist_to_binary(IoData), EndStream).
+    Bin = iolist_to_binary(IoData),
+    closed_guard(fun() -> quic_h3:send_data(Conn, StreamId, Bin, EndStream) end).
 
 -spec send_trailers(stream(), [{binary(), binary()}]) ->
     livery_adapter:send_result().
 send_trailers({Conn, StreamId}, Trailers) ->
-    quic_h3:send_trailers(Conn, StreamId, Trailers).
+    closed_guard(fun() -> quic_h3:send_trailers(Conn, StreamId, Trailers) end).
+
+%% A send to a connection whose process has gone away (peer closed) exits
+%% the underlying gen_statem:call with noproc/normal/shutdown. Map that to
+%% {error, closed} so livery:emit/3 treats it as a normal disconnect, not a
+%% handler crash. See livery_h2:closed_guard/1 for the full rationale.
+-spec closed_guard(fun(() -> R)) -> R | {error, closed}.
+closed_guard(Fun) ->
+    try
+        Fun()
+    catch
+        exit:{noproc, _} -> {error, closed};
+        exit:{normal, _} -> {error, closed};
+        exit:{{shutdown, _}, _} -> {error, closed}
+    end.
 
 -spec reset(stream(), term()) -> ok.
 reset({Conn, StreamId}, _Reason) ->

--- a/src/livery_mcp.erl
+++ b/src/livery_mcp.erl
@@ -154,14 +154,14 @@ responder(Adapter, Stream) ->
         reply => fun(Status, Headers, Body) ->
             Bin = iolist_to_binary(Body),
             Hdrs = ensure_content_length(Headers, byte_size(Bin)),
-            _ = Adapter:send_headers(
-                Stream,
-                Status,
-                Hdrs,
-                #{end_stream => false}
-            ),
-            _ = Adapter:send_data(Stream, Bin, #{end_stream => true}),
-            ok
+            case Adapter:send_headers(Stream, Status, Hdrs, #{end_stream => false}) of
+                {error, closed} ->
+                    %% Peer gone: drop the body, the stream is already over.
+                    ok;
+                _ ->
+                    _ = Adapter:send_data(Stream, Bin, #{end_stream => true}),
+                    ok
+            end
         end,
         stream_start => fun(Status, Headers) ->
             _ = Adapter:send_headers(

--- a/src/livery_req_proc.erl
+++ b/src/livery_req_proc.erl
@@ -65,11 +65,32 @@ dispatch(#{
     Req = ensure_started_at(Req0),
     try
         Resp = livery:dispatch(Stack, Handler, Req),
-        _ = livery:emit(Adapter, Stream, Resp)
+        case livery:emit(Adapter, Stream, Resp) of
+            {error, closed} -> peer_closed();
+            _ -> ok
+        end
     catch
         Class:Reason:Stack0 ->
-            handle_crash(Adapter, Stream, Class, Reason, Stack0)
+            case disconnect_reason(Class, Reason) of
+                true -> peer_closed();
+                false -> handle_crash(Adapter, Stream, Class, Reason, Stack0)
+            end
     end,
+    ok.
+
+%% A disconnect (socket/stream closed, connection process gone) is normal,
+%% not a handler fault. Covers the gen_statem:call exits a dead connection
+%% raises and the disconnect reason the adapters report.
+-spec disconnect_reason(throw | error | exit, term()) -> boolean().
+disconnect_reason(exit, {noproc, _}) -> true;
+disconnect_reason(exit, {normal, _}) -> true;
+disconnect_reason(exit, {{shutdown, _}, _}) -> true;
+disconnect_reason(_Class, {connection_closed, _}) -> true;
+disconnect_reason(_Class, _Reason) -> false.
+
+-spec peer_closed() -> ok.
+peer_closed() ->
+    logger:debug(#{msg => "livery_request_peer_closed"}),
     ok.
 
 -spec ensure_started_at(livery_req:req()) -> livery_req:req().
@@ -95,5 +116,10 @@ handle_crash(Adapter, Stream, Class, Reason, Stack) ->
         stacktrace => Stack
     }),
     Resp = livery_resp:text(500, <<"internal server error">>),
-    _ = livery:emit(Adapter, Stream, Resp),
-    ok.
+    %% The 500 goes to the same connection the handler was using; if the
+    %% peer is already gone the emit must not crash the worker a second time.
+    try livery:emit(Adapter, Stream, Resp) of
+        _ -> ok
+    catch
+        _Class:_Reason -> peer_closed()
+    end.

--- a/test/livery_h1_SUITE.erl
+++ b/test/livery_h1_SUITE.erl
@@ -29,8 +29,13 @@
     oversize_upload_delivers_413/1,
     early_response_no_read_delivers_413/1,
     error_500_on_crash/1,
-    cancel_on_client_disconnect/1
+    cancel_on_client_disconnect/1,
+    send_to_gone_client_is_closed/1,
+    disconnect_mid_response_is_quiet/1
 ]).
+
+%% logger handler callback (used by disconnect_mid_response_is_quiet).
+-export([log/2]).
 
 %%====================================================================
 %% Suite plumbing
@@ -50,7 +55,9 @@ all() ->
         oversize_upload_delivers_413,
         early_response_no_read_delivers_413,
         error_500_on_crash,
-        cancel_on_client_disconnect
+        cancel_on_client_disconnect,
+        send_to_gone_client_is_closed,
+        disconnect_mid_response_is_quiet
     ].
 
 init_per_suite(Config) ->
@@ -200,6 +207,52 @@ cancel_on_client_disconnect(Config) ->
     after 5000 -> ct:fail(cancel_callback_not_run)
     end.
 
+%% A send to a connection whose process has died returns {error, closed}
+%% rather than letting the gen_statem:call noproc exit propagate.
+send_to_gone_client_is_closed(_Config) ->
+    Dead = spawn(fun() -> ok end),
+    Ref = monitor(process, Dead),
+    receive
+        {'DOWN', Ref, process, Dead, _} -> ok
+    after 5000 -> ct:fail(proc_not_dead)
+    end,
+    Stream = {Dead, 1},
+    ?assertEqual({error, closed}, livery_h1:send_full(Stream, 200, [], <<"body">>, #{})),
+    ?assertEqual(
+        {error, closed}, livery_h1:send_data(Stream, <<"body">>, #{end_stream => true})
+    ),
+    ?assertEqual(
+        {error, closed}, livery_h1:send_headers(Stream, 200, [], #{end_stream => true})
+    ),
+    ?assertEqual({error, closed}, livery_h1:send_trailers(Stream, [{<<"x">>, <<"y">>}])).
+
+%% The client closes before the slow handler writes its response. The
+%% worker emits into the now-dead connection: that must end the request
+%% quietly (no ERROR/CRASH log), and the server must stay healthy for the
+%% next request.
+disconnect_mid_response_is_quiet(Config) ->
+    Port = ?config(port, Config),
+    HandlerId = h1_disconnect_log,
+    ok = logger:add_handler(HandlerId, ?MODULE, #{config => self(), level => all}),
+    try
+        {ok, Sock} = gen_tcp:connect(
+            "127.0.0.1", Port, [binary, {active, false}], 5000
+        ),
+        ok = gen_tcp:send(Sock, <<"GET / HTTP/1.1\r\nHost: x\r\n\r\n">>),
+        receive
+            handler_ready -> ok
+        after 5000 -> ct:fail(handler_did_not_start)
+        end,
+        ok = gen_tcp:close(Sock),
+        %% Let the handler wake and emit into the dead connection.
+        timer:sleep(400),
+        ok = assert_no_error_logged(),
+        %% Server is still healthy: a fresh request returns 200.
+        ?assertMatch({ok, 200, _, <<"awake">>}, get(Config, <<"/">>))
+    after
+        logger:remove_handler(HandlerId)
+    end.
+
 %%====================================================================
 %% Handlers
 %%====================================================================
@@ -272,6 +325,15 @@ handler_for(early_response_no_read_delivers_413) ->
     fun(_R) -> livery_resp:json(413, <<"{\"error\":\"too_big\"}">>) end;
 handler_for(error_500_on_crash) ->
     fun(_R) -> error(boom) end;
+handler_for(send_to_gone_client_is_closed) ->
+    fun(_R) -> livery_resp:text(200, <<"unused">>) end;
+handler_for(disconnect_mid_response_is_quiet) ->
+    Test = self(),
+    fun(_R) ->
+        Test ! handler_ready,
+        timer:sleep(200),
+        livery_resp:text(200, <<"awake">>)
+    end;
 handler_for(cancel_on_client_disconnect) ->
     Test = self(),
     fun(R) ->
@@ -337,6 +399,23 @@ post_no_pool(Config, Path, Body) ->
 
 normalize(Headers) ->
     [{string:lowercase(N), V} || {N, V} <- Headers].
+
+%%====================================================================
+%% Log capture (for disconnect_mid_response_is_quiet)
+%%====================================================================
+
+log(Event, #{config := Pid}) ->
+    Pid ! {log_event, Event},
+    ok.
+
+assert_no_error_logged() ->
+    receive
+        {log_event, #{level := error} = Event} ->
+            ct:fail({unexpected_error_log, Event});
+        {log_event, _Other} ->
+            assert_no_error_logged()
+    after 200 -> ok
+    end.
 
 header(Name, Headers) ->
     LName = string:lowercase(Name),

--- a/test/livery_h3_SUITE.erl
+++ b/test/livery_h3_SUITE.erl
@@ -24,7 +24,8 @@
     echo_buffered_body/1,
     error_500_on_crash/1,
     response_with_trailers/1,
-    cancel_on_connection_close/1
+    cancel_on_connection_close/1,
+    send_to_gone_client_is_closed/1
 ]).
 
 %%====================================================================
@@ -41,7 +42,8 @@ all() ->
         echo_buffered_body,
         error_500_on_crash,
         response_with_trailers,
-        cancel_on_connection_close
+        cancel_on_connection_close,
+        send_to_gone_client_is_closed
     ].
 
 init_per_suite(Config) ->
@@ -159,6 +161,8 @@ handler_for(echo_buffered_body) ->
     end;
 handler_for(error_500_on_crash) ->
     fun(_R) -> error(boom) end;
+handler_for(send_to_gone_client_is_closed) ->
+    fun(_R) -> livery_resp:text(200, <<"unused">>) end;
 handler_for(response_with_trailers) ->
     fun(_R) ->
         Resp = livery_resp:text(200, <<"hello">>),
@@ -177,6 +181,24 @@ handler_for(cancel_on_connection_close) ->
             end
         end)
     end.
+
+%% A send to a connection whose process has died returns {error, closed}
+%% rather than letting the gen_statem:call noproc exit propagate.
+send_to_gone_client_is_closed(_Config) ->
+    Dead = spawn(fun() -> ok end),
+    Ref = monitor(process, Dead),
+    receive
+        {'DOWN', Ref, process, Dead, _} -> ok
+    after 5000 -> ct:fail(proc_not_dead)
+    end,
+    Stream = {Dead, 1},
+    ?assertEqual(
+        {error, closed}, livery_h3:send_data(Stream, <<"body">>, #{end_stream => true})
+    ),
+    ?assertEqual(
+        {error, closed}, livery_h3:send_headers(Stream, 200, [], #{end_stream => true})
+    ),
+    ?assertEqual({error, closed}, livery_h3:send_trailers(Stream, [{<<"x">>, <<"y">>}])).
 
 cancel_on_connection_close(Config) ->
     Port = ?config(port, Config),

--- a/test/livery_mcp_SUITE.erl
+++ b/test/livery_mcp_SUITE.erl
@@ -20,17 +20,22 @@
 -export([
     initialize_returns_session/1,
     tools_list_returns_registered_tool/1,
-    tools_call_runs_tool/1
+    tools_call_runs_tool/1,
+    disconnect_mid_reply_is_quiet/1
 ]).
 
-%% Tool callback (registered in init_per_suite).
--export([echo_tool/1]).
+%% Tool callbacks (registered in init_per_suite).
+-export([echo_tool/1, slow_tool/1]).
+
+%% logger handler callback (used by disconnect_mid_reply_is_quiet).
+-export([log/2]).
 
 all() ->
     [
         initialize_returns_session,
         tools_list_returns_registered_tool,
-        tools_call_runs_tool
+        tools_call_runs_tool,
+        disconnect_mid_reply_is_quiet
     ].
 
 init_per_suite(Config) ->
@@ -47,10 +52,15 @@ init_per_suite(Config) ->
             }
         }
     }),
+    ok = barrel_mcp:reg_tool(<<"slow">>, ?MODULE, slow_tool, #{
+        description => <<"Sleeps then replies">>,
+        input_schema => #{<<"type">> => <<"object">>, <<"properties">> => #{}}
+    }),
     Config.
 
 end_per_suite(_Config) ->
     catch barrel_mcp:unreg_tool(<<"echo">>),
+    catch barrel_mcp:unreg_tool(<<"slow">>),
     _ = application:stop(hackney),
     ok.
 
@@ -78,6 +88,11 @@ end_per_testcase(_TC, Config) ->
 echo_tool(Args) ->
     Value = maps:get(<<"value">>, Args, <<"default">>),
     <<"echo: ", Value/binary>>.
+
+%% Tool callback: sleeps so the client can disconnect before the reply.
+slow_tool(_Args) ->
+    timer:sleep(300),
+    <<"slow done">>.
 
 %%====================================================================
 %% Cases
@@ -133,6 +148,54 @@ tools_call_runs_tool(Config) ->
     ],
     Joined = iolist_to_binary(Texts),
     ?assertNotEqual(nomatch, binary:match(Joined, <<"echo: hi">>)).
+
+%% The client closes before the slow tool's reply is written. The MCP
+%% responder writes into the now-dead connection: that must end the
+%% request quietly (no ERROR/CRASH log), and the server must stay healthy.
+disconnect_mid_reply_is_quiet(Config) ->
+    Url = ?config(url, Config),
+    Port = h1:server_port(?config(listener, Config)),
+    {200, Headers, _} = initialize(Url),
+    Sid = session_id(Headers),
+    ok = initialized(Url, Sid),
+    HandlerId = mcp_disconnect_log,
+    ok = logger:add_handler(HandlerId, ?MODULE, #{config => self(), level => all}),
+    try
+        ReqBody = iolist_to_binary(
+            json:encode(#{
+                <<"jsonrpc">> => <<"2.0">>,
+                <<"id">> => 9,
+                <<"method">> => <<"tools/call">>,
+                <<"params">> => #{<<"name">> => <<"slow">>, <<"arguments">> => #{}}
+            })
+        ),
+        Raw = [
+            <<"POST /mcp HTTP/1.1\r\n">>,
+            <<"Host: x\r\n">>,
+            <<"Content-Type: application/json\r\n">>,
+            <<"Accept: application/json, text/event-stream\r\n">>,
+            <<"Mcp-Session-Id: ">>,
+            Sid,
+            <<"\r\n">>,
+            <<"Content-Length: ">>,
+            integer_to_binary(byte_size(ReqBody)),
+            <<"\r\n\r\n">>,
+            ReqBody
+        ],
+        {ok, Sock} = gen_tcp:connect(
+            "127.0.0.1", Port, [binary, {active, false}], 5000
+        ),
+        ok = gen_tcp:send(Sock, Raw),
+        timer:sleep(50),
+        ok = gen_tcp:close(Sock),
+        %% Let the slow tool finish and the responder write into the dead conn.
+        timer:sleep(600),
+        ok = assert_no_error_logged(),
+        %% Server is still healthy: a fresh session initializes.
+        ?assertMatch({200, _, _}, initialize(Url))
+    after
+        logger:remove_handler(HandlerId)
+    end.
 
 %%====================================================================
 %% MCP client helpers (hackney)
@@ -198,3 +261,20 @@ with_session(Headers, Sid) -> [{<<"mcp-session-id">>, Sid} | Headers].
 session_id(Headers) ->
     Lower = [{string:lowercase(K), V} || {K, V} <- Headers],
     proplists:get_value(<<"mcp-session-id">>, Lower, undefined).
+
+%%====================================================================
+%% Log capture (for disconnect_mid_reply_is_quiet)
+%%====================================================================
+
+log(Event, #{config := Pid}) ->
+    Pid ! {log_event, Event},
+    ok.
+
+assert_no_error_logged() ->
+    receive
+        {log_event, #{level := error} = Event} ->
+            ct:fail({unexpected_error_log, Event});
+        {log_event, _Other} ->
+            assert_no_error_logged()
+    after 200 -> ok
+    end.


### PR DESCRIPTION
When a client closed the connection before the handler's response was written, the request worker crashed with a noproc exit from the adapter's gen_statem:call and then crashed again in handle_crash trying to send a 500 on the same dead connection, so a normal disconnect produced an ERROR plus a CRASH report. The repro path was MCP: the responder's reply called send_headers into a connection whose process had already died.

HTTP/2 already guarded its send callbacks with closed_guard, mapping the noproc/normal/shutdown exits to {error, closed}. This adds the same guard to the H1 and H3 send paths, so a dead connection surfaces as {error, closed} everywhere instead of an exit. livery_req_proc now treats a closed connection as a benign early termination: it logs at debug, sends no 500, and emits no error report, while a real handler crash on a live socket still logs an error and returns a 500. handle_crash wraps its 500 emit so it can never crash the worker a second time, and the MCP responder stops quietly when a send reports closed.

Tests: send-to-a-dead-connection returns {error, closed} on H1 and H3 (mirroring the existing H2 test); an in-process H1 server with a slow handler where the client closes before the response asserts no error or crash is logged and a fresh request still returns 200; an MCP variant drives the same through a slow tool and the responder path that originally crashed.