### PR TITLE
Bump dependencies to their latest releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WebSocket handlers' `terminate/2` receives `{remote, Code, Reason}`
   when the peer's close frame carried a status code (`remote` for a bare
   close), on every adapter (ws 0.4.0).
-- Bump `h1` to 0.8.0, `ws` (erlang_ws) to 0.4.0.
+- Bump `h1` to 0.8.0, `quic` to 1.8.0 (RFC 6125 wildcard SAN matching,
+  Happy Eyeballs backlog delivery on the winning attempt, Retry
+  packet-number continuity, Version Negotiation handling), `ws`
+  (erlang_ws) to 0.5.0 (RFC 8441 `Sec-WebSocket-Version` validation on
+  extended CONNECT), `webtransport` to 0.4.4, `instrument` to 1.1.5
+  (OTLP histogram encoding fixes), `hackney` to 4.7.3, `barrel_mcp` to
+  2.3.0.
+- Bump test and bench dependencies: `cowboy` to 2.18.0, `cowlib` to
+  2.19.0, `ranch` to 2.2.1.
+- Bump tooling: `erlfmt` to 1.8.0, `rebar3_lint` to 5.0.4 (elvis_core
+  5.x), and migrate the elvis config to the new format.
 
 ## [0.6.1] - 2026-07-17
 

--- a/rebar.config
+++ b/rebar.config
@@ -8,12 +8,12 @@
     {mimerl, "1.5.0"},
     {h1, "~> 0.8.0", {pkg, erlang_h1}},
     {h2, "~> 0.11.0"},
-    {quic, "~> 1.7.0"},
-    {ws, "~> 0.4.0", {pkg, erlang_ws}},
-    {instrument, "~> 1.1.4"},
-    {webtransport, "~> 0.4.3"},
-    {hackney, "~> 4.7.0"},
-    {barrel_mcp, "~> 2.2.4"}
+    {quic, "~> 1.8.0"},
+    {ws, "~> 0.5.0", {pkg, erlang_ws}},
+    {instrument, "~> 1.1.5"},
+    {webtransport, "~> 0.4.4"},
+    {hackney, "~> 4.7.3"},
+    {barrel_mcp, "~> 2.3.0"}
 ]}.
 
 {profiles, [
@@ -30,9 +30,9 @@
         %% cowlib/ranch are pinned from hex to satisfy it.
         {deps, [
             {proper, "1.5.0"},
-            {cowlib, "2.17.1"},
-            {ranch, "1.8.1"},
-            {cowboy, {git, "https://github.com/ninenines/cowboy.git", {tag, "2.16.1"}}}
+            {cowlib, "2.19.0"},
+            {ranch, "2.2.1"},
+            {cowboy, {git, "https://github.com/ninenines/cowboy.git", {tag, "2.18.0"}}}
         ]}
     ]},
     {examples, [
@@ -45,9 +45,9 @@
         %% cowboy (+ cowlib/ranch) for the livery-vs-cowboy comparison;
         %% same pins as the test profile. See rebar.config test deps.
         {deps, [
-            {cowlib, "2.17.1"},
-            {ranch, "1.8.1"},
-            {cowboy, {git, "https://github.com/ninenines/cowboy.git", {tag, "2.16.1"}}}
+            {cowlib, "2.19.0"},
+            {ranch, "2.2.1"},
+            {cowboy, {git, "https://github.com/ninenines/cowboy.git", {tag, "2.18.0"}}}
         ]}
     ]}
 ]}.
@@ -69,8 +69,8 @@
 {cover_opts, [verbose]}.
 
 {project_plugins, [
-    {erlfmt, "1.7.0"},
-    {rebar3_lint, "4.1.1"},
+    {erlfmt, "1.8.0"},
+    {rebar3_lint, "5.0.4"},
     rebar3_ex_doc
 ]}.
 
@@ -302,136 +302,151 @@
 {hex, [{doc, #{provider => ex_doc}}]}.
 
 {elvis, [
-    #{
-        dirs => ["src", "src/client", "src/middleware", "src/auth", "src/codec"],
-        filter => "*.erl",
-        rules => [
-            {elvis_style, no_macros, disable},
-            {elvis_style, no_common_caveats_call, disable},
-            {elvis_style, no_init_lists, disable},
-            {elvis_style, param_pattern_matching, disable},
-            %% `livery' and `livery_resp' are intentional public
-            %% facades; `livery_req'/`livery_resp' expose req/0 and
-            %% resp/0 as the public request/response value types.
-            %% livery_client is the client's public facade (verbs,
-            %% accessors, layer and sugar constructors), like livery_req/resp.
-            {elvis_style, god_modules, #{
-                ignore => [livery_req, livery_resp, livery_client]
-            }},
-            {elvis_style, private_data_types, #{
-                ignore => [livery_req, livery_resp]
-            }},
-            {elvis_style, export_used_types, #{
-                ignore => [
-                    livery_middleware,
-                    livery_req,
-                    livery_resp,
-                    livery_router,
-                    livery_ws_h2,
-                    livery_ws_h3
-                ]
-            }},
-            %% The adapter behaviour is dispatched dynamically by
-            %% design (Adapter:send_*, accept_ws/accept_wt).
-            %% livery_req:inform/3 dispatches to the adapter's optional
-            %% send_informational/3.
-            %% livery_client dispatches to the configured client adapter;
-            %% livery_client_discover dispatches to the discovery provider;
-            %% livery_client_cookie dispatches to the cookie store module;
-            %% livery_client_timeout reparents a streamed connection via the
-            %% adapter's optional adopt/2.
-            {elvis_style, invalid_dynamic_call, #{
-                ignore => [
-                    livery,
-                    livery_req,
-                    livery_mcp,
-                    livery_ws,
-                    livery_wt,
-                    livery_compress,
-                    livery_client,
-                    livery_client_discover,
-                    livery_client_cookie,
-                    livery_client_timeout
-                ]
-            }},
-            %% Per-stream translators (and the client push-stream relay)
-            %% block on receive and exit on the monitored peer's DOWN, so an
-            %% after clause is wrong.
-            {elvis_style, no_receive_without_timeout, #{
-                ignore => [livery_h1, livery_h2, livery_h3, livery_client_hackney]
-            }},
-            %% Internal records used directly in specs; introducing a
-            %% wrapper type would not add clarity.
-            {elvis_style, no_spec_with_records, #{
-                ignore => [
-                    livery_auth,
-                    livery_router,
-                    livery_service,
-                    livery_test_adapter
-                ]
-            }},
-            {elvis_style, state_record_and_type, #{
-                ignore => [livery_service]
-            }},
-            {elvis_style, no_throw, #{ignore => [livery_service]}},
-            {elvis_style, no_catch_expressions, #{
-                ignore => [livery_ws_h2, livery_ws_h3]
-            }},
-            {elvis_style, no_boolean_in_comparison, #{
-                ignore => [livery_req]
-            }},
-            %% Capitalised OTP record names ('RSAPublicKey', ...) and
-            %% camelCase JSON-Schema keyword atoms are external shapes.
-            {elvis_style, atom_naming_convention, #{
-                ignore => [livery_auth, livery_openapi_validate]
-            }},
-            %% The new-bucket (insert_new) and existing-bucket (CAS
-            %% select_replace) branches share the allow shape but differ
-            %% in the atomic write primitive; keeping them apart is clearer.
-            {elvis_style, dont_repeat_yourself, #{
-                ignore => [livery, livery_openapi, livery_ratelimit_store]
-            }},
-            {elvis_style, max_function_length, #{
-                ignore => [
-                    livery,
-                    livery_client_hackney,
-                    livery_h1,
-                    livery_h2,
-                    livery_h3,
-                    livery_mcp,
-                    livery_openapi_validate,
-                    livery_router
-                ]
-            }},
-            {elvis_style, max_function_clause_length, #{
-                ignore => [
-                    livery,
-                    livery_client_hackney,
-                    livery_h1,
-                    livery_h2,
-                    livery_h3,
-                    livery_mcp,
-                    livery_openapi_validate,
-                    livery_router
-                ]
-            }},
-            %% The per-stream translator loops thread immutable stream
-            %% context (conn, ids, monitors, body ceiling) positionally.
-            {elvis_style, max_function_arity, #{
-                ignore => [livery_h1, livery_h2, livery_h3]
-            }},
-            %% Long lines are CDN URL string literals in the doc-UI
-            %% HTML; they cannot be wrapped without splitting them.
-            {elvis_text_style, line_length, #{ignore => [livery_openapi]}}
-        ],
-        ruleset => erl_files_strict
-    },
-    #{
-        dirs => ["."],
-        filter => "rebar.config",
-        rules => [
-            {elvis_project, no_branch_deps, disable}
-        ],
-        ruleset => rebar_config
-    }
+    {config, [
+        #{
+            files => ["src/**/*.erl"],
+            rules => [
+                {elvis_style, no_macros, disable},
+                {elvis_style, no_common_caveats_call, disable},
+                {elvis_style, no_init_lists, disable},
+                {elvis_style, param_pattern_matching, disable},
+                %% `<:-' strict generators need OTP 28; Livery supports 27.
+                {elvis_style, prefer_strict_generators, disable},
+                %% `~"..."' sigils would restyle every binary literal.
+                {elvis_style, prefer_sigils, disable},
+                %% `Ratio == trunc(Ratio)' compares a float against an
+                %% integer on purpose; `=:=' would never hold.
+                {elvis_style, strict_term_equivalence, #{
+                    ignore => [livery_openapi_validate]
+                }},
+                %% `{ok, _}' is the shape these entry points promise:
+                %% `start_link/1' by OTP convention, `livery_body:discard/1,2'
+                %% because it returns the advanced reader.
+                {elvis_style, consistent_ok_error_spec, #{
+                    ignore => [livery_body, livery_req_proc, livery_ws]
+                }},
+                %% `livery' and `livery_resp' are intentional public
+                %% facades; `livery_req'/`livery_resp' expose req/0 and
+                %% resp/0 as the public request/response value types.
+                %% livery_client is the client's public facade (verbs,
+                %% accessors, layer and sugar constructors), like livery_req/resp.
+                {elvis_style, no_god_modules, #{
+                    ignore => [livery_req, livery_resp, livery_client]
+                }},
+                {elvis_style, private_data_types, #{
+                    ignore => [livery_req, livery_resp]
+                }},
+                {elvis_style, export_used_types, #{
+                    ignore => [
+                        livery_middleware,
+                        livery_req,
+                        livery_resp,
+                        livery_router,
+                        livery_ws_h2,
+                        livery_ws_h3
+                    ]
+                }},
+                %% The adapter behaviour is dispatched dynamically by
+                %% design (Adapter:send_*, accept_ws/accept_wt).
+                %% livery_req:inform/3 dispatches to the adapter's optional
+                %% send_informational/3.
+                %% livery_client dispatches to the configured client adapter;
+                %% livery_client_discover dispatches to the discovery provider;
+                %% livery_client_cookie dispatches to the cookie store module;
+                %% livery_client_timeout reparents a streamed connection via the
+                %% adapter's optional adopt/2.
+                {elvis_style, no_invalid_dynamic_calls, #{
+                    ignore => [
+                        livery,
+                        livery_req,
+                        livery_mcp,
+                        livery_ws,
+                        livery_wt,
+                        livery_compress,
+                        livery_client,
+                        livery_client_discover,
+                        livery_client_cookie,
+                        livery_client_timeout
+                    ]
+                }},
+                %% Per-stream translators (and the client push-stream relay)
+                %% block on receive and exit on the monitored peer's DOWN, so an
+                %% after clause is wrong.
+                {elvis_style, no_receive_without_timeout, #{
+                    ignore => [livery_h1, livery_h2, livery_h3, livery_client_hackney]
+                }},
+                %% Internal records used directly in specs; introducing a
+                %% wrapper type would not add clarity.
+                {elvis_style, no_spec_with_records, #{
+                    ignore => [
+                        livery_auth,
+                        livery_router,
+                        livery_service,
+                        livery_test_adapter
+                    ]
+                }},
+                {elvis_style, state_record_and_type, #{
+                    ignore => [livery_service]
+                }},
+                {elvis_style, no_throw, #{ignore => [livery_service]}},
+                {elvis_style, no_catch_expressions, #{
+                    ignore => [livery_ws_h2, livery_ws_h3]
+                }},
+                {elvis_style, no_boolean_in_comparison, #{
+                    ignore => [livery_req]
+                }},
+                %% Capitalised OTP record names ('RSAPublicKey', ...) and
+                %% camelCase JSON-Schema keyword atoms are external shapes.
+                {elvis_style, atom_naming_convention, #{
+                    ignore => [livery_auth, livery_openapi_validate]
+                }},
+                %% The new-bucket (insert_new) and existing-bucket (CAS
+                %% select_replace) branches share the allow shape but differ
+                %% in the atomic write primitive; keeping them apart is clearer.
+                {elvis_style, dont_repeat_yourself, #{
+                    ignore => [livery, livery_openapi, livery_ratelimit_store]
+                }},
+                {elvis_style, max_function_length, #{
+                    ignore => [
+                        livery,
+                        livery_client_hackney,
+                        livery_h1,
+                        livery_h2,
+                        livery_h3,
+                        livery_mcp,
+                        livery_openapi_validate,
+                        livery_router
+                    ]
+                }},
+                {elvis_style, max_function_clause_length, #{
+                    ignore => [
+                        livery,
+                        livery_client_hackney,
+                        livery_h1,
+                        livery_h2,
+                        livery_h3,
+                        livery_mcp,
+                        livery_openapi_validate,
+                        livery_router
+                    ]
+                }},
+                %% The per-stream translator loops thread immutable stream
+                %% context (conn, ids, monitors, body ceiling) positionally.
+                {elvis_style, max_function_arity, #{
+                    ignore => [livery_h1, livery_h2, livery_h3]
+                }},
+                %% Long lines are CDN URL string literals in the doc-UI
+                %% HTML; they cannot be wrapped without splitting them.
+                {elvis_text_style, max_line_length, #{ignore => [livery_openapi]}}
+            ],
+            ruleset => erl_files_strict
+        },
+        #{
+            files => ["rebar.config"],
+            rules => [
+                {elvis_project, no_branch_deps, disable}
+            ],
+            ruleset => rebar_config
+        }
+    ]}
 ]}.

--- a/src/livery_req.erl
+++ b/src/livery_req.erl
@@ -192,7 +192,7 @@ headers_all(Name, #livery_req{headers = Hs}) ->
 -spec has_header(header_name(), req()) -> boolean().
 has_header(Name, #livery_req{headers = Hs}) ->
     LName = lowercase(Name),
-    lists:keyfind(LName, 1, Hs) /= false.
+    lists:keyfind(LName, 1, Hs) =/= false.
 
 -doc "Replace (or insert) a header.".
 -spec set_header(header_name(), header_value(), req()) -> req().


### PR DESCRIPTION
Moves every dependency to its latest release: quic 1.7.0 to 1.8.0, ws 0.4.0 to 0.5.0, webtransport 0.4.3 to 0.4.4, instrument 1.1.4 to 1.1.5, hackney 4.7.0 to 4.7.3 and barrel_mcp 2.2.4 to 2.3.0. mimerl, h1 and h2 were already current. The test and bench profiles follow with cowboy 2.18.0, cowlib 2.19.0 and ranch 2.2.1, and the tooling with erlfmt 1.8.0 and rebar3_lint 5.0.4.

rebar3_lint 5.0.4 pulls elvis_core 5.x, so the elvis config moves to the new format: dirs and filter become a single files glob, god_modules becomes no_god_modules, invalid_dynamic_call becomes no_invalid_dynamic_calls and line_length becomes max_line_length. Four strict rules are new. prefer_strict_generators is disabled because `<:-` needs OTP 28 while the quickstart promises 27 or later, and prefer_sigils is disabled because it would restyle every binary literal in the tree. strict_term_equivalence turned up one real weak comparison, fixed in livery_req:has_header/2; livery_openapi_validate keeps `==` since it compares a float against an integer on purpose and `=:=` would never hold. consistent_ok_error_spec is ignored for livery_body, livery_req_proc and livery_ws, whose `{ok, _}` returns are the shape those entry points promise.

Adopting sigils and strict generators is a separate sweep and would mean dropping OTP 27.