### PR TITLE
Reparent a streamed client response off the timeout worker

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
     {ws, "~> 0.3.0", {pkg, erlang_ws}},
     {instrument, "~> 1.1.4"},
     {webtransport, "~> 0.4.3"},
-    {hackney, "~> 4.5.2"},
+    {hackney, "~> 4.6.0"},
     {barrel_mcp, "~> 2.2.4"}
 ]}.
 
@@ -335,7 +335,9 @@
             %% design (Adapter:send_*, accept_ws/accept_wt).
             %% livery_client dispatches to the configured client adapter;
             %% livery_client_discover dispatches to the discovery provider;
-            %% livery_client_cookie dispatches to the cookie store module.
+            %% livery_client_cookie dispatches to the cookie store module;
+            %% livery_client_timeout reparents a streamed connection via the
+            %% adapter's optional adopt/2.
             {elvis_style, invalid_dynamic_call, #{
                 ignore => [
                     livery,
@@ -345,7 +347,8 @@
                     livery_compress,
                     livery_client,
                     livery_client_discover,
-                    livery_client_cookie
+                    livery_client_cookie,
+                    livery_client_timeout
                 ]
             }},
             %% Per-stream translators (and the client push-stream relay)

--- a/src/client/livery_client_adapter.erl
+++ b/src/client/livery_client_adapter.erl
@@ -31,6 +31,12 @@ write your own to front a different client.
   manual`, ask for one more body chunk.
 - `stop_stream(Ref) -> ok` - *optional*; cancel a push stream and release
   its connection.
+- `adopt(Reader, Owner) -> ok | {error, term()}` - *optional*; hand the
+  live connection behind a `{stream, Reader}` response body to `Owner`. A
+  layer that runs the request in a short-lived worker (e.g.
+  `livery_client_timeout`) calls this to reparent the connection to the
+  process that will read it, before the worker exits. Only adapters whose
+  streamed reader is tied to its owning process need it.
 """.
 
 -type stream_ref() :: term().
@@ -50,4 +56,6 @@ write your own to front a different client.
 
 -callback stop_stream(stream_ref()) -> ok.
 
--optional_callbacks([read/2, stream/3, stream_next/1, stop_stream/1]).
+-callback adopt(term(), pid()) -> ok | {error, term()}.
+
+-optional_callbacks([read/2, stream/3, stream_next/1, stop_stream/1, adopt/2]).

--- a/src/client/livery_client_hackney.erl
+++ b/src/client/livery_client_hackney.erl
@@ -28,7 +28,7 @@ never leaks a connection.
 """.
 -behaviour(livery_client_adapter).
 
--export([request/2, read/2]).
+-export([request/2, read/2, adopt/2]).
 -export([stream/3, stream_next/1, stop_stream/1]).
 
 -spec request(livery_client:request(), map()) ->
@@ -57,6 +57,17 @@ read(Conn, _Timeout) ->
         done -> {done, Conn};
         {error, Reason} -> {error, Reason}
     end.
+
+%% Optional callback: hand a streamed connection to a new owner. hackney
+%% monitors the owner and tears the connection down when it dies, so a
+%% caller that ran the request in a short-lived worker reparents to the
+%% process that will read the body. hackney >= 4.6 accepts set_owner while
+%% the response body is streaming.
+-spec adopt(term(), pid()) -> ok | {error, term()}.
+adopt(ConnPid, NewOwner) when is_pid(ConnPid) ->
+    hackney_conn:set_owner(ConnPid, NewOwner);
+adopt(_State, _NewOwner) ->
+    ok.
 
 %% Optional callback: drive the request in a relay process that pushes
 %% `{livery_response, Ref, _}` messages to `stream_to`.

--- a/src/client/livery_client_timeout.erl
+++ b/src/client/livery_client_timeout.erl
@@ -6,6 +6,11 @@ Runs the downstream call in a monitored child process and returns
 `{error, timeout}` if it does not finish within `Ms`, killing the child
 (which tears down the in-flight connection). Add it with
 `livery_client:timeout/1`.
+
+A `{stream, Reader}` response body holds a live connection owned by the
+child. Before the child exits, this layer hands that connection to the
+caller via the adapter's `adopt/2`, so the caller's later `read/1` does not
+race the child's death.
 """.
 
 -export([call/3]).
@@ -22,7 +27,7 @@ call(Req, Next, Ms) ->
             catch
                 Class:Reason:Stack -> {'$crash', Class, Reason, Stack}
             end,
-        Self ! {Ref, Result}
+        Self ! {Ref, reparent(Result, Self)}
     end),
     receive
         {Ref, {'$crash', Class, Reason, Stack}} ->
@@ -37,4 +42,25 @@ call(Req, Next, Ms) ->
         exit(Pid, kill),
         erlang:demonitor(MRef, [flush]),
         {error, timeout}
+    end.
+
+%% Hand a streamed response's connection to the caller before this child
+%% exits, so it is not torn down with the child. Non-streamed results and
+%% adapters without adopt/2 pass through unchanged.
+reparent({ok, #{body := {stream, {Adapter, State}}}} = Result, Owner) ->
+    _ = adopt(Adapter, State, Owner),
+    Result;
+reparent(Result, _Owner) ->
+    Result.
+
+adopt(Adapter, State, Owner) ->
+    case erlang:function_exported(Adapter, adopt, 2) of
+        true ->
+            try
+                Adapter:adopt(State, Owner)
+            catch
+                _:_ -> ok
+            end;
+        false ->
+            ok
     end.

--- a/test/livery_client_SUITE.erl
+++ b/test/livery_client_SUITE.erl
@@ -17,6 +17,7 @@
     circuit_layer/1,
     circuit_store_recovers/1,
     stream_response/1,
+    stream_response_through_timeout/1,
     stream_request/1,
     push_stream/1,
     push_stream_stop/1,
@@ -39,6 +40,7 @@ all() ->
         circuit_layer,
         circuit_store_recovers,
         stream_response,
+        stream_response_through_timeout,
         stream_request,
         push_stream,
         push_stream_stop,
@@ -242,6 +244,20 @@ circuit_store_recovers(_Config) ->
 
 stream_response(Config) ->
     C = livery_client:new(#{base_url => ?config(base, Config)}),
+    {ok, Resp} = livery_client:request(C, get, <<"/big">>, #{stream => true}),
+    {stream, Reader} = livery_client:body(Resp),
+    {ok, Body} = livery_client:read_body(Reader),
+    ?assertEqual(100000, byte_size(Body)).
+
+%% The timeout layer runs the request in a worker that exits once the
+%% response returns. A streamed body owns a live connection, so the worker
+%% must hand it to the caller before exiting; otherwise read_body races the
+%% worker's death and crashes with {noproc, _}.
+stream_response_through_timeout(Config) ->
+    C = livery_client:new(#{
+        base_url => ?config(base, Config),
+        stack => [livery_client:timeout(5000)]
+    }),
     {ok, Resp} = livery_client:request(C, get, <<"/big">>, #{stream => true}),
     {stream, Reader} = livery_client:body(Resp),
     {ok, Body} = livery_client:read_body(Reader),


### PR DESCRIPTION
livery_client_timeout runs the downstream request in a spawned worker that exits the moment the response returns. That is fine for a buffered response, but a `stream => true` response body holds a live hackney connection owned by that worker. hackney monitors the connection's owner and tears it down when the owner dies, so the worker's exit killed the connection out from under the caller, whose next read_body/1 crashed with `{noproc, _}`. Reproduced with raw hackney (works) versus through the timeout-wrapped layer (crashes).

hackney cannot reassign a connection's owner mid-stream in 4.5.x (set_owner is only honored between requests), so the fix pairs with hackney 4.6, which accepts set_owner while the response body is streaming. Before the worker exits, the timeout layer now hands the streamed connection to the caller via a new optional adapter callback adopt/2. The hackney adapter implements it with hackney_conn:set_owner/2; adapters without adopt/2 fall through unchanged. The hackney floor moves to ~> 4.6.0.

New client CT case streams a response through a timeout layer and drains it, which crashed before and passes now.