### PR TITLE
Bump hackney to 4.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `hackney` 4.4.3 -> 4.4.5.
+
 ## [0.4.3] - 2026-06-17
 
 Maintenance release: a disconnect-handling fix and a dependency bump.

--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
     {ws, "~> 0.3.0", {pkg, erlang_ws}},
     {instrument, "~> 1.1.4"},
     {webtransport, "~> 0.4.1"},
-    {hackney, "~> 4.4.3"},
+    {hackney, "~> 4.4.5"},
     {barrel_mcp, "~> 2.2.4"}
 ]}.
 


### PR DESCRIPTION
Bumps the hackney requirement from 4.4.3 to 4.4.5. Compiles cleanly and the client suite passes locally on 4.4.5; opening as a PR so CI confirms the full build, lint, xref, dialyzer, and test run.