### PR TITLE
Add HTTP QUERY method support and release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-04
+
+Adds first-class support for the HTTP QUERY method (RFC 10008), end to
+end: server, client, OpenAPI, example, and docs.
+
+### Added
+
+- HTTP QUERY method support. The core was already method-agnostic
+  (router dispatch, the 405 `Allow` header, body reading, all three
+  adapters), and the parity suite now locks QUERY-with-body behaviour
+  across HTTP/1.1, HTTP/2, and HTTP/3.
+- `livery_client:query/3`, mirroring `post/3`. The retry layer treats
+  QUERY as idempotent and replays it.
+- A `QUERY /notes` search endpoint in the complete example, exercised
+  by the e2e journey, and a new guide: `docs/guides/query-method.md`.
+
+### Changed
+
+- `livery_openapi` emits OpenAPI 3.2.0 documents (previously 3.1.0);
+  QUERY routes appear as the `query` operation, a first-class key in
+  3.2.
+- `livery_cors` includes `QUERY` in the default allow-methods.
+- Bump `hackney` 4.4.5 -> 4.5.1.
+
 ## [0.4.4] - 2026-06-18
 
 Maintenance release: dependency update.

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,7 @@ solution.
 
 **Routing & middleware**
 - [Mount a router on a service](guides/mount-a-router.md)
+- [Handle QUERY requests](guides/query-method.md)
 - [Write a custom middleware](guides/custom-middleware.md)
 - [Cap request body size](guides/cap-body-size.md)
 - [Add per-request deadlines](guides/add-deadlines.md)

--- a/docs/design.md
+++ b/docs/design.md
@@ -296,7 +296,7 @@ transport.
 - **REST:** router, extractors, JSON response builder (user-chosen
   codec), content negotiation helpers, ranges on file responses.
 - **OpenAPI:** routes carry metadata, `livery_openapi:build/1`
-  emits a 3.1 document, `/openapi.json` is served, optional
+  emits a 3.2 document, `/openapi.json` is served, optional
   request/response validation middleware, Redoc and Swagger UI
   from `priv/`.
 - **MCP:** Streamable HTTP handler mounted at a user-chosen path,

--- a/docs/features.md
+++ b/docs/features.md
@@ -166,3 +166,14 @@ invalid decision crashes before any byte, surfacing as a clean 500. Tests:
 The original reproducer is `barrel_inference`'s `chat_busy_returns_429/1`
 CT case (saturates a concurrency=1/depth=1 queue, asserts a racing request
 reports `429`/`504`).
+
+## HTTP QUERY method (RFC 10008)
+
+DONE: QUERY is first-class end to end. The core was already
+method-agnostic (router dispatch, the 405 `Allow` header, body
+reading, all three adapters), so the changes are the deliberate
+opt-ins: `livery_client:query/3`, QUERY in the client retry
+idempotent set and in the CORS default allow-methods, and OpenAPI
+3.2 output where a QUERY route emits a `query` operation. Locked by
+the parity SUITE (`query_with_body`) across H1/H2/H3 and by a QUERY
+search step in the e2e journey. See `docs/guides/query-method.md`.

--- a/docs/guides/make-http-requests.md
+++ b/docs/guides/make-http-requests.md
@@ -38,8 +38,9 @@ case livery_client:get(Client, <<"/users/42">>) of
 end.
 ```
 
-`post/3`, `put/3`, `delete/2`, and `request/3,4` round it out. With a
-`base_url` set you pass paths; without one you pass full URLs.
+`post/3`, `put/3`, `delete/2`, `query/3` (the RFC 10008 QUERY method),
+and `request/3,4` round it out. With a `base_url` set you pass paths;
+without one you pass full URLs.
 
 ## A real client, end to end
 

--- a/docs/guides/openapi-and-validation.md
+++ b/docs/guides/openapi-and-validation.md
@@ -1,13 +1,13 @@
 # How to generate OpenAPI docs and validate requests
 
-Livery can turn your route metadata into an OpenAPI 3.1 spec, serve a
+Livery can turn your route metadata into an OpenAPI 3.2 spec, serve a
 browsable docs page from it, and reject malformed request bodies. You
 need this when you want a machine-readable contract for your routes and
 automatic validation against it.
 
 ## Generate the spec
 
-`livery_openapi:build/1` turns route metadata into an OpenAPI 3.1
+`livery_openapi:build/1` turns route metadata into an OpenAPI 3.2
 document. Livery path templates (`:param`, `*wildcard`) become `{param}`
 and gain synthesised path parameters:
 

--- a/docs/guides/query-method.md
+++ b/docs/guides/query-method.md
@@ -1,0 +1,71 @@
+# How to handle QUERY requests
+
+QUERY (RFC 10008) is an HTTP method that behaves like GET with a body:
+it is safe and idempotent, so it never changes state and may be
+repeated freely, yet it carries its search criteria in the request
+body instead of the URL. You need it when a search is too structured
+or too large for a query string, and POST would throw away the safe
+semantics.
+
+## Route it
+
+A QUERY route registers exactly like any other method:
+
+```erlang
+Router = livery_router:compile([
+    {<<"QUERY">>, <<"/documents/search">>, {docs, search}}
+]).
+```
+
+If a path accepts only QUERY, requests with another method get a `405`
+whose `Allow` header lists `QUERY` automatically.
+
+## Handle it
+
+The body arrives exactly like a POST body; read it the same way:
+
+```erlang
+search(Req) ->
+    {stream, Reader} = livery_req:body(Req),
+    {ok, Bin, _} = livery_body:read_all(Reader),
+    #{<<"q">> := Q} = json:decode(Bin),
+    livery_resp:json(200, json:encode(documents:search(Q))).
+```
+
+Headers, query string parameters, and path bindings all work
+unchanged.
+
+## Call it
+
+The client has a helper that mirrors `post/3`:
+
+```erlang
+Client = livery_client:new(#{base_url => <<"https://api.example.com">>}),
+{ok, Resp} = livery_client:query(
+    Client,
+    <<"/documents/search">>,
+    json:encode(#{q => <<"boots">>, limit => 20})
+).
+```
+
+Because QUERY is idempotent, the `livery_client:retry/1` layer replays
+a failed QUERY like a GET, as long as the body is not a stream.
+
+## When to prefer QUERY
+
+- Over GET: the criteria form a structured document (JSON filters,
+  sub-queries) that would be unreadable or oversized in a URL.
+- Over POST: the request has no side effects. Saying so with QUERY
+  lets clients retry safely and lets caches store responses, keyed on
+  the request content.
+
+Two notes. QUERY routes appear in generated OpenAPI documents as a
+`query` operation (OpenAPI 3.2). And `livery_etag` keeps its
+conditional handling on GET and HEAD only, since RFC 9110 defines the
+304 revalidation flow for those two methods.
+
+## See also
+
+- Guide: [Parse a JSON body](parse-json-bodies.md)
+- Guide: [Make outbound HTTP requests](make-http-requests.md)
+- Reference: `livery_router`, `livery_client`

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,13 +40,15 @@ started with a TLS/QUIC listener and extended CONNECT enabled.
 The end-to-end notes service from the [Build a complete
 service](../docs/tutorials/build-a-complete-service.md) tutorial: a
 service, a router with path params, a service-wide and a per-route
-middleware, JSON CRUD, an SSE feed, and a WebSocket echo. Start it with
+middleware, JSON CRUD, a QUERY search, an SSE feed, and a WebSocket
+echo. Start it with
 `livery_example_complete:start(8080)`, or `start_tls/1` to serve H1, H2,
 and H3 at once from the vendored `test/certs`.
 
 ```
 curl http://127.0.0.1:8080/notes
 curl -XPOST --data '{"text":"buy bread"}' http://127.0.0.1:8080/notes
+curl -XQUERY --data '{"text":"bread"}' http://127.0.0.1:8080/notes
 curl http://127.0.0.1:8080/notes/1
 curl -N http://127.0.0.1:8080/events
 ```

--- a/examples/livery_example_complete.erl
+++ b/examples/livery_example_complete.erl
@@ -15,6 +15,7 @@
 %%
 %%     curl http://127.0.0.1:8080/notes
 %%     curl -XPOST --data '{"text":"buy bread"}' http://127.0.0.1:8080/notes
+%%     curl -XQUERY --data '{"text":"bread"}' http://127.0.0.1:8080/notes
 %%     curl http://127.0.0.1:8080/notes/1
 %%     curl -XDELETE http://127.0.0.1:8080/notes/1
 %%     curl -N http://127.0.0.1:8080/events
@@ -33,7 +34,7 @@
 %% reusable pieces (handy for embedding the service in a test harness)
 -export([base_stack/0, ensure_table/0]).
 %% route handlers
--export([list_notes/1, create_note/1, show_note/1, delete_note/1, events/1, ws/1]).
+-export([list_notes/1, create_note/1, search_notes/1, show_note/1, delete_note/1, events/1, ws/1]).
 %% ws_handler callbacks
 -export([init/2, handle_in/2, handle_info/2, terminate/2]).
 
@@ -102,6 +103,9 @@ router() ->
     livery_router:compile([
         {<<"GET">>, <<"/notes">>, {?MODULE, list_notes}, #{middleware => [list_marker()]}},
         {<<"POST">>, <<"/notes">>, {?MODULE, create_note}},
+        %% QUERY (RFC 10008): a safe search over the same resource, with
+        %% the criteria in a JSON body instead of the URL.
+        {<<"QUERY">>, <<"/notes">>, {?MODULE, search_notes}},
         {<<"GET">>, <<"/notes/:id">>, {?MODULE, show_note}},
         {<<"DELETE">>, <<"/notes/:id">>, {?MODULE, delete_note}},
         {<<"GET">>, <<"/events">>, {?MODULE, events}},
@@ -162,6 +166,23 @@ create_note(Req) ->
             Location = <<"/notes/", Id/binary>>,
             Resp = livery_resp:json(201, json:encode(Note)),
             livery_resp:with_header(<<"location">>, Location, Resp);
+        {ok, _} ->
+            livery_resp:json(422, <<"{\"error\":\"text is required\"}">>);
+        {error, _} ->
+            livery_resp:json(400, <<"{\"error\":\"invalid json\"}">>)
+    end.
+
+%% Search notes with a QUERY request: same body handling as POST, but
+%% safe and idempotent, so clients and caches may repeat it freely.
+search_notes(Req) ->
+    case decode_body(Req) of
+        {ok, #{<<"text">> := Text}} when is_binary(Text) ->
+            Matches = [
+                Note
+             || Note <- all_notes(),
+                binary:match(maps:get(<<"text">>, Note), Text) =/= nomatch
+            ],
+            livery_resp:json(200, json:encode(Matches));
         {ok, _} ->
             livery_resp:json(422, <<"{\"error\":\"text is required\"}">>);
         {error, _} ->

--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
     {ws, "~> 0.3.0", {pkg, erlang_ws}},
     {instrument, "~> 1.1.4"},
     {webtransport, "~> 0.4.1"},
-    {hackney, "~> 4.4.5"},
+    {hackney, "~> 4.5.1"},
     {barrel_mcp, "~> 2.2.4"}
 ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -100,6 +100,7 @@
         }},
 
         {"docs/guides/mount-a-router.md", #{title => <<"Mount a router on a service">>}},
+        {"docs/guides/query-method.md", #{title => <<"Handle QUERY requests">>}},
         {"docs/guides/bind-listen-address.md", #{
             title => <<"Bind to an address or IPv6">>
         }},

--- a/src/client/livery_client.erl
+++ b/src/client/livery_client.erl
@@ -4,7 +4,7 @@ A composable HTTP client: the outbound twin of the server middleware.
 
 Build a client once with `new/1` (a transport adapter, a base URL,
 default headers, and a layer stack), then call it with `get/2`, `post/3`,
-`request/3,4`. Layers run outermost-first and each is
+`query/3`, `request/3,4`. Layers run outermost-first and each is
 `call(Request, Next, State) -> {ok, response()} | {error, term()}`, the
 same shape as server middleware, with errors threaded as values.
 
@@ -27,7 +27,7 @@ The transport is a `livery_client_adapter`; the default,
 """.
 
 -export([new/1]).
--export([get/2, post/3, put/3, delete/2, request/3, request/4, run/2]).
+-export([get/2, post/3, put/3, delete/2, query/3, request/3, request/4, run/2]).
 -export([status/1, headers/1, header/2, header/3, body/1, method/1, url/1, set_header/3]).
 -export([read/2, read_body/1]).
 -export([stream_next/1, stop_stream/1]).
@@ -101,6 +101,10 @@ put(Client, Path, Body) -> request(Client, put, Path, #{body => {full, Body}}).
 
 -spec delete(client(), binary()) -> result().
 delete(Client, Path) -> request(Client, delete, Path, #{}).
+
+-doc "Send a QUERY request (RFC 10008): safe and idempotent, with a body.".
+-spec query(client(), binary(), iodata()) -> result().
+query(Client, Path, Body) -> request(Client, query, Path, #{body => {full, Body}}).
 
 -spec request(client(), atom() | binary(), binary()) -> result().
 request(Client, Method, Path) -> request(Client, Method, Path, #{}).

--- a/src/client/livery_client_retry.erl
+++ b/src/client/livery_client_retry.erl
@@ -55,7 +55,7 @@ idempotent(_Method, #{retry_non_idempotent := true}) ->
 idempotent(Method, _Opts) ->
     lists:member(
         normalize(Method),
-        [<<"get">>, <<"head">>, <<"put">>, <<"delete">>, <<"options">>]
+        [<<"get">>, <<"head">>, <<"put">>, <<"delete">>, <<"options">>, <<"query">>]
     ).
 
 normalize(M) when is_atom(M) -> normalize(atom_to_binary(M, utf8));

--- a/src/livery.app.src
+++ b/src/livery.app.src
@@ -1,6 +1,6 @@
 {application, livery, [
     {description, "Livery: a modern Erlang web framework over HTTP/1.1, HTTP/2, and HTTP/3"},
-    {vsn, "0.4.4"},
+    {vsn, "0.5.0"},
     {registered, [livery_sup]},
     {mod, {livery_app, []}},
     {applications, [

--- a/src/livery_openapi.erl
+++ b/src/livery_openapi.erl
@@ -1,8 +1,8 @@
 -module(livery_openapi).
 -moduledoc """
-OpenAPI 3.1 document generation from route metadata.
+OpenAPI 3.2 document generation from route metadata.
 
-`build/1` turns a list of routes into an OpenAPI 3.1 document
+`build/1` turns a list of routes into an OpenAPI 3.2 document
 (a JSON-encodable map). Each route is
 `{Method, Path, Handler}` or `{Method, Path, Handler, Meta}`; the
 optional `Meta` map carries operation-level fields:
@@ -67,7 +67,7 @@ JsonBytes = livery_openapi:to_json(Doc).
 %% Build
 %%====================================================================
 
--doc "Build an OpenAPI 3.1 document map from routes + info.".
+-doc "Build an OpenAPI 3.2 document map from routes + info.".
 -spec build(build_opts()) -> document().
 build(Opts) ->
     Info = maps:get(info, Opts, #{
@@ -76,7 +76,7 @@ build(Opts) ->
     }),
     Routes = maps:get(routes, Opts, []),
     Base = #{
-        <<"openapi">> => <<"3.1.0">>,
+        <<"openapi">> => <<"3.2.0">>,
         <<"info">> => normalize_info(Info),
         <<"paths">> => build_paths(Routes)
     },

--- a/src/middleware/livery_cors.erl
+++ b/src/middleware/livery_cors.erl
@@ -229,6 +229,7 @@ default_methods() ->
         <<"PATCH">>,
         <<"POST">>,
         <<"DELETE">>,
+        <<"QUERY">>,
         <<"OPTIONS">>
     ].
 

--- a/test/livery_builtin_middleware_tests.erl
+++ b/test/livery_builtin_middleware_tests.erl
@@ -282,11 +282,10 @@ cors_preflight_returns_204_and_skips_handler_test() ->
         <<"http://app.test">>,
         livery_test_adapter:header(<<"access-control-allow-origin">>, Cap)
     ),
-    ?assert(
-        is_binary(
-            livery_test_adapter:header(<<"access-control-allow-methods">>, Cap)
-        )
-    ).
+    Methods = livery_test_adapter:header(<<"access-control-allow-methods">>, Cap),
+    ?assert(is_binary(Methods)),
+    %% QUERY is part of the default allow-methods set.
+    ?assertNotEqual(nomatch, binary:match(Methods, <<"QUERY">>)).
 
 cors_simple_allowed_origin_echoes_and_varies_test() ->
     Cap = run_cors(

--- a/test/livery_client_SUITE.erl
+++ b/test/livery_client_SUITE.erl
@@ -9,8 +9,10 @@
 -export([
     get_round_trip/1,
     post_round_trip/1,
+    query_round_trip/1,
     timeout_layer/1,
     retry_layer/1,
+    query_retry_idempotent/1,
     concurrency_layer/1,
     circuit_layer/1,
     circuit_store_recovers/1,
@@ -29,8 +31,10 @@ all() ->
     [
         get_round_trip,
         post_round_trip,
+        query_round_trip,
         timeout_layer,
         retry_layer,
+        query_retry_idempotent,
         concurrency_layer,
         circuit_layer,
         circuit_store_recovers,
@@ -54,8 +58,10 @@ init_per_suite(Config) ->
     Router = livery_router:compile([
         {<<"GET">>, <<"/ok">>, fun handle_ok/1},
         {<<"POST">>, <<"/echo">>, fun handle_echo/1},
+        {<<"QUERY">>, <<"/search">>, fun handle_echo/1},
         {<<"GET">>, <<"/slow">>, fun handle_slow/1},
         {<<"GET">>, <<"/flaky">>, fun handle_flaky/1},
+        {<<"QUERY">>, <<"/flaky">>, fun handle_flaky/1},
         {<<"GET">>, <<"/big">>, fun handle_big/1},
         {<<"GET">>, <<"/chunks">>, fun handle_chunks/1},
         {<<"GET">>, <<"/block">>, fun handle_block/1},
@@ -149,6 +155,12 @@ post_round_trip(Config) ->
     ?assertEqual(200, livery_client:status(Resp)),
     ?assertEqual({full, <<"hello">>}, livery_client:body(Resp)).
 
+query_round_trip(Config) ->
+    C = livery_client:new(#{base_url => ?config(base, Config)}),
+    {ok, Resp} = livery_client:query(C, <<"/search">>, <<"{\"q\":\"boots\"}">>),
+    ?assertEqual(200, livery_client:status(Resp)),
+    ?assertEqual({full, <<"{\"q\":\"boots\"}">>}, livery_client:body(Resp)).
+
 timeout_layer(Config) ->
     C = livery_client:new(#{
         base_url => ?config(base, Config),
@@ -163,6 +175,17 @@ retry_layer(Config) ->
         stack => [livery_client:retry(#{max => 5, backoff => {10, 1.2}})]
     }),
     {ok, Resp} = livery_client:get(C, <<"/flaky">>),
+    ?assertEqual(200, livery_client:status(Resp)),
+    ?assertEqual({full, <<"recovered">>}, livery_client:body(Resp)).
+
+%% QUERY is idempotent (RFC 10008), so the retry layer replays it.
+query_retry_idempotent(Config) ->
+    atomics:put(?config(counter, Config), 1, 0),
+    C = livery_client:new(#{
+        base_url => ?config(base, Config),
+        stack => [livery_client:retry(#{max => 5, backoff => {10, 1.2}})]
+    }),
+    {ok, Resp} = livery_client:query(C, <<"/flaky">>, <<"{}">>),
     ?assertEqual(200, livery_client:status(Resp)),
     ?assertEqual({full, <<"recovered">>}, livery_client:body(Resp)).
 

--- a/test/livery_e2e_SUITE.erl
+++ b/test/livery_e2e_SUITE.erl
@@ -97,7 +97,7 @@ end_per_group(_Proto, _Config) ->
     ok.
 
 %%====================================================================
-%% The journey: CRUD + list (with middleware headers) + SSE
+%% The journey: CRUD + QUERY search + list (with middleware headers) + SSE
 %%====================================================================
 
 journey(Config) ->
@@ -125,14 +125,21 @@ journey(Config) ->
     ?assertNotEqual(undefined, header(<<"x-request-id">>, ListHs)),
     ?assertNotEqual(undefined, header(<<"x-response-time-ms">>, ListHs)),
 
-    %% 4. Delete.
+    %% 4. Search with QUERY (RFC 10008): a safe method that carries its
+    %% criteria in the body, dispatched and middleware-wrapped like POST.
+    SearchReq = iolist_to_binary(json:encode(#{<<"text">> => Tag})),
+    {200, SearchHs, SearchBody} = req(Config, <<"QUERY">>, <<"/notes">>, SearchReq),
+    ?assert(lists:member(Id, [maps:get(<<"id">>, N) || N <- json:decode(SearchBody)])),
+    ?assertNotEqual(undefined, header(<<"x-request-id">>, SearchHs)),
+
+    %% 5. Delete.
     {204, _, DeleteBody} = req(Config, <<"DELETE">>, Path, <<>>),
     ?assertEqual(<<>>, DeleteBody),
 
-    %% 5. Gone.
+    %% 6. Gone.
     {404, _, _} = req(Config, <<"GET">>, Path, <<>>),
 
-    %% 6. SSE feed: three `event: notes' frames, then the stream ends.
+    %% 7. SSE feed: three `event: notes' frames, then the stream ends.
     {200, EventsHs, EventsBody} = req(Config, <<"GET">>, <<"/events">>, <<>>),
     ?assertEqual(<<"text/event-stream">>, header(<<"content-type">>, EventsHs)),
     ?assert(count_occurrences(EventsBody, <<"event: notes">>) >= 3).

--- a/test/livery_middleware_tests.erl
+++ b/test/livery_middleware_tests.erl
@@ -36,6 +36,23 @@ before_transforms_request_test() ->
     Resp = livery_middleware:run(Stack, Handler, req()),
     ?assertEqual(200, livery_resp:status(Resp)).
 
+query_method_passes_through_middleware_test() ->
+    Stack = [
+        livery_middleware:before(fun(R) ->
+            livery_req:set_meta(marker, yes, R)
+        end)
+    ],
+    Handler = fun(R) ->
+        <<"QUERY">> = livery_req:method(R),
+        yes = livery_req:meta(marker, R),
+        livery_resp:text(200, <<"queried">>)
+    end,
+    Req = livery_req:new(#{
+        protocol => h1, method => <<"QUERY">>, path => <<"/search">>
+    }),
+    Resp = livery_middleware:run(Stack, Handler, Req),
+    ?assertEqual(200, livery_resp:status(Resp)).
+
 after_response_transforms_response_test() ->
     Stack = [
         livery_middleware:after_response(fun(Resp) ->

--- a/test/livery_openapi_tests.erl
+++ b/test/livery_openapi_tests.erl
@@ -7,12 +7,12 @@
 %% build/1
 %%====================================================================
 
-emits_openapi_31_and_info_test() ->
+emits_openapi_32_and_info_test() ->
     Doc = livery_openapi:build(#{
         info => #{title => <<"My API">>, version => <<"2.1.0">>},
         routes => []
     }),
-    ?assertEqual(<<"3.1.0">>, maps:get(<<"openapi">>, Doc)),
+    ?assertEqual(<<"3.2.0">>, maps:get(<<"openapi">>, Doc)),
     ?assertEqual(
         #{<<"title">> => <<"My API">>, <<"version">> => <<"2.1.0">>},
         maps:get(<<"info">>, Doc)
@@ -80,6 +80,26 @@ metadata_populates_operation_test() ->
         maps:get(<<"responses">>, Post)
     ).
 
+query_route_emits_query_operation_test() ->
+    Doc = livery_openapi:build(#{
+        info => #{title => <<"A">>, version => <<"1">>},
+        routes => [
+            {<<"QUERY">>, <<"/documents/search">>, {docs, search}, #{
+                operation_id => <<"searchDocuments">>,
+                request_body => #{<<"required">> => true},
+                responses => #{200 => #{description => <<"matches">>}}
+            }}
+        ]
+    }),
+    Item = maps:get(<<"/documents/search">>, maps:get(<<"paths">>, Doc)),
+    Query = maps:get(<<"query">>, Item),
+    ?assertEqual(<<"searchDocuments">>, maps:get(<<"operationId">>, Query)),
+    ?assertMatch(#{<<"required">> := true}, maps:get(<<"requestBody">>, Query)),
+    ?assertMatch(
+        #{<<"200">> := #{<<"description">> := <<"matches">>}},
+        maps:get(<<"responses">>, Query)
+    ).
+
 multiple_methods_same_path_test() ->
     Doc = livery_openapi:build(#{
         info => #{title => <<"A">>, version => <<"1">>},
@@ -115,7 +135,7 @@ to_json_roundtrips_test() ->
     Json = livery_openapi:to_json(Doc),
     ?assert(is_binary(Json)),
     Decoded = json:decode(Json),
-    ?assertEqual(<<"3.1.0">>, maps:get(<<"openapi">>, Decoded)).
+    ?assertEqual(<<"3.2.0">>, maps:get(<<"openapi">>, Decoded)).
 
 handler_serves_json_test() ->
     Doc = livery_openapi:build(#{
@@ -130,4 +150,4 @@ handler_serves_json_test() ->
         livery_test_adapter:header(<<"content-type">>, Cap)
     ),
     Decoded = json:decode(livery_test_adapter:body(Cap)),
-    ?assertEqual(<<"3.1.0">>, maps:get(<<"openapi">>, Decoded)).
+    ?assertEqual(<<"3.2.0">>, maps:get(<<"openapi">>, Decoded)).

--- a/test/livery_parity_SUITE.erl
+++ b/test/livery_parity_SUITE.erl
@@ -30,6 +30,7 @@
     json_response/1,
     empty_response/1,
     echo_buffered_body/1,
+    query_with_body/1,
     streaming_chunked_response/1,
     sse_response/1,
     ndjson_response/1,
@@ -64,6 +65,7 @@ groups() ->
         json_response,
         empty_response,
         echo_buffered_body,
+        query_with_body,
         streaming_chunked_response,
         sse_response,
         ndjson_response,
@@ -205,6 +207,31 @@ echo_buffered_body(Config) ->
         }
     ),
     ?assertEqual(<<"echo me">>, body(Resp)).
+
+%% QUERY (RFC 10008) is a safe method that carries a request body;
+%% it must dispatch and deliver its body exactly like POST.
+query_with_body(Config) ->
+    Handler = fun(R) ->
+        <<"QUERY">> = livery_req:method(R),
+        case livery_req:body(R) of
+            {buffered, IoData} ->
+                livery_resp:json(200, IoData);
+            {stream, Reader} ->
+                {ok, Bytes, _} = livery_body:read_all(Reader, 5000),
+                livery_resp:json(200, Bytes)
+        end
+    end,
+    Resp = drive(
+        Config,
+        [],
+        Handler,
+        #{
+            method => <<"QUERY">>,
+            body => {buffered, <<"{\"q\":\"boots\"}">>}
+        }
+    ),
+    ?assertEqual(200, status(Resp)),
+    ?assertEqual(<<"{\"q\":\"boots\"}">>, body(Resp)).
 
 streaming_chunked_response(Config) ->
     Producer = fun(Emit) ->

--- a/test/livery_router_tests.erl
+++ b/test/livery_router_tests.erl
@@ -60,12 +60,14 @@ wildcard_captures_rest_test() ->
 method_filter_test() ->
     R = livery_router:compile([
         {<<"GET">>, <<"/x">>, show},
-        {<<"POST">>, <<"/x">>, create}
+        {<<"POST">>, <<"/x">>, create},
+        {<<"QUERY">>, <<"/x">>, search}
     ]),
     ?assertMatch({ok, show, _, _}, livery_router:match(<<"GET">>, <<"/x">>, R)),
     ?assertMatch({ok, create, _, _}, livery_router:match(<<"POST">>, <<"/x">>, R)),
+    ?assertMatch({ok, search, _, _}, livery_router:match(<<"QUERY">>, <<"/x">>, R)),
     ?assertEqual(
-        {error, {method_not_allowed, [<<"GET">>, <<"POST">>]}},
+        {error, {method_not_allowed, [<<"GET">>, <<"POST">>, <<"QUERY">>]}},
         livery_router:match(<<"DELETE">>, <<"/x">>, R)
     ).
 

--- a/test/livery_tests.erl
+++ b/test/livery_tests.erl
@@ -270,7 +270,8 @@ router_handler_not_found_test() ->
 router_handler_method_not_allowed_sets_allow_test() ->
     Router = livery_router:compile([
         {<<"GET">>, <<"/x">>, {?MODULE, rh_index}},
-        {<<"POST">>, <<"/x">>, {?MODULE, rh_index}}
+        {<<"POST">>, <<"/x">>, {?MODULE, rh_index}},
+        {<<"QUERY">>, <<"/x">>, {?MODULE, rh_index}}
     ]),
     H = livery:router_handler(Router),
     Cap = livery_test_adapter:run(
@@ -281,7 +282,8 @@ router_handler_method_not_allowed_sets_allow_test() ->
     ?assertEqual(405, livery_test_adapter:status(Cap)),
     Allow = livery_test_adapter:header(<<"allow">>, Cap),
     ?assertNotEqual(nomatch, binary:match(Allow, <<"GET">>)),
-    ?assertNotEqual(nomatch, binary:match(Allow, <<"POST">>)).
+    ?assertNotEqual(nomatch, binary:match(Allow, <<"POST">>)),
+    ?assertNotEqual(nomatch, binary:match(Allow, <<"QUERY">>)).
 
 router_handler_custom_fallbacks_test() ->
     Router = livery_router:compile([{<<"GET">>, <<"/">>, {?MODULE, rh_index}}]),


### PR DESCRIPTION
Adds first-class support for the HTTP QUERY method (RFC 10008) end to end. The core was already method-agnostic, so routing, dispatch, body delivery and the 405 Allow header needed no changes; the parity suite now locks QUERY-with-body behaviour across HTTP/1.1, HTTP/2 and HTTP/3, and the e2e journey gained a QUERY search step through the complete example.

New livery_client:query/3 helper, QUERY in the client retry idempotent set and in the CORS default allow-methods, and livery_openapi now emits OpenAPI 3.2.0 documents where QUERY routes appear as the query operation. livery_etag stays on GET/HEAD since RFC 9110 scopes the 304 flow to those methods. A new guide, docs/guides/query-method.md, covers when to prefer QUERY over GET or POST.

Also bumps hackney to 4.5.1 and cuts release 0.5.0.