### PR TITLE
Bump wire deps to latest hex releases

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,12 +7,12 @@
 {deps, [
     {mimerl, "1.5.0"},
     {h1, "~> 0.7.1", {pkg, erlang_h1}},
-    {h2, "~> 0.10.2"},
-    {quic, "~> 1.6.5"},
+    {h2, "~> 0.10.4"},
+    {quic, "~> 1.7.0"},
     {ws, "~> 0.3.0", {pkg, erlang_ws}},
     {instrument, "~> 1.1.4"},
-    {webtransport, "~> 0.4.1"},
-    {hackney, "~> 4.5.1"},
+    {webtransport, "~> 0.4.3"},
+    {hackney, "~> 4.5.2"},
     {barrel_mcp, "~> 2.2.4"}
 ]}.
 


### PR DESCRIPTION
Bump the wire libraries to their latest hex releases: hackney 4.5.1 -> 4.5.2, h2 0.10.2 -> 0.10.4, webtransport 0.4.1 -> 0.4.3, quic 1.6.5 -> 1.7.0.

All checks pass (fmt, compile, xref, lint, eunit, dialyzer, ct).