### PR TITLE
Bump hackney to 4.7.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
     {ws, "~> 0.3.0", {pkg, erlang_ws}},
     {instrument, "~> 1.1.4"},
     {webtransport, "~> 0.4.3"},
-    {hackney, "~> 4.6.0"},
+    {hackney, "~> 4.7.0"},
     {barrel_mcp, "~> 2.2.4"}
 ]}.
 


### PR DESCRIPTION
Bumps hackney from ~> 4.6.0 to ~> 4.7.0. This picks up the HTTP/2 fixes in hackney 4.7.0: request-body sends now block on flow control instead of failing with send_buffer_full, async responses are delivered again, and {async, once} honors stream_next/1. All suites pass locally against 4.7.0.