### PR TITLE
Make max_body govern the HTTP/1.1 request-body limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `max_body` now governs the HTTP/1.1 request-body limit end to end.
+  It previously bounded only livery's translator while h1's parser kept
+  its own 8 MiB default, so any `max_body` above 8 MiB was silently
+  capped and uploads past 8 MiB were lost. The H1 adapter now disables
+  h1's parser cap and enforces `max_body` itself, returning a graceful
+  413 on exceed. Requires erlang_h1 >= 0.7.1.
+
+### Changed
+
+- `livery:start_service/1` listener options accept `max_body`
+  (`non_neg_integer() | infinity`, default 16 MiB), now documented and
+  type-checked.
+
 ## [0.5.0] - 2026-07-04
 
 Adds first-class support for the HTTP QUERY method (RFC 10008), end to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-07-05
+
 ### Fixed
 
 - `max_body` now governs the HTTP/1.1 request-body limit end to end.

--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 
 {deps, [
     {mimerl, "1.5.0"},
-    {h1, "~> 0.7.0", {pkg, erlang_h1}},
+    {h1, "~> 0.7.1", {pkg, erlang_h1}},
     {h2, "~> 0.10.2"},
     {quic, "~> 1.6.5"},
     {ws, "~> 0.3.0", {pkg, erlang_ws}},

--- a/src/livery.app.src
+++ b/src/livery.app.src
@@ -1,6 +1,6 @@
 {application, livery, [
     {description, "Livery: a modern Erlang web framework over HTTP/1.1, HTTP/2, and HTTP/3"},
-    {vsn, "0.5.0"},
+    {vsn, "0.5.1"},
     {registered, [livery_sup]},
     {mod, {livery_app, []}},
     {applications, [

--- a/src/livery_h1.erl
+++ b/src/livery_h1.erl
@@ -64,6 +64,10 @@ content-length write via `send_full/5` -> `h1:respond/5`.
     cacerts => [binary()],
     ssl_opts => [ssl:tls_server_option()],
     acceptors => pos_integer(),
+    %% Authoritative request-body ceiling: a body past it yields a graceful
+    %% 413, `infinity' disables it, default 16 MiB. This drives h1's parser
+    %% cap too (h1's own 8 MiB default is disabled in its favour), so a value
+    %% above 8 MiB takes effect instead of being silently capped.
     max_body => non_neg_integer() | infinity,
     %% Slow-client guards, passed through to `h1'. They have finite
     %% defaults there (idle_timeout 300000 ms, request_timeout 60000 ms),
@@ -306,6 +310,14 @@ build_h1_opts(Opts, Stack, Handler) ->
     Transport = maps:get(transport, Opts, tcp),
     Base = #{
         transport => Transport,
+        %% Disable h1's own parser-level body cap and enforce `max_body' in
+        %% the translator instead. h1's parser runs upstream of the translate
+        %% cap and, on exceed, tears the connection down, which would pre-empt
+        %% the graceful 413 the translator delivers via h1's early-response
+        %% drain (see abort_body/2). h1's 8 MiB default previously did exactly
+        %% that, silently capping any `max_body' above 8 MiB. Requires
+        %% erlang_h1 >= 0.7.1, which forwards max_body_size from server opts.
+        max_body_size => infinity,
         handler => make_handler_fun(
             Stack, Handler, MaxBody, maps:get(config, Opts, undefined), Transport
         )

--- a/src/livery_service.erl
+++ b/src/livery_service.erl
@@ -80,6 +80,11 @@ in-flight requests finish, use `livery:drain/1,2`.
     key => binary() | string() | term(),
     cacerts => [binary()],
     acceptors => pos_integer(),
+    %% Request-body ceiling. A body past this yields a graceful 413;
+    %% `infinity' disables it, default 16 MiB. Honored by all three adapters;
+    %% the H1 adapter enforces it in place of h1's own parser cap, so a value
+    %% above h1's 8 MiB default takes effect instead of being silently capped.
+    max_body => non_neg_integer() | infinity,
     %% H3 per-SNI certificate selection, forwarded to `quic' (>= 1.6.5).
     sni_callback => fun(
         (binary() | undefined) ->

--- a/test/livery_service_SUITE.erl
+++ b/test/livery_service_SUITE.erl
@@ -26,6 +26,8 @@
     http3_listener_forwards_sni_callback/1,
     service_without_handler_or_router_fails/1,
     stop_accepting_refuses_new_connections/1,
+    max_body_raises_h1_parser_cap/1,
+    default_max_body_authoritative/1,
     drain_lets_inflight_finish/1,
     drain_times_out_on_stuck_request/1
 ]).
@@ -45,6 +47,8 @@ all() ->
         http3_listener_forwards_sni_callback,
         service_without_handler_or_router_fails,
         stop_accepting_refuses_new_connections,
+        max_body_raises_h1_parser_cap,
+        default_max_body_authoritative,
         drain_lets_inflight_finish,
         drain_times_out_on_stuck_request
     ].
@@ -256,6 +260,44 @@ stop_accepting_refuses_new_connections(_Config) ->
     ?assertMatch({error, _}, http_try(Port, <<"/">>)),
     livery:stop_service(Pid).
 
+%% A 20 MiB upload, well past h1's 8 MiB parser default, must succeed when the
+%% listener raises `max_body'. The handler streams the body one chunk at a
+%% time via livery_body:read, mirroring barrel_server's attachment path. Before
+%% the fix, h1's parser cap won and the upload was lost past 8 MiB.
+max_body_raises_h1_parser_cap(_Config) ->
+    Size = 20 * 1024 * 1024,
+    {ok, Pid} = livery:start_service(#{
+        http => #{port => 0, max_body => 32 * 1024 * 1024},
+        handler => count_body_handler()
+    }),
+    try
+        Port = maps:get(h1, livery:which_listeners(Pid)),
+        Body = binary:copy(<<"x">>, Size),
+        ?assertEqual({200, integer_to_binary(Size)}, http_put(Port, <<"/">>, Body))
+    after
+        livery:stop_service(Pid)
+    end.
+
+%% The default `max_body' (16 MiB) is authoritative, not h1's old 8 MiB parser
+%% cap: a 12 MiB body (past 8 MiB) succeeds, while a 20 MiB body past 16 MiB
+%% gets a graceful 413.
+default_max_body_authoritative(_Config) ->
+    {ok, Pid} = livery:start_service(#{
+        http => #{port => 0}, handler => count_body_handler()
+    }),
+    try
+        Port = maps:get(h1, livery:which_listeners(Pid)),
+        Under = 12 * 1024 * 1024,
+        ?assertEqual(
+            {200, integer_to_binary(Under)},
+            http_put(Port, <<"/">>, binary:copy(<<"x">>, Under))
+        ),
+        {StatusOver, _} = http_put(Port, <<"/">>, binary:copy(<<"x">>, 20 * 1024 * 1024)),
+        ?assertEqual(413, StatusOver)
+    after
+        livery:stop_service(Pid)
+    end.
+
 drain_lets_inflight_finish(_Config) ->
     Self = self(),
     Ref = make_ref(),
@@ -392,6 +434,24 @@ http_try(Port, Path) ->
         ]
     ).
 
+%% PUT a body over a fresh connection (pool disabled): the oversize case
+%% closes the connection after the 413, so a pooled socket would be poisoned.
+http_put(Port, Path, Body) ->
+    Url = iolist_to_binary([
+        <<"http://127.0.0.1:">>,
+        integer_to_binary(Port),
+        Path
+    ]),
+    Headers = [{<<"Content-Length">>, integer_to_binary(byte_size(Body))}],
+    {ok, Status, _Hs, RBody} = hackney:request(
+        <<"PUT">>,
+        Url,
+        Headers,
+        Body,
+        [with_body, {pool, false}, {recv_timeout, 10000}]
+    ),
+    {Status, RBody}.
+
 body_via_h1(Port) ->
     Url = url(<<"http">>, Port),
     {ok, 200, _, Body} = hackney:request(
@@ -525,6 +585,24 @@ url(Scheme, Port) ->
         integer_to_binary(Port),
         <<"/">>
     ]).
+
+%% Stream the request body one chunk at a time and reply with its byte count,
+%% or 413 if the body cap aborts the read.
+count_body_handler() ->
+    fun(R) ->
+        {stream, Reader} = livery_req:body(R),
+        case drain_count(Reader, 0) of
+            {ok, Count} -> livery_resp:text(200, integer_to_binary(Count));
+            {error, _} -> livery_resp:text(413, <<"too large">>)
+        end
+    end.
+
+drain_count(Reader, Acc) ->
+    case livery_body:read(Reader, 5000) of
+        {ok, Chunk, Reader1} -> drain_count(Reader1, Acc + iolist_size(Chunk));
+        {done, _} -> {ok, Acc};
+        {error, Reason, _} -> {error, Reason}
+    end.
 
 collect_h2(Conn, StreamId, _Status, _Headers, BodyAcc) ->
     receive


### PR DESCRIPTION
max_body previously bounded only livery's translator while h1's parser kept its own 8 MiB default, so any max_body above 8 MiB was silently capped and uploads past 8 MiB were lost. The H1 adapter now forwards max_body_size => infinity to h1 so its parser never pre-empts livery's translate cap, which stays the authoritative limit and returns a graceful 413 on exceed. max_body is also added to livery_service listener_opts so passing it through start_service is type-valid. Requires erlang_h1 >= 0.7.1.