### PR TITLE
Surface the peer, add interim responses, and close connections on stop

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,7 @@ solution.
 - [Return a streaming response](guides/stream-chunked.md)
 - [Return Server-Sent Events](guides/server-sent-events.md)
 - [Return trailers](guides/return-trailers.md)
+- [Send Early Hints](guides/early-hints.md)
 - [Serve a file](guides/serve-a-file.md)
 - [Send an empty or redirect response](guides/empty-and-redirects.md)
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -53,6 +53,30 @@ Modern web/AI framework gaps, in priority order. All 10 items are done.
     `instrument_prometheus`). See `docs/guides/health-checks.md` and
     `docs/guides/export-metrics.md`.
 
+## Server-side gaps (closed in 0.7.0)
+
+1. Peer address on plain HTTP requests. DONE: `livery_req:peer/1` is
+   set on H1 (via `h1:peername/1`, h1 0.8.0), H2, and H3;
+   `peer_info/1` returns the real peer on every adapter. Previously
+   only the WebSocket handoff carried it.
+2. Interim (1xx) responses. DONE: `livery_req:inform/3` (primarily
+   `103 Early Hints`), backed by the optional adapter callback
+   `send_informational/3` and advertised via the `informational`
+   capability. H1 (h1 0.8.0) and H2 send it; H3 returns
+   `{error, unsupported}` until the QUIC stack surfaces interim
+   HEADERS. See `docs/guides/early-hints.md`. Follow-up: implement in
+   `erlang_quic`'s h3 and flip the capability.
+3. Connection teardown on stop. DONE: h1 0.8.0 tracks accepted
+   connections; `h1:stop_server/1` is synchronous and closes them, so
+   `livery:stop_service/1` really cuts off kept-alive clients.
+   `h1:stop_accepting/1` keeps them serving during `livery:drain/2`,
+   which closes the idle ones at the end of the window.
+
+WebSocket extras shipped alongside (ws 0.4.0): `max_frame_size` /
+`max_message_size` and `compress` (permessage-deflate) on
+`livery_ws:upgrade/3`, and the peer's close code delivered to
+`ws_handler:terminate/2` as `{remote, Code, Reason}`.
+
 ## Benchmarking: H3 needs an external client
 
 The in-VM bench harness understates H3. Findings (loopback, 14

--- a/docs/guides/early-hints.md
+++ b/docs/guides/early-hints.md
@@ -1,0 +1,51 @@
+# How to send Early Hints
+
+`livery_req:inform/3` sends an interim (1xx) response before your
+real one. The main use is `103 Early Hints`: you tell the browser
+which assets the page will need while your handler is still building
+it, so stylesheets and scripts start downloading during your own
+processing time. Use it when a response takes real work (a database
+query, an upstream call) and the asset list is known up front.
+
+## Send hints, then respond
+
+Call `inform/3` from your handler, any time before you return the
+response. It can be called more than once.
+
+```erlang
+page(Req) ->
+    _ = livery_req:inform(103, [
+        {<<"link">>, <<"</assets/app.css>; rel=preload; as=style">>},
+        {<<"link">>, <<"</assets/app.js>; rel=preload; as=script">>}
+    ], Req),
+    Body = render_page(),   %% the slow part
+    livery_resp:html(200, Body).
+```
+
+The interim response goes out immediately; the final `200` follows
+as usual and is completely independent, so repeat any headers that
+matter there (the `103` block is advisory only).
+
+## Ignore the return value
+
+Hints are best-effort. `inform/3` returns `ok` when the interim
+response was written, or `{error, Reason}` when it could not be:
+
+- HTTP/1.1 and HTTP/2 send it on the wire. HTTP/1.1 skips HTTP/1.0
+  clients (RFC 9110 forbids 1xx there) and returns
+  `{error, http_1_0}`.
+- HTTP/3 does not support it yet and returns
+  `{error, unsupported}`.
+
+Matching `_ = livery_req:inform(...)` and moving on is the normal
+pattern; a page that loads without hints is still a page.
+
+## Notes
+
+- `101` is reserved for the upgrade machinery
+  (`livery_ws:upgrade/3`) and rejected.
+- Adapters report support in `capabilities/1` as
+  `informational => boolean()` if you need to branch.
+- Middleware only sees the final response; interim responses bypass
+  the response pipeline by design (nothing should compress or cache
+  a `103`).

--- a/docs/guides/graceful-shutdown.md
+++ b/docs/guides/graceful-shutdown.md
@@ -19,7 +19,9 @@ ok = livery:drain(Pid, #{timeout => 30000}).
    connections are taken. Connections already open keep serving.
 2. **Waits** up to `timeout` (default 30s) for the requests already
    in flight to finish.
-3. **Stops** the service.
+3. **Stops** the service, closing the remaining connections. Idle
+   keep-alive clients are cut off here, at the end of the window,
+   instead of lingering against a dead service.
 
 It returns `ok` once everything drained, or `{error, timeout}` if
 the window elapsed with requests still running. Either way the

--- a/rebar.config
+++ b/rebar.config
@@ -6,10 +6,10 @@
 
 {deps, [
     {mimerl, "1.5.0"},
-    {h1, "~> 0.7.1", {pkg, erlang_h1}},
+    {h1, "~> 0.8.0", {pkg, erlang_h1}},
     {h2, "~> 0.11.0"},
     {quic, "~> 1.7.0"},
-    {ws, "~> 0.3.0", {pkg, erlang_ws}},
+    {ws, "~> 0.4.0", {pkg, erlang_ws}},
     {instrument, "~> 1.1.4"},
     {webtransport, "~> 0.4.3"},
     {hackney, "~> 4.7.0"},
@@ -333,6 +333,8 @@
             }},
             %% The adapter behaviour is dispatched dynamically by
             %% design (Adapter:send_*, accept_ws/accept_wt).
+            %% livery_req:inform/3 dispatches to the adapter's optional
+            %% send_informational/3.
             %% livery_client dispatches to the configured client adapter;
             %% livery_client_discover dispatches to the discovery provider;
             %% livery_client_cookie dispatches to the cookie store module;
@@ -341,6 +343,7 @@
             {elvis_style, invalid_dynamic_call, #{
                 ignore => [
                     livery,
+                    livery_req,
                     livery_mcp,
                     livery_ws,
                     livery_wt,

--- a/src/livery_adapter.erl
+++ b/src/livery_adapter.erl
@@ -28,6 +28,12 @@ here.
   than batch.
 - `send_trailers(Stream, Trailers) -> SendResult` — emit trailers
   (and implicitly close the send half).
+- `send_informational(Stream, Status, Headers) -> SendResult` —
+  optional: emit an interim (1xx) response, e.g. 103 Early Hints,
+  ahead of the final response. May be called several times per
+  stream. Adapters that cannot (or do not) implement it are
+  reported as `informational => false` in `capabilities/1`, and
+  `livery_req:inform/3` returns `{error, unsupported}`.
 - `reset(Stream, Reason) -> ok` — reset a stream with a
   protocol-specific reason.
 - `peer_info(Stream) -> peer_info()` — return peer/TLS info for a
@@ -66,7 +72,8 @@ here.
     trailers => boolean(),
     extended_connect => boolean(),
     datagrams => boolean(),
-    capsules => boolean()
+    capsules => boolean(),
+    informational => boolean()
 }.
 
 -type peer_info() :: #{
@@ -116,4 +123,14 @@ here.
 ) ->
     send_result().
 
--optional_callbacks([send_full/5]).
+%% Optional: emit an interim (1xx) response before the final one.
+%% `livery_req:inform/3' calls it when exported and returns
+%% `{error, unsupported}' otherwise.
+-callback send_informational(
+    stream(),
+    100..199,
+    [{binary(), binary()}]
+) ->
+    send_result().
+
+-optional_callbacks([send_full/5, send_informational/3]).

--- a/src/livery_drain.erl
+++ b/src/livery_drain.erl
@@ -15,8 +15,11 @@ protocol, runs in a `livery_req_proc` worker it tracks. A
 single-service node drains exactly its own requests; on a
 multi-service node `drain/2` waits for all of them.
 
-Stopping acceptance closes the listen socket (no new connections);
-it does not send GOAWAY on existing keep-alive connections.
+Stopping acceptance closes the listen sockets (no new connections)
+while established HTTP/1.1 connections keep being served through
+the drain window. The final stop then closes every remaining
+connection, so idle keep-alive clients are cut off once the drain
+ends instead of lingering against a dead service.
 
 ```erlang
 {ok, Pid} = livery:start_service(#{http => #{port => 8080}, router => R}),

--- a/src/livery_h1.erl
+++ b/src/livery_h1.erl
@@ -32,7 +32,7 @@ content-length write via `send_full/5` -> `h1:respond/5`.
 -define(DEFAULT_MAX_BODY, 16 * 1024 * 1024).
 
 %% Public API
--export([start/1, accept_ws/4]).
+-export([start/1, stop_accepting/1, accept_ws/4]).
 
 %% livery_adapter callbacks
 -export([
@@ -42,6 +42,7 @@ content-length write via `send_full/5` -> `h1:respond/5`.
     send_full/5,
     send_data/3,
     send_trailers/2,
+    send_informational/3,
     reset/2,
     peer_info/1,
     capabilities/1
@@ -121,8 +122,20 @@ start(_Name, Opts, _StartOpts) ->
     h1:start_server(Port, H1Opts).
 
 -spec stop(listener()) -> ok.
+%% Synchronous (h1 >= 0.8.0): closes the listen socket, the acceptor
+%% pool, and every accepted connection before returning.
 stop(Listener) ->
     _ = h1:stop_server(Listener),
+    ok.
+
+-doc """
+Stop accepting new connections while continuing to serve the
+established ones. Used by `livery_drain` for graceful shutdown;
+`stop/1` afterwards closes the remaining connections.
+""".
+-spec stop_accepting(listener()) -> ok.
+stop_accepting(Listener) ->
+    _ = h1:stop_accepting(Listener),
     ok.
 
 -spec send_headers(
@@ -194,16 +207,30 @@ closed_guard(Fun) ->
         exit:{{shutdown, _}, _} -> {error, closed}
     end.
 
+-spec send_informational(stream(), 100..199, [{binary(), binary()}]) ->
+    livery_adapter:send_result().
+send_informational({Conn, StreamId}, Status, Headers) ->
+    closed_guard(fun() -> h1:send_informational(Conn, StreamId, Status, Headers) end).
+
 -spec reset(stream(), term()) -> ok.
 reset({Conn, StreamId}, Reason) ->
     _ = h1:cancel_stream(Conn, StreamId, Reason),
     ok.
 
 -spec peer_info(stream()) -> livery_adapter:peer_info().
-peer_info({_Conn, _StreamId}) ->
-    %% The h1 library does not surface the peer address, so it stays
-    %% undefined here.
-    #{peer => undefined, tls => undefined, alpn => <<"http/1.1">>}.
+peer_info({Conn, _StreamId}) ->
+    #{peer => conn_peer(Conn), tls => undefined, alpn => <<"http/1.1">>}.
+
+%% The h1 connection records the peer at accept time (h1 >= 0.8.0).
+-spec conn_peer(h1:connection()) ->
+    {inet:ip_address(), inet:port_number()} | undefined.
+conn_peer(Conn) ->
+    try h1:peername(Conn) of
+        {ok, Peer} -> Peer;
+        {error, _} -> undefined
+    catch
+        exit:_ -> undefined
+    end.
 
 -spec capabilities(listener()) -> livery_adapter:capabilities().
 capabilities(_Listener) ->
@@ -211,7 +238,8 @@ capabilities(_Listener) ->
         trailers => true,
         extended_connect => false,
         datagrams => false,
-        capsules => false
+        capsules => false,
+        informational => true
     }.
 
 %% Translate the per-response `early_response_drain' send-opt into the
@@ -256,11 +284,12 @@ handshake or socket transfer failure.
 ) ->
     {ok, pid()} | {error, term()}.
 accept_ws({Conn, StreamId}, Req, HandlerMod, Opts) ->
-    {ValidateOpts, AcceptOpts} = livery_ws:handshake_opts(Opts),
+    {ValidateOpts, AcceptOpts0} = livery_ws:handshake_opts(Opts),
     Headers = livery_req:headers(Req),
     case ws_h1_upgrade:validate_request(Headers, ValidateOpts) of
         {ok, Info} ->
-            RespHeaders = ws_h1_upgrade:response_headers(Info),
+            {ExtHeaders, AcceptOpts} = livery_ws:deflate_opts(Info, Opts, AcceptOpts0),
+            RespHeaders = ws_h1_upgrade:response_headers(Info) ++ ExtHeaders,
             case h1:accept_upgrade(Conn, StreamId, RespHeaders) of
                 {ok, Socket, _BufferedBytes} ->
                     WsReq = build_ws_req(Req, Socket),
@@ -489,6 +518,7 @@ build_req(Conn, StreamId, Method, Path, Headers, Reader, Transport) ->
         adapter => ?MODULE,
         stream => {Conn, StreamId},
         engine_pid => Conn,
+        peer => conn_peer(Conn),
         tls => tls_info(Transport)
     }).
 

--- a/src/livery_h2.erl
+++ b/src/livery_h2.erl
@@ -44,6 +44,7 @@ in `capabilities/1`.
     send_data/3,
     send_full/5,
     send_trailers/2,
+    send_informational/3,
     reset/2,
     peer_info/1,
     capabilities/1
@@ -154,6 +155,14 @@ send_full({Conn, StreamId}, Status, Headers, IoData, _Opts) ->
 send_trailers({Conn, StreamId}, Trailers) ->
     closed_guard(fun() -> h2:send_trailers(Conn, StreamId, Trailers) end).
 
+%% Interim responses ride the normal HEADERS path: a 1xx block carries
+%% no END_STREAM (1xx is not body-forbidden) and the final response
+%% follows on the same stream. h2 itself rejects 101 (RFC 9113 §8.6).
+-spec send_informational(stream(), 100..199, [{binary(), binary()}]) ->
+    livery_adapter:send_result().
+send_informational({Conn, StreamId}, Status, Headers) ->
+    closed_guard(fun() -> h2:send_response(Conn, StreamId, Status, Headers) end).
+
 %% A send to a connection whose client has gone away exits the underlying
 %% `gen_statem:call` (e.g. `{{shutdown, {send_failed, closed}}, _}` or
 %% `{noproc, _}`). Map that to `{error, closed}`, the way `gen_tcp:send`
@@ -177,9 +186,9 @@ reset({Conn, StreamId}, _Reason) ->
     ok.
 
 -spec peer_info(stream()) -> livery_adapter:peer_info().
-peer_info({_Conn, _StreamId}) ->
+peer_info({Conn, _StreamId}) ->
     %% Future: surface ALPN, peer cert, etc. via h2's connection state.
-    #{peer => undefined, tls => undefined, alpn => <<"h2">>}.
+    #{peer => h2_peer(Conn), tls => undefined, alpn => <<"h2">>}.
 
 -spec capabilities(listener()) -> livery_adapter:capabilities().
 capabilities(_Listener) ->
@@ -187,7 +196,8 @@ capabilities(_Listener) ->
         trailers => true,
         extended_connect => true,
         datagrams => false,
-        capsules => false
+        capsules => false,
+        informational => true
     }.
 
 %%====================================================================
@@ -204,11 +214,12 @@ driven by the `livery_ws_h2` transport.
 -spec accept_ws(stream(), livery_req:req(), module(), term()) ->
     {ok, pid()} | {error, term()}.
 accept_ws({Conn, StreamId}, Req, HandlerMod, Opts) ->
-    {ValidateOpts, AcceptOpts} = livery_ws:handshake_opts(Opts),
+    {ValidateOpts, AcceptOpts0} = livery_ws:handshake_opts(Opts),
     Pseudo = connect_pseudo_headers(Req, <<"websocket">>),
     case ws_h2_upgrade:validate_request(Pseudo, ValidateOpts) of
         {ok, Info} ->
-            RespHeaders = drop_status(ws_h2_upgrade:response_headers(Info)),
+            {ExtHeaders, AcceptOpts} = livery_ws:deflate_opts(Info, Opts, AcceptOpts0),
+            RespHeaders = drop_status(ws_h2_upgrade:response_headers(Info)) ++ ExtHeaders,
             case h2:send_response(Conn, StreamId, 200, RespHeaders) of
                 ok ->
                     WsReq = #{
@@ -237,12 +248,16 @@ accept_ws({Conn, StreamId}, Req, HandlerMod, Opts) ->
 drop_status(Headers) ->
     [{N, V} || {N, V} <- Headers, N =/= <<":status">>].
 
-%% The h2 request does not carry the peer, but the h2 connection knows it.
+%% The h2 request does not carry the peer, but the h2 connection knows
+%% it. A connection that is already gone (client disconnected) reads as
+%% undefined instead of crashing the caller.
 -spec h2_peer(term()) -> {inet:ip_address(), inet:port_number()} | undefined.
 h2_peer(Conn) ->
-    case h2:peername(Conn) of
+    try h2:peername(Conn) of
         {ok, Peer} -> Peer;
         {error, _} -> undefined
+    catch
+        exit:_ -> undefined
     end.
 
 %%====================================================================
@@ -440,7 +455,8 @@ build_req(Conn, StreamId, Method, Path, Headers, Reader) ->
         body => {stream, Reader},
         adapter => ?MODULE,
         stream => {Conn, StreamId},
-        engine_pid => Conn
+        engine_pid => Conn,
+        peer => h2_peer(Conn)
     }).
 
 %% h2 (>= 0.10.2) keeps `:authority' and `:scheme' in the handler header

--- a/src/livery_h3.erl
+++ b/src/livery_h3.erl
@@ -37,6 +37,7 @@ adapter callbacks, which call into `quic_h3:send_response/4`,
     send_headers/4,
     send_data/3,
     send_trailers/2,
+    send_informational/3,
     reset/2,
     peer_info/1,
     capabilities/1
@@ -171,9 +172,15 @@ reset({Conn, StreamId}, _Reason) ->
     _ = quic_h3:cancel(Conn, StreamId),
     ok.
 
+%% Interim (1xx) responses are not surfaced by the h3 engine yet.
+-spec send_informational(stream(), 100..199, [{binary(), binary()}]) ->
+    {error, unsupported}.
+send_informational(_Stream, _Status, _Headers) ->
+    {error, unsupported}.
+
 -spec peer_info(stream()) -> livery_adapter:peer_info().
-peer_info({_Conn, _StreamId}) ->
-    #{peer => undefined, tls => undefined, alpn => <<"h3">>}.
+peer_info({Conn, _StreamId}) ->
+    #{peer => h3_peer(Conn), tls => undefined, alpn => <<"h3">>}.
 
 -spec capabilities(listener()) -> livery_adapter:capabilities().
 capabilities(_Listener) ->
@@ -181,7 +188,8 @@ capabilities(_Listener) ->
         trailers => true,
         extended_connect => true,
         datagrams => true,
-        capsules => true
+        capsules => true,
+        informational => false
     }.
 
 %%====================================================================
@@ -197,11 +205,12 @@ stream to the `ws` library driven by the `livery_ws_h3` transport.
 -spec accept_ws(stream(), livery_req:req(), module(), term()) ->
     {ok, pid()} | {error, term()}.
 accept_ws({Conn, StreamId}, Req, HandlerMod, Opts) ->
-    {ValidateOpts, AcceptOpts} = livery_ws:handshake_opts(Opts),
+    {ValidateOpts, AcceptOpts0} = livery_ws:handshake_opts(Opts),
     Pseudo = connect_pseudo_headers(Req, <<"websocket">>),
     case ws_h3_upgrade:validate_request(Pseudo, ValidateOpts) of
         {ok, Info} ->
-            RespHeaders = drop_status(ws_h3_upgrade:response_headers(Info)),
+            {ExtHeaders, AcceptOpts} = livery_ws:deflate_opts(Info, Opts, AcceptOpts0),
+            RespHeaders = drop_status(ws_h3_upgrade:response_headers(Info)) ++ ExtHeaders,
             case quic_h3:send_response(Conn, StreamId, 200, RespHeaders) of
                 ok ->
                     WsReq = #{
@@ -229,12 +238,16 @@ drop_status(Headers) ->
     [{N, V} || {N, V} <- Headers, N =/= <<":status">>].
 
 %% The h3 request does not carry the peer, but the underlying QUIC
-%% connection knows it. Reach it via quic_h3:get_quic_conn/1.
+%% connection knows it. Reach it via quic_h3:get_quic_conn/1. A
+%% connection that is already gone reads as undefined instead of
+%% crashing the caller.
 -spec h3_peer(term()) -> {inet:ip_address(), inet:port_number()} | undefined.
 h3_peer(Conn) ->
-    case quic_connection:peername(quic_h3:get_quic_conn(Conn)) of
+    try quic_connection:peername(quic_h3:get_quic_conn(Conn)) of
         {ok, Peer} -> Peer;
         {error, _} -> undefined
+    catch
+        exit:_ -> undefined
     end.
 
 %%====================================================================
@@ -452,7 +465,8 @@ build_req(Conn, StreamId, Method, Path, Headers, Reader) ->
         body => {stream, Reader},
         adapter => ?MODULE,
         stream => {Conn, StreamId},
-        engine_pid => Conn
+        engine_pid => Conn,
+        peer => h3_peer(Conn)
     }).
 
 -spec split_query(binary()) -> {binary(), binary()}.

--- a/src/livery_req.erl
+++ b/src/livery_req.erl
@@ -55,6 +55,8 @@ new value for the next stage using the setters.
 
     set_req_id/2,
 
+    inform/3,
+
     on_disconnect/2,
     disconnect_tag/0
 ]).
@@ -298,6 +300,44 @@ config(_Key, #livery_req{}, Default) ->
 -spec set_req_id(binary(), req()) -> req().
 set_req_id(Id, Req) when is_binary(Id) ->
     Req#livery_req{req_id = Id}.
+
+%%====================================================================
+%% Interim responses
+%%====================================================================
+
+-doc """
+Send an interim (1xx) response, e.g. `103` Early Hints, ahead of the
+final response.
+
+May be called several times per request, any time before the handler
+returns its `#livery_resp{}`. The final response is unaffected. `101`
+is reserved for the upgrade machinery and rejected by the adapters.
+
+Support depends on the wire protocol: HTTP/1.1 and HTTP/2 send it
+(HTTP/1.1 skips it for HTTP/1.0 clients, per RFC 9110 §15.2); HTTP/3
+returns `{error, unsupported}` for now. Check
+`Adapter:capabilities/1` for `informational => true`, or just ignore
+the return value — hints are best-effort by nature.
+
+```erlang
+handler(Req) ->
+    _ = livery_req:inform(103,
+        [{<<"link">>, <<"</app.css>; rel=preload; as=style">>}], Req),
+    livery_resp:html(200, render()).
+```
+""".
+-spec inform(100..199, [{header_name(), header_value()}], req()) ->
+    ok | {error, term()}.
+inform(Status, Headers, #livery_req{adapter = Adapter, stream = Stream}) when
+    is_integer(Status), Status >= 100, Status =< 199
+->
+    case
+        Adapter =/= undefined andalso
+            erlang:function_exported(Adapter, send_informational, 3)
+    of
+        true -> Adapter:send_informational(Stream, Status, Headers);
+        false -> {error, unsupported}
+    end.
 
 %%====================================================================
 %% Client disconnect

--- a/src/livery_service.erl
+++ b/src/livery_service.erl
@@ -167,10 +167,14 @@ init(Opts) ->
 -spec handle_call(term(), {pid(), term()}, #state{}) ->
     {reply, term(), #state{}}.
 handle_call(stop_accepting, _From, State) ->
+    %% H2/H3 listeners stop entirely; the H1 listener only stops
+    %% accepting, so established (in-flight and kept-alive) connections
+    %% keep being served through the drain window. The kept ref lets
+    %% terminate/2 close them once the drain ends.
     _ = stop_h3(State#state.h3),
     _ = stop_h2(State#state.h2),
-    _ = stop_h1(State#state.h1),
-    {reply, ok, State#state{h1 = undefined, h2 = undefined, h3 = undefined}};
+    _ = stop_accepting_h1(State#state.h1),
+    {reply, ok, State#state{h2 = undefined, h3 = undefined}};
 handle_call(which_listeners, _From, State) ->
     {reply, listeners_map(State), State};
 handle_call(_, _, State) ->
@@ -308,6 +312,9 @@ ensure_h3_name(Opts) ->
 
 stop_h1(undefined) -> ok;
 stop_h1({Ref, _Port}) -> livery_h1:stop(Ref).
+
+stop_accepting_h1(undefined) -> ok;
+stop_accepting_h1({Ref, _Port}) -> livery_h1:stop_accepting(Ref).
 
 stop_h2(undefined) -> ok;
 stop_h2({Ref, _Port}) -> livery_h2:stop(Ref).

--- a/src/livery_test_adapter.erl
+++ b/src/livery_test_adapter.erl
@@ -30,6 +30,7 @@ walker that every adapter calls back into.
     body/1,
     body_chunks/1,
     trailers/1,
+    informational/1,
     reset_reason/1,
     end_stream/1,
     run/3,
@@ -42,6 +43,7 @@ walker that every adapter calls back into.
     send_headers/4,
     send_data/3,
     send_trailers/2,
+    send_informational/3,
     reset/2,
     peer_info/1,
     capabilities/1
@@ -55,6 +57,8 @@ walker that every adapter calls back into.
     body_chunks = [] :: [iodata()],
     end_stream = false :: boolean(),
     trailers :: undefined | [{binary(), binary()}],
+    %% Interim (1xx) responses sent before the final one, in order.
+    informational = [] :: [{100..199, [{binary(), binary()}]}],
     reset :: undefined | term()
 }).
 
@@ -131,6 +135,10 @@ body_chunks(#captured{body_chunks = Cs}) ->
 
 -spec trailers(capture()) -> undefined | [{binary(), binary()}].
 trailers(#captured{trailers = T}) -> T.
+
+-doc "Interim (1xx) responses sent before the final one, in order.".
+-spec informational(capture()) -> [{100..199, [{binary(), binary()}]}].
+informational(#captured{informational = Is}) -> lists:reverse(Is).
 
 -spec reset_reason(capture()) -> undefined | term().
 reset_reason(#captured{reset = R}) -> R.
@@ -214,6 +222,12 @@ send_trailers({Tab, Ref}, Trailers) ->
         C#captured{trailers = Trailers, end_stream = true}
     end).
 
+-spec send_informational(stream(), 100..199, [{binary(), binary()}]) -> ok.
+send_informational({Tab, Ref}, Status, Headers) ->
+    update(Tab, Ref, fun(C) ->
+        C#captured{informational = [{Status, Headers} | C#captured.informational]}
+    end).
+
 -spec reset(stream(), term()) -> ok.
 reset({Tab, Ref}, Reason) ->
     update(Tab, Ref, fun(C) -> C#captured{reset = Reason} end).
@@ -228,7 +242,8 @@ capabilities(_) ->
         trailers => true,
         extended_connect => true,
         datagrams => false,
-        capsules => false
+        capsules => false,
+        informational => true
     }.
 
 %%====================================================================

--- a/src/livery_ws.erl
+++ b/src/livery_ws.erl
@@ -25,7 +25,7 @@ via `livery_ws_h3`).
 
 -include("livery.hrl").
 
--export([upgrade/3, handshake_opts/1]).
+-export([upgrade/3, handshake_opts/1, deflate_opts/3]).
 
 -export_type([handler_module/0, handler_opts/0]).
 
@@ -37,7 +37,7 @@ Upgrade the current request to a WebSocket session.
 
 `HandlerMod` must implement the `ws_handler` behaviour. `Opts`
 is a map forwarded as `HMod:init(Req, Opts)`'s second argument by
-the `ws` library. Two keys are also interpreted by the handshake
+the `ws` library. Some keys are also interpreted by the handshake
 (and left in `Opts`, so the handler still sees them):
 
 - `subprotocols => [binary()]` drives subprotocol negotiation: the
@@ -46,6 +46,17 @@ the `ws` library. Two keys are also interpreted by the handshake
   rejected. Omit to skip negotiation.
 - `idle_timeout => timeout()` overrides the session idle timeout
   (`infinity` never idle-closes). Omit for the `ws` default.
+- `max_frame_size => pos_integer()` and
+  `max_message_size => pos_integer()` bound a single frame and a
+  reassembled fragmented message; a peer exceeding them is closed
+  with `1009`. Omit for the `ws` defaults (16 MiB / 64 MiB).
+- `compress => true` negotiates permessage-deflate (RFC 7692) when
+  the client offers it; the session then runs compressed in both
+  directions. Clients not offering it are served uncompressed.
+
+When the session ends because the peer sent a close frame, the
+handler's `terminate/2` receives `{remote, Code, Reason}` (or
+`remote` for a bare close without a status code).
 
 The handler's `Req` carries `peer => {IpAddress, Port}`, the client
 address from the socket (H1), the h2 connection (H2), or the QUIC
@@ -110,14 +121,62 @@ handshake_opts(Opts) when is_map(Opts) ->
             [_ | _] = Subs -> #{required_subprotocols => Subs};
             _ -> #{}
         end,
-    AcceptOpts =
+    AcceptOpts0 =
         case maps:get(idle_timeout, Opts, undefined) of
             undefined -> #{};
             Timeout -> #{idle_timeout => Timeout}
         end,
+    AcceptOpts =
+        case parser_opts(Opts) of
+            Empty when map_size(Empty) =:= 0 -> AcceptOpts0;
+            ParserOpts -> AcceptOpts0#{parser_opts => ParserOpts}
+        end,
     {ValidateOpts, AcceptOpts};
 handshake_opts(_Opts) ->
     {#{}, #{}}.
+
+%% Frame limits forwarded to the ws parser.
+-spec parser_opts(map()) -> map().
+parser_opts(Opts) ->
+    P0 =
+        case maps:get(max_frame_size, Opts, undefined) of
+            undefined -> #{};
+            MaxFrame -> #{max_frame => MaxFrame}
+        end,
+    case maps:get(max_message_size, Opts, undefined) of
+        undefined -> P0;
+        MaxMessage -> P0#{max_message => MaxMessage}
+    end.
+
+-doc """
+Negotiate permessage-deflate for an upgrade when `Opts` carries
+`compress => true` and the client offered it.
+
+`Info` is the validated-request info from `ws_h1_upgrade` /
+`ws_h2_upgrade` / `ws_h3_upgrade` (its `extensions` key holds the
+client's raw offers). Returns extra response headers (the
+`sec-websocket-extensions` acceptance, or none) and the accept opts
+with `deflate` merged in. Called by the H1/H2/H3 adapters.
+""".
+-spec deflate_opts(map(), handler_opts(), map()) ->
+    {[{binary(), binary()}], map()}.
+deflate_opts(Info, Opts, AcceptOpts) when is_map(Opts) ->
+    case maps:get(compress, Opts, false) of
+        true ->
+            case ws_deflate:negotiate(maps:get(extensions, Info, []), #{}) of
+                {ok, RespExt, Negotiated} ->
+                    {
+                        [{<<"sec-websocket-extensions">>, iolist_to_binary(RespExt)}],
+                        AcceptOpts#{deflate => Negotiated}
+                    };
+                ignore ->
+                    {[], AcceptOpts}
+            end;
+        false ->
+            {[], AcceptOpts}
+    end;
+deflate_opts(_Info, _Opts, AcceptOpts) ->
+    {[], AcceptOpts}.
 
 -spec adapter_supports_ws(module()) -> boolean().
 adapter_supports_ws(livery_h1) -> true;

--- a/test/livery_h1_SUITE.erl
+++ b/test/livery_h1_SUITE.erl
@@ -31,7 +31,10 @@
     error_500_on_crash/1,
     cancel_on_client_disconnect/1,
     send_to_gone_client_is_closed/1,
-    disconnect_mid_response_is_quiet/1
+    disconnect_mid_response_is_quiet/1,
+    peer_on_request_tcp/1,
+    peer_on_request_tls/1,
+    early_hints_before_response/1
 ]).
 
 %% logger handler callback (used by disconnect_mid_response_is_quiet).
@@ -57,7 +60,10 @@ all() ->
         error_500_on_crash,
         cancel_on_client_disconnect,
         send_to_gone_client_is_closed,
-        disconnect_mid_response_is_quiet
+        disconnect_mid_response_is_quiet,
+        peer_on_request_tcp,
+        peer_on_request_tls,
+        early_hints_before_response
     ].
 
 init_per_suite(Config) ->
@@ -253,6 +259,66 @@ disconnect_mid_response_is_quiet(Config) ->
         logger:remove_handler(HandlerId)
     end.
 
+%% Regression: livery_req:peer/1 carries the client address on plain
+%% HTTP requests (it used to be undefined on the H1 adapter).
+peer_on_request_tcp(Config) ->
+    Port = ?config(port, Config),
+    {ok, Sock} = gen_tcp:connect(
+        "127.0.0.1", Port, [binary, {active, false}, {packet, raw}]
+    ),
+    ok = gen_tcp:send(Sock, <<"GET / HTTP/1.1\r\nhost: x\r\n\r\n">>),
+    {ok, {IP, LPort}} = inet:sockname(Sock),
+    Resp = recv_all(Sock, <<>>),
+    ok = gen_tcp:close(Sock),
+    ?assertMatch({_, _}, binary:match(Resp, peer_bin({IP, LPort}))).
+
+peer_on_request_tls(_Config) ->
+    %% The default per-testcase listener is TCP; run a dedicated TLS
+    %% listener for this case.
+    {CertFile, KeyFile} = livery_test_certs:paths(),
+    {ok, Listener} = livery_h1:start(#{
+        port => 0,
+        transport => ssl,
+        cert => CertFile,
+        key => KeyFile,
+        stack => [],
+        handler => handler_for(peer_on_request_tls)
+    }),
+    try
+        Port = h1:server_port(Listener),
+        {ok, Sock} = ssl:connect(
+            "127.0.0.1",
+            Port,
+            [binary, {active, false}, {packet, raw}, {verify, verify_none}],
+            5000
+        ),
+        ok = ssl:send(Sock, <<"GET / HTTP/1.1\r\nhost: x\r\n\r\n">>),
+        {ok, {IP, LPort}} = ssl:sockname(Sock),
+        Resp = ssl_recv_all(Sock, <<>>),
+        _ = ssl:close(Sock),
+        ?assertMatch({_, _}, binary:match(Resp, peer_bin({IP, LPort})))
+    after
+        livery_h1:stop(Listener)
+    end.
+
+%% Two 103 Early Hints go out ahead of the final 200 on the wire.
+early_hints_before_response(Config) ->
+    Port = ?config(port, Config),
+    {ok, Sock} = gen_tcp:connect(
+        "127.0.0.1", Port, [binary, {active, false}, {packet, raw}]
+    ),
+    ok = gen_tcp:send(Sock, <<"GET / HTTP/1.1\r\nhost: x\r\n\r\n">>),
+    Resp = recv_all(Sock, <<>>),
+    ok = gen_tcp:close(Sock),
+    [First, Second, Final | _] = binary:split(Resp, <<"HTTP/1.1 ">>, [global, trim_all]),
+    ?assertMatch(<<"103 ", _/binary>>, First),
+    ?assertMatch(
+        {_, _}, binary:match(First, <<"link: </style.css>; rel=preload; as=style">>)
+    ),
+    ?assertMatch(<<"103 ", _/binary>>, Second),
+    ?assertMatch(<<"200 ", _/binary>>, Final),
+    ?assertMatch({_, _}, binary:match(Final, <<"hinted">>)).
+
 %%====================================================================
 %% Handlers
 %%====================================================================
@@ -264,6 +330,20 @@ max_body_for(body_ceiling_rejects_oversize) -> 64;
 max_body_for(oversize_upload_delivers_413) -> 1024 * 1024;
 max_body_for(_TC) -> 16 * 1024 * 1024.
 
+handler_for(peer_on_request_tcp) ->
+    fun(R) -> livery_resp:text(200, peer_bin(livery_req:peer(R))) end;
+handler_for(peer_on_request_tls) ->
+    fun(R) -> livery_resp:text(200, peer_bin(livery_req:peer(R))) end;
+handler_for(early_hints_before_response) ->
+    fun(R) ->
+        ok = livery_req:inform(
+            103, [{<<"link">>, <<"</style.css>; rel=preload; as=style">>}], R
+        ),
+        ok = livery_req:inform(
+            103, [{<<"link">>, <<"</app.js>; rel=preload; as=script">>}], R
+        ),
+        livery_resp:text(200, <<"hinted">>)
+    end;
 handler_for(text_response) ->
     fun(_R) -> livery_resp:text(200, <<"hello">>) end;
 handler_for(json_response) ->
@@ -423,4 +503,25 @@ header(Name, Headers) ->
         {_, V} when is_binary(V) -> V;
         {_, V} when is_list(V) -> list_to_binary(V);
         false -> undefined
+    end.
+
+%%====================================================================
+%% Raw-socket helpers (peer + early-hints cases)
+%%====================================================================
+
+peer_bin({IP, Port}) ->
+    iolist_to_binary([inet:ntoa(IP), $:, integer_to_binary(Port)]);
+peer_bin(undefined) ->
+    <<"undefined">>.
+
+recv_all(Sock, Acc) ->
+    case gen_tcp:recv(Sock, 0, 500) of
+        {ok, Data} -> recv_all(Sock, <<Acc/binary, Data/binary>>);
+        {error, _} -> Acc
+    end.
+
+ssl_recv_all(Sock, Acc) ->
+    case ssl:recv(Sock, 0, 500) of
+        {ok, Data} -> ssl_recv_all(Sock, <<Acc/binary, Data/binary>>);
+        {error, _} -> Acc
     end.

--- a/test/livery_h2_SUITE.erl
+++ b/test/livery_h2_SUITE.erl
@@ -8,6 +8,8 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
 
+-define(REQUEST_TIMEOUT, 5000).
+
 -export([
     all/0,
     init_per_suite/1,
@@ -27,7 +29,9 @@
     error_500_on_crash/1,
     response_with_trailers/1,
     cancel_on_connection_close/1,
-    send_to_gone_client_is_closed/1
+    send_to_gone_client_is_closed/1,
+    peer_on_request/1,
+    early_hints_interim/1
 ]).
 
 %%====================================================================
@@ -46,7 +50,9 @@ all() ->
         error_500_on_crash,
         response_with_trailers,
         cancel_on_connection_close,
-        send_to_gone_client_is_closed
+        send_to_gone_client_is_closed,
+        peer_on_request,
+        early_hints_interim
     ].
 
 init_per_suite(Config) ->
@@ -141,6 +147,24 @@ response_with_trailers(Config) ->
 
 stack_for(_TC) -> [].
 
+handler_for(peer_on_request) ->
+    fun(R) ->
+        Body =
+            case livery_req:peer(R) of
+                {{127, 0, 0, 1}, Port} when is_integer(Port), Port > 0 ->
+                    <<"peer-ok">>;
+                Other ->
+                    iolist_to_binary(io_lib:format("~p", [Other]))
+            end,
+        livery_resp:text(200, Body)
+    end;
+handler_for(early_hints_interim) ->
+    fun(R) ->
+        ok = livery_req:inform(
+            103, [{<<"link">>, <<"</app.css>; rel=preload; as=style">>}], R
+        ),
+        livery_resp:text(200, <<"hinted">>)
+    end;
 handler_for(text_response) ->
     fun(_R) -> livery_resp:text(200, <<"hello">>) end;
 handler_for(json_response) ->
@@ -242,11 +266,51 @@ send_to_gone_client_is_closed(_Config) ->
     ),
     ?assertEqual({error, closed}, livery_h2:send_trailers(Stream, [{<<"x">>, <<"y">>}])).
 
+%% Regression: livery_req:peer/1 carries the client address on plain
+%% HTTP/2 requests (it used to be undefined).
+peer_on_request(Config) ->
+    {Status, _Headers, Body, _} = get(Config, <<"/">>),
+    ?assertEqual(200, Status),
+    ?assertEqual(<<"peer-ok">>, Body).
+
+%% A 103 interim HEADERS block reaches the client ahead of the final
+%% response on the same stream.
+early_hints_interim(Config) ->
+    Port = ?config(port, Config),
+    {ok, Conn} = h2:connect("127.0.0.1", Port, #{transport => tcp}),
+    {ok, StreamId} = h2:request(Conn, <<"GET">>, <<"/">>, [
+        {<<"host">>, <<"127.0.0.1">>}
+    ]),
+    {Infos, {Status, _Headers, Body, _}} = collect_with_informational(Conn, StreamId),
+    ?assertMatch([{103, _}], Infos),
+    [{103, Hs}] = Infos,
+    ?assertEqual(
+        <<"</app.css>; rel=preload; as=style">>,
+        header(<<"link">>, Hs)
+    ),
+    ?assertEqual(200, Status),
+    ?assertEqual(<<"hinted">>, Body),
+    h2:close(Conn).
+
+collect_with_informational(Conn, StreamId) ->
+    collect_with_informational(Conn, StreamId, []).
+
+%% Interim events strictly precede the final response HEADERS; once
+%% that arrives, hand off to the shared collector for body/trailers.
+collect_with_informational(Conn, StreamId, Infos) ->
+    receive
+        {h2, Conn, {informational, StreamId, S, Hs}} ->
+            collect_with_informational(Conn, StreamId, [{S, Hs} | Infos]);
+        {h2, Conn, {response, StreamId, S, Hs}} ->
+            Result = collect_response(Conn, StreamId, S, Hs, [], undefined),
+            {lists:reverse(Infos), Result}
+    after ?REQUEST_TIMEOUT ->
+        {lists:reverse(Infos), {error, timeout}}
+    end.
+
 %%====================================================================
 %% HTTP/2 client helpers
 %%====================================================================
-
--define(REQUEST_TIMEOUT, 5000).
 
 get(Config, Path) ->
     request(<<"GET">>, Config, Path, <<>>).

--- a/test/livery_h3_SUITE.erl
+++ b/test/livery_h3_SUITE.erl
@@ -25,7 +25,9 @@
     error_500_on_crash/1,
     response_with_trailers/1,
     cancel_on_connection_close/1,
-    send_to_gone_client_is_closed/1
+    send_to_gone_client_is_closed/1,
+    peer_on_request/1,
+    inform_unsupported/1
 ]).
 
 %%====================================================================
@@ -43,7 +45,9 @@ all() ->
         error_500_on_crash,
         response_with_trailers,
         cancel_on_connection_close,
-        send_to_gone_client_is_closed
+        send_to_gone_client_is_closed,
+        peer_on_request,
+        inform_unsupported
     ].
 
 init_per_suite(Config) ->
@@ -78,6 +82,20 @@ end_per_testcase(_TC, Config) ->
 %%====================================================================
 %% Cases
 %%====================================================================
+
+%% Regression: livery_req:peer/1 carries the client address on plain
+%% HTTP/3 requests (it used to be undefined).
+peer_on_request(Config) ->
+    {Status, _Headers, Body, _} = get(Config, <<"/">>),
+    ?assertEqual(200, Status),
+    ?assertEqual(<<"peer-ok">>, Body).
+
+%% The H3 adapter does not implement interim responses yet: inform/3
+%% reports {error, unsupported} instead of crashing the handler.
+inform_unsupported(Config) ->
+    {Status, _Headers, Body, _} = get(Config, <<"/">>),
+    ?assertEqual(200, Status),
+    ?assertEqual(<<"unsupported">>, Body).
 
 text_response(Config) ->
     {Status, Headers, Body, _} = get(Config, <<"/">>),
@@ -134,6 +152,26 @@ response_with_trailers(Config) ->
 
 stack_for(_TC) -> [].
 
+handler_for(peer_on_request) ->
+    fun(R) ->
+        Body =
+            case livery_req:peer(R) of
+                {{127, 0, 0, 1}, Port} when is_integer(Port), Port > 0 ->
+                    <<"peer-ok">>;
+                Other ->
+                    iolist_to_binary(io_lib:format("~p", [Other]))
+            end,
+        livery_resp:text(200, Body)
+    end;
+handler_for(inform_unsupported) ->
+    fun(R) ->
+        Body =
+            case livery_req:inform(103, [], R) of
+                {error, unsupported} -> <<"unsupported">>;
+                Other -> iolist_to_binary(io_lib:format("~p", [Other]))
+            end,
+        livery_resp:text(200, Body)
+    end;
 handler_for(text_response) ->
     fun(_R) -> livery_resp:text(200, <<"hello">>) end;
 handler_for(json_response) ->

--- a/test/livery_service_SUITE.erl
+++ b/test/livery_service_SUITE.erl
@@ -29,7 +29,9 @@
     max_body_raises_h1_parser_cap/1,
     default_max_body_authoritative/1,
     drain_lets_inflight_finish/1,
-    drain_times_out_on_stuck_request/1
+    drain_times_out_on_stuck_request/1,
+    stop_service_closes_keepalive_connections/1,
+    drain_closes_idle_keepalive_at_end/1
 ]).
 
 %%====================================================================
@@ -50,7 +52,9 @@ all() ->
         max_body_raises_h1_parser_cap,
         default_max_body_authoritative,
         drain_lets_inflight_finish,
-        drain_times_out_on_stuck_request
+        drain_times_out_on_stuck_request,
+        stop_service_closes_keepalive_connections,
+        drain_closes_idle_keepalive_at_end
     ].
 
 init_per_suite(Config) ->
@@ -336,6 +340,62 @@ drain_lets_inflight_finish(_Config) ->
         end
     ),
     ?assertNot(is_process_alive(Pid)).
+
+%% Probe regression: a kept-alive client must stop being served once
+%% the service is stopped. Before the fix only the listen socket
+%% closed; accepted connections lived on and still answered requests.
+stop_service_closes_keepalive_connections(_Config) ->
+    {ok, Pid} = livery:start_service(#{
+        http => #{port => 0},
+        handler => fun(_R) -> livery_resp:text(200, <<"ok">>) end
+    }),
+    Port = maps:get(h1, livery:which_listeners(Pid)),
+    {ok, Sock} = gen_tcp:connect(
+        "127.0.0.1", Port, [binary, {active, false}, {packet, raw}]
+    ),
+    ok = gen_tcp:send(Sock, <<"GET / HTTP/1.1\r\nhost: x\r\n\r\n">>),
+    ?assertMatch({_, _}, binary:match(raw_recv(Sock), <<"HTTP/1.1 200">>)),
+    ok = livery:stop_service(Pid),
+    %% The kept-alive socket is closed; nothing serves it anymore.
+    ?assertEqual({error, closed}, wait_closed(Sock, 2000)),
+    ?assertMatch(
+        {error, _},
+        gen_tcp:connect("127.0.0.1", Port, [binary, {active, false}], 500)
+    ),
+    gen_tcp:close(Sock).
+
+%% Idle keep-alive connections survive the drain window (still served)
+%% and are closed once the drain completes.
+drain_closes_idle_keepalive_at_end(_Config) ->
+    {ok, Pid} = livery:start_service(#{
+        http => #{port => 0},
+        handler => fun(_R) -> livery_resp:text(200, <<"ok">>) end
+    }),
+    Port = maps:get(h1, livery:which_listeners(Pid)),
+    {ok, Sock} = gen_tcp:connect(
+        "127.0.0.1", Port, [binary, {active, false}, {packet, raw}]
+    ),
+    ok = gen_tcp:send(Sock, <<"GET / HTTP/1.1\r\nhost: x\r\n\r\n">>),
+    ?assertMatch({_, _}, binary:match(raw_recv(Sock), <<"HTTP/1.1 200">>)),
+    %% No in-flight requests: the drain window is a no-op wait; the
+    %% final stop closes the idle keep-alive connection.
+    ?assertEqual(ok, livery:drain(Pid, #{timeout => 5000})),
+    ?assertEqual({error, closed}, wait_closed(Sock, 2000)),
+    gen_tcp:close(Sock).
+
+raw_recv(Sock) ->
+    case gen_tcp:recv(Sock, 0, 5000) of
+        {ok, Data} -> Data;
+        {error, R} -> ct:fail({raw_recv_failed, R})
+    end.
+
+%% Read until the socket reports closed (discarding leftover response
+%% bytes); errors other than closed surface as-is.
+wait_closed(Sock, Timeout) ->
+    case gen_tcp:recv(Sock, 0, Timeout) of
+        {ok, _} -> wait_closed(Sock, Timeout);
+        {error, _} = E -> E
+    end.
 
 drain_times_out_on_stuck_request(_Config) ->
     Self = self(),

--- a/test/livery_test_adapter_tests.erl
+++ b/test/livery_test_adapter_tests.erl
@@ -185,3 +185,45 @@ capabilities_test() ->
         Caps
     ),
     livery_test_adapter:stop(Tab).
+
+%%====================================================================
+%% Interim (1xx) responses
+%%====================================================================
+
+inform_is_captured_in_order_test() ->
+    Tab = livery_test_adapter:start(),
+    Stream = livery_test_adapter:new_stream(Tab),
+    Req = livery_req:new(#{adapter => livery_test_adapter, stream => Stream}),
+    ?assertEqual(
+        ok,
+        livery_req:inform(103, [{<<"link">>, <<"</a.css>; rel=preload">>}], Req)
+    ),
+    ?assertEqual(ok, livery_req:inform(103, [{<<"link">>, <<"</b.js>">>}], Req)),
+    Cap = livery_test_adapter:capture(Stream),
+    ?assertEqual(
+        [
+            {103, [{<<"link">>, <<"</a.css>; rel=preload">>}]},
+            {103, [{<<"link">>, <<"</b.js>">>}]}
+        ],
+        livery_test_adapter:informational(Cap)
+    ),
+    livery_test_adapter:stop(Tab).
+
+inform_without_adapter_is_unsupported_test() ->
+    Req = livery_req:new(#{}),
+    ?assertEqual({error, unsupported}, livery_req:inform(103, [], Req)).
+
+inform_rejects_non_1xx_test() ->
+    Tab = livery_test_adapter:start(),
+    Stream = livery_test_adapter:new_stream(Tab),
+    Req = livery_req:new(#{adapter => livery_test_adapter, stream => Stream}),
+    ?assertError(function_clause, livery_req:inform(200, [], Req)),
+    livery_test_adapter:stop(Tab).
+
+informational_capability_test() ->
+    Tab = livery_test_adapter:start(),
+    ?assertMatch(
+        #{informational := true},
+        livery_test_adapter:capabilities(Tab)
+    ),
+    livery_test_adapter:stop(Tab).

--- a/test/livery_ws_SUITE.erl
+++ b/test/livery_ws_SUITE.erl
@@ -33,7 +33,10 @@
     h2_surfaces_peer/1,
     h3_echo_text_frame/1,
     h3_surfaces_peer/1,
-    h1_echo_text_frame_ipv6/1
+    h1_echo_text_frame_ipv6/1,
+    h1_compressed_echo/1,
+    h1_max_frame_size_closes/1,
+    h1_close_code_reaches_terminate/1
 ]).
 
 %%====================================================================
@@ -59,7 +62,10 @@ all() ->
         h2_rejects_plain_get,
         h2_surfaces_peer,
         h3_echo_text_frame,
-        h3_surfaces_peer
+        h3_surfaces_peer,
+        h1_compressed_echo,
+        h1_max_frame_size_closes,
+        h1_close_code_reaches_terminate
     ].
 
 init_per_suite(Config) ->
@@ -190,6 +196,45 @@ init_per_testcase(TC, Config) when
         {port, h1:server_port(Listener)}
         | Config
     ];
+init_per_testcase(h1_compressed_echo, Config) ->
+    {ok, Listener} = livery_h1:start(#{
+        port => 0,
+        stack => [],
+        handler => fun ws_compress_handler/1
+    }),
+    [
+        {adapter, h1},
+        {listener, Listener},
+        {port, h1:server_port(Listener)}
+        | Config
+    ];
+init_per_testcase(h1_max_frame_size_closes, Config) ->
+    {ok, Listener} = livery_h1:start(#{
+        port => 0,
+        stack => [],
+        handler => fun ws_small_frame_handler/1
+    }),
+    [
+        {adapter, h1},
+        {listener, Listener},
+        {port, h1:server_port(Listener)}
+        | Config
+    ];
+init_per_testcase(h1_close_code_reaches_terminate, Config) ->
+    Self = self(),
+    {ok, Listener} = livery_h1:start(#{
+        port => 0,
+        stack => [],
+        handler => fun(R) ->
+            livery_ws:upgrade(R, livery_ws_term_handler, #{notify => Self})
+        end
+    }),
+    [
+        {adapter, h1},
+        {listener, Listener},
+        {port, h1:server_port(Listener)}
+        | Config
+    ];
 init_per_testcase(_TC, Config) ->
     {ok, Listener} = livery_h1:start(#{
         port => 0,
@@ -226,6 +271,14 @@ ws_peer_handler(R) ->
 %% Short idle timeout so an idle connection is closed quickly.
 ws_idle_handler(R) ->
     livery_ws:upgrade(R, livery_ws_echo_handler, #{idle_timeout => 300}).
+
+%% Negotiate permessage-deflate with clients that offer it.
+ws_compress_handler(R) ->
+    livery_ws:upgrade(R, livery_ws_echo_handler, #{compress => true}).
+
+%% Tiny frame cap so an ordinary frame trips the 1009 close.
+ws_small_frame_handler(R) ->
+    livery_ws:upgrade(R, livery_ws_echo_handler, #{max_frame_size => 64}).
 
 %% Probe the IPv6 loopback with a real connect round-trip, not just a
 %% listen: CI runners can bind `::1' yet fail to connect to it. A false
@@ -357,6 +410,53 @@ ws_echo_frames(Sess) ->
             after 15000 -> {error, no_echo_frame}
             end
     after 15000 -> {error, no_ready_frame}
+    end.
+
+%% Frames round-trip compressed when both sides negotiate
+%% permessage-deflate (compress => true on the upgrade and the client).
+h1_compressed_echo(Config) ->
+    Port = ?config(port, Config),
+    ?assertEqual(ok, ws_echo_roundtrip(ws_url(Port), #{compress => true}, 1)).
+
+%% max_frame_size is enforced by the server: an oversized frame closes
+%% the session with 1009 (message too big), which the client handler
+%% observes as {remote, 1009, _} in terminate/2.
+h1_max_frame_size_closes(Config) ->
+    Port = ?config(port, Config),
+    Self = self(),
+    {ok, Sess} = ws_client:connect(ws_url(Port), #{
+        handler => livery_ws_client_capture,
+        handler_opts => #{parent => Self}
+    }),
+    receive
+        {captured, {text, <<"ready">>}} -> ok
+    after 15000 -> ct:fail(no_ready_frame)
+    end,
+    ok = ws:send(Sess, [{text, binary:copy(<<"x">>, 1024)}]),
+    receive
+        {ws_terminate, Reason} ->
+            ?assertMatch({remote, 1009, _}, Reason)
+    after 15000 -> ct:fail(no_client_terminate)
+    end.
+
+%% The peer's close code and reason surface in the server handler's
+%% terminate/2 as {remote, Code, Reason}.
+h1_close_code_reaches_terminate(Config) ->
+    Port = ?config(port, Config),
+    Self = self(),
+    {ok, Sess} = ws_client:connect(ws_url(Port), #{
+        handler => livery_ws_client_capture,
+        handler_opts => #{parent => Self}
+    }),
+    receive
+        {captured, {text, <<"ready">>}} -> ok
+    after 15000 -> ct:fail(no_ready_frame)
+    end,
+    ok = ws:close(Sess, 4002, <<"done">>),
+    receive
+        {ws_server_terminate, Reason} ->
+            ?assertEqual({remote, 4002, <<"done">>}, Reason)
+    after 15000 -> ct:fail(no_server_terminate)
     end.
 
 h1_rejects_request_without_upgrade_headers(Config) ->

--- a/test/livery_ws_client_capture.erl
+++ b/test/livery_ws_client_capture.erl
@@ -20,5 +20,8 @@ handle_in(Frame, Parent) when is_pid(Parent) ->
 handle_info(_Msg, State) ->
     {ok, State}.
 
+terminate(Reason, Parent) when is_pid(Parent) ->
+    Parent ! {ws_terminate, Reason},
+    ok;
 terminate(_Reason, _State) ->
     ok.

--- a/test/livery_ws_term_handler.erl
+++ b/test/livery_ws_term_handler.erl
@@ -1,0 +1,22 @@
+%% @doc Server-side `ws_handler' used by livery_ws_SUITE.
+%%
+%% Emits a `ready' frame on connect and reports its terminate reason to
+%% the pid given as `notify', so a test can assert the peer's close code
+%% surfaced as `{remote, Code, Reason}'.
+-module(livery_ws_term_handler).
+-behaviour(ws_handler).
+
+-export([init/2, handle_in/2, handle_info/2, terminate/2]).
+
+init(_Req, #{notify := Parent} = Opts) when is_pid(Parent) ->
+    {reply, [{text, <<"ready">>}], Opts}.
+
+handle_in(_Frame, State) ->
+    {ok, State}.
+
+handle_info(_Msg, State) ->
+    {ok, State}.
+
+terminate(Reason, #{notify := Parent}) ->
+    Parent ! {ws_server_terminate, Reason},
+    ok.


### PR DESCRIPTION
Closes three server-side gaps. livery_req:peer/1 is now set on plain requests on all three adapters and peer_info/1 returns the real peer. livery_req:inform/3 sends interim (1xx) responses such as 103 Early Hints through the new optional adapter callback send_informational/3, advertised via the informational capability; H1 and H2 send it, H3 reports {error, unsupported} for now. livery:stop_service/1 really cuts off kept-alive HTTP/1.1 clients (h1 0.8.0 closes accepted connections synchronously), and livery:drain/2 keeps established connections serving through the window then closes the idle ones at the end. Alongside: livery_ws:upgrade/3 takes max_frame_size, max_message_size, and compress (permessage-deflate via ws 0.4.0), and WebSocket handlers receive the peer's close code in terminate/2 as {remote, Code, Reason}. Bumps h1 to 0.8.0 and erlang_ws to 0.4.0.