### PR TITLE
Serve HTTP/2 and HTTP/1.1 on one TLS port by ALPN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-12
+
+### Added
+
+- `https => #{..., alpn => [h2, http1]}` serves HTTP/2 and HTTP/1.1 from
+  one TLS port, chosen per connection. Livery owns the listen socket
+  (`livery_h1h2`), handshakes off the accept path, reads the negotiated
+  protocol, and hands the socket to `h2:serve_socket/2` or
+  `h1:serve_socket/2`; a client that offered no ALPN is served HTTP/1.1
+  rather than dropped. The list is server preference order, so
+  `[h2, http1]` means h2 wins when a client offers both. `alpn` defaults
+  to `[h2]`, which is the previous h2-only behaviour.
+- The H1 listener forwards h1's parser size limits: `max_line_length`,
+  `max_request_line_size`, `max_empty_lines`, `max_header_name_size`,
+  `max_header_value_size`, `max_headers`, `max_header_block_size`, and
+  `pipeline`. They were selectable in h1 but unreachable through livery.
+- `verify => verify_peer` on the H1 and H2 listeners, for mutual TLS.
+  It requires `cacerts` and makes the client certificate mandatory; h1
+  gained the option in 0.9.0, so it no longer silently does nothing on
+  the H1 listener.
+- The service's `host` is now used: with it set, `alt_svc => advertise`
+  emits an authority-qualified `Alt-Svc` (`h3="example.com:443"`)
+  instead of the port-only form. It was documented but read by nothing.
+- `livery_service:listener_opts()` declares the options that already
+  worked but went undeclared (`transport`, `ssl_opts`, the H1 timeouts,
+  `settings`, `enable_connect_protocol`, ...) and says that anything
+  else is forwarded to the adapter's own `listen_opts()`.
+  `livery_h3:listen_opts()` declares `pool_size`.
+
+### Changed
+
+- **Breaking.** `livery:which_listeners/1` maps each protocol to a
+  *list* of ports rather than a single port. One port can serve two
+  protocols (an `alpn` listener) and one protocol can be on two ports (a
+  cleartext `http` listener next to an `alpn` one), neither of which the
+  old shape could express. `maps:get(h1, Listeners)` becomes
+  `hd(maps:get(h1, Listeners))`.
+- **Breaking for adapter callers.** The H1 and H2 `stream()` handle is
+  now `{Connection, StreamId, Alpn}`. `peer_info/1` reports the ALPN the
+  connection actually negotiated instead of a constant: `undefined` on a
+  cleartext listener, and `undefined` for a TLS client that offered no
+  ALPN.
+- H2 requests carry `tls => #{}` on a TLS listener, as H1 requests
+  already did, so `livery_req:tls/1` distinguishes h2 from h2c.
+
+### Dependencies
+
+- `h1` 0.9.0 (`serve_socket/2`, `verify`, `max_request_line_size`) and
+  `h2` 0.12.0 (`serve_socket/2`).
+- `webtransport` 0.4.5, which moves to `h2 ~> 0.12` so the WebTransport
+  path and the listeners agree on one h2.
+- `hackney` 4.7.4, which stops a wedged or timed-out connection from
+  taking down the pool it belongs to, and with it every caller of that
+  pool. `livery_client` runs on that pool.
+
 ## [0.7.0] - 2026-08-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ livery:start_service(#{
 }).
 ```
 
+Add `alpn => [h2, http1]` to the `https` map and that one TLS port
+serves HTTP/2 and HTTP/1.1, chosen per connection:
+
+```erlang
+https => #{port => 443, cert => Cert, key => Key, alpn => [h2, http1]}
+```
+
 Need just one protocol? `livery:start_listener(livery_h1, #{port => 8080,
 router => Router})`.
 

--- a/docs/concepts/adapters.md
+++ b/docs/concepts/adapters.md
@@ -55,6 +55,22 @@ The test adapter is the one to read first: it is the smallest complete
 implementation, and the parity SUITE drives one handler set through every
 adapter to prove they behave the same.
 
+## The ALPN listener
+
+`livery_h1h2` is a listener, not an adapter. It owns one TLS port,
+resolves ALPN itself, and hands each connection to `h2:serve_socket/2`
+or `h1:serve_socket/2`; a client that offered no ALPN goes to HTTP/1.1,
+since ALPN is what makes h2 over TLS possible in the first place.
+
+Requests still dispatch through `livery_h1` and `livery_h2`, so from a
+handler's side nothing changes: `livery_req:protocol/1` is the protocol
+that connection negotiated, and `peer_info/1`'s `alpn` is the exact
+value ALPN settled on (`undefined` when the client offered none, or when
+the listener is cleartext).
+
+Reach it with `https => #{..., alpn => [h2, http1]}` on a service, or
+`livery:start_listener(livery_h1h2, Opts)` directly.
+
 ## What an adapter is not
 
 - **Not a state machine.** Framing, header compression, flow control, and

--- a/docs/design.md
+++ b/docs/design.md
@@ -150,9 +150,11 @@ livery:start_service(#{
 }).
 ```
 
-One call brings up H3 on UDP:443, H2 on TLS:443, and H1 on TCP:80.
-Responses on H1 and H2 carry `Alt-Svc: h3=":443"`, so clients race
-and upgrade to H3 on the next request.
+One call brings up H3 on UDP:443, H2 and H1 together on TLS:443
+(ALPN picks per connection), and H1 on TCP:80. Responses on H1 and
+H2 carry `Alt-Svc: h3="example.com:443"`, so clients race and
+upgrade to H3 on the next request; without a `host` the advertised
+authority is port-only, `h3=":443"`.
 
 ### 6.3 Extractors
 

--- a/docs/guides/bind-listen-address.md
+++ b/docs/guides/bind-listen-address.md
@@ -24,12 +24,11 @@ Each key in `start_service/1` is one adapter serving one protocol:
 | Key | Protocol | Transport |
 |---|---|---|
 | `http` | HTTP/1.1 | cleartext TCP |
-| `https` | HTTP/2 | TLS (needs `cert`/`key`) |
+| `https` | HTTP/2, or HTTP/2 and HTTP/1.1 by ALPN | TLS (needs `cert`/`key`) |
 | `http3` | HTTP/3 | QUIC (needs `cert`/`key`) |
 
-So `http` is HTTP/1.1 only, *not* HTTP/1.1 plus HTTP/2. To serve more
-than one protocol, list more than one key, which is what the examples
-below do.
+`http` is HTTP/1.1 only, *not* HTTP/1.1 plus HTTP/2, so serving both
+cleartext and TLS still means listing both keys.
 
 The transport shown is the default per key, but `http` and `https` take
 a `transport` override. The useful one is **h2c**, HTTP/2 over cleartext
@@ -45,6 +44,34 @@ You can likewise run HTTP/1.1 over TLS by giving the `http` map a
 `transport => ssl` with `cert`/`key`. Add `alt_svc => advertise` to the
 service map to put an `Alt-Svc` header on the H1 and H2 responses so
 capable clients can upgrade to H3.
+
+### Serve HTTP/2 and HTTP/1.1 on one TLS port
+
+Give `https` an `alpn` list and the listener advertises both protocols,
+picking one per connection from what the client offered:
+
+```erlang
+livery:start_service(#{
+    https  => #{port => 443, cert => Cert, key => Key,
+                alpn => [h2, http1]},
+    router => Router
+}).
+```
+
+Order is server preference, so `[h2, http1]` means h2 wins whenever a
+client offers both. A client offering only `http/1.1`, and one that
+sends no ALPN at all, are both served over HTTP/1.1.
+
+The default is `alpn => [h2]`: an `https` key without it stays an
+h2-only listener, and an HTTP/1.1-only client cannot handshake with it.
+
+`which_listeners/1` reports the one port under both protocols, and
+`livery_req:protocol/1` gives each request the protocol its own
+connection negotiated:
+
+```erlang
+#{h1 := [443], h2 := [443]} = livery:which_listeners(Pid).
+```
 
 ### Starting an adapter: on its own, or as a service
 
@@ -255,7 +282,10 @@ listener's bind address and family. Bind the listener to IPv6 and a
 - For HTTP/3 the options fold into the QUIC listener's
   `extra_socket_opts`; any `extra_socket_opts` you set yourself are
   preserved.
-- `livery_service:which_listeners/1` reports the bound ports.
+- `livery_service:which_listeners/1` reports the bound ports, as a list
+  per protocol. One port can appear under two protocols (an `alpn`
+  listener), and one protocol under two ports (a cleartext `http`
+  listener next to an `alpn` one).
 
 ## See also
 

--- a/rebar.config
+++ b/rebar.config
@@ -6,13 +6,13 @@
 
 {deps, [
     {mimerl, "1.5.0"},
-    {h1, "~> 0.8.0", {pkg, erlang_h1}},
-    {h2, "~> 0.11.0"},
+    {h1, "~> 0.9.0", {pkg, erlang_h1}},
+    {h2, "~> 0.12.0"},
     {quic, "~> 1.8.0"},
     {ws, "~> 0.5.0", {pkg, erlang_ws}},
     {instrument, "~> 1.1.5"},
-    {webtransport, "~> 0.4.4"},
-    {hackney, "~> 4.7.3"},
+    {webtransport, "~> 0.4.5"},
+    {hackney, "~> 4.7.4"},
     {barrel_mcp, "~> 2.3.0"}
 ]}.
 
@@ -287,7 +287,7 @@
             livery_instrument_trace
         ]},
         {<<"WebSocket and WebTransport">>, [livery_ws, livery_wt]},
-        {<<"Adapters">>, [livery_adapter, livery_test_adapter]},
+        {<<"Adapters">>, [livery_adapter, livery_h1h2, livery_test_adapter]},
         {<<"Body reader">>, [livery_body]},
         {<<"Runtime">>, [
             livery_app,
@@ -330,6 +330,12 @@
                 %% resp/0 as the public request/response value types.
                 %% livery_client is the client's public facade (verbs,
                 %% accessors, layer and sugar constructors), like livery_req/resp.
+                %% The listener option maps mirror the option sets the
+                %% wire libraries themselves accept; splitting them would
+                %% hide what a listener takes.
+                {elvis_style, max_map_type_keys, #{
+                    ignore => [livery_h1, livery_h1h2, livery_service]
+                }},
                 {elvis_style, no_god_modules, #{
                     ignore => [livery_req, livery_resp, livery_client]
                 }},
@@ -372,8 +378,17 @@
                 %% Per-stream translators (and the client push-stream relay)
                 %% block on receive and exit on the monitored peer's DOWN, so an
                 %% after clause is wrong.
+                %% livery_h1h2's per-connection process blocks on the
+                %% DOWN of the connection it handed the socket to; its
+                %% lifetime is the connection's, so a timeout is wrong.
                 {elvis_style, no_receive_without_timeout, #{
-                    ignore => [livery_h1, livery_h2, livery_h3, livery_client_hackney]
+                    ignore => [
+                        livery_h1,
+                        livery_h1h2,
+                        livery_h2,
+                        livery_h3,
+                        livery_client_hackney
+                    ]
                 }},
                 %% Internal records used directly in specs; introducing a
                 %% wrapper type would not add clarity.

--- a/src/livery.app.src
+++ b/src/livery.app.src
@@ -1,6 +1,6 @@
 {application, livery, [
     {description, "Livery: a modern Erlang web framework over HTTP/1.1, HTTP/2, and HTTP/3"},
-    {vsn, "0.7.0"},
+    {vsn, "0.8.0"},
     {registered, [livery_sup]},
     {mod, {livery_app, []}},
     {applications, [

--- a/src/livery.erl
+++ b/src/livery.erl
@@ -32,12 +32,14 @@ one wire; for multi-protocol services with Alt-Svc, use
 `start_service/1`.
 
 `Name` selects the adapter (`livery_h1`, `livery_h2`, or
-`livery_h3`). `Opts` is the adapter's `listen_opts()` map.
+`livery_h3`), or `livery_h1h2` for one TLS port serving HTTP/2 and
+HTTP/1.1 by ALPN. `Opts` is that module's `listen_opts()` map.
 """.
 -spec start_listener(atom(), map()) -> {ok, term()} | {error, term()}.
 start_listener(livery_h1, Opts) -> livery_h1:start(Opts);
 start_listener(livery_h2, Opts) -> livery_h2:start(Opts);
 start_listener(livery_h3, Opts) -> livery_h3:start(Opts);
+start_listener(livery_h1h2, Opts) -> livery_h1h2:start(Opts);
 start_listener(_Name, _Opts) -> {error, unknown_adapter}.
 
 -doc "Stop a single-protocol listener by adapter and handle.".
@@ -45,11 +47,13 @@ start_listener(_Name, _Opts) -> {error, unknown_adapter}.
     {livery_h1, livery_h1:listener()}
     | {livery_h2, livery_h2:listener()}
     | {livery_h3, livery_h3:listener()}
+    | {livery_h1h2, livery_h1h2:listener()}
     | term()
 ) -> ok | {error, term()}.
 stop_listener({livery_h1, Ref}) -> livery_h1:stop(Ref);
 stop_listener({livery_h2, Ref}) -> livery_h2:stop(Ref);
 stop_listener({livery_h3, Ref}) -> livery_h3:stop(Ref);
+stop_listener({livery_h1h2, Ref}) -> livery_h1h2:stop(Ref);
 stop_listener(_) -> {error, unknown_listener}.
 
 -doc """
@@ -88,7 +92,7 @@ List the bound ports of a running service, keyed by protocol.
 
 Returns a map containing only the protocols that were configured.
 """.
--spec which_listeners(pid()) -> #{h1 | h2 | h3 => inet:port_number()}.
+-spec which_listeners(pid()) -> #{h1 | h2 | h3 => [inet:port_number()]}.
 which_listeners(Pid) when is_pid(Pid) ->
     livery_service:which_listeners(Pid).
 

--- a/src/livery_h1.erl
+++ b/src/livery_h1.erl
@@ -31,8 +31,42 @@ content-length write via `send_full/5` -> `h1:respond/5`.
 %% with the `max_body' option (`infinity' disables it).
 -define(DEFAULT_MAX_BODY, 16 * 1024 * 1024).
 
+%% Options that configure the listen socket and the acceptor pool. They
+%% only apply when livery owns the listen socket, so `serve_opts/2' drops
+%% them.
+-define(LISTEN_KEYS, [
+    ip,
+    inet6,
+    cert,
+    key,
+    cacerts,
+    verify,
+    ssl_opts,
+    acceptors,
+    handshake_timeout
+]).
+
+%% Per-connection options. h1 selects exactly this set into its connection
+%% opts, so both the listener and the serve-an-accepted-socket path forward
+%% all of them.
+-define(CONN_KEYS, [
+    idle_timeout,
+    request_timeout,
+    early_response_drain,
+    lingering_timeout,
+    max_keepalive_requests,
+    pipeline,
+    max_line_length,
+    max_request_line_size,
+    max_empty_lines,
+    max_header_name_size,
+    max_header_value_size,
+    max_headers,
+    max_header_block_size
+]).
+
 %% Public API
--export([start/1, stop_accepting/1, accept_ws/4]).
+-export([start/1, stop_accepting/1, accept_ws/4, serve_opts/2]).
 
 %% livery_adapter callbacks
 -export([
@@ -51,7 +85,11 @@ content-length write via `send_full/5` -> `h1:respond/5`.
 -export_type([listen_opts/0, listener/0, stream/0]).
 
 -type listener() :: h1:server_ref().
--type stream() :: {h1:connection(), h1:stream_id()}.
+%% The third element is the protocol ALPN settled on for this connection
+%% (`undefined` when the client offered none, or when the listener is
+%% cleartext). It is carried here rather than looked up because only the
+%% process that handshaked the socket ever knows it.
+-type stream() :: {h1:connection(), h1:stream_id(), binary() | undefined}.
 
 -type listen_opts() :: #{
     port => inet:port_number(),
@@ -63,6 +101,10 @@ content-length write via `send_full/5` -> `h1:respond/5`.
     cert => binary() | string(),
     key => binary() | string(),
     cacerts => [binary()],
+    %% Client-certificate policy. `verify_peer' asks for (and requires) a
+    %% client certificate and needs `cacerts'; h1 rejects the pair otherwise
+    %% rather than listening with authentication silently off.
+    verify => verify_none | verify_peer,
     ssl_opts => [ssl:tls_server_option()],
     acceptors => pos_integer(),
     %% Authoritative request-body ceiling: a body past it yields a graceful
@@ -86,6 +128,20 @@ content-length write via `send_full/5` -> `h1:respond/5`.
     early_response_drain => 0 | {non_neg_integer() | infinity, non_neg_integer() | infinity},
     lingering_timeout => timeout(),
     max_keepalive_requests => pos_integer() | infinity,
+    %% Serve pipelined requests concurrently rather than one at a time.
+    pipeline => boolean(),
+    %% Parser size limits, passed through to `h1'. All have finite defaults
+    %% there; tighten them for an edge-facing listener. `max_request_line_size'
+    %% caps the whole request line (method + target + version) and yields 414,
+    %% `max_line_length' only bounds an unterminated line. Header breaches
+    %% yield 431. Requires erlang_h1 >= 0.9.0 for `max_request_line_size'.
+    max_line_length => pos_integer(),
+    max_request_line_size => pos_integer() | infinity,
+    max_empty_lines => non_neg_integer(),
+    max_header_name_size => pos_integer(),
+    max_header_value_size => pos_integer(),
+    max_headers => pos_integer(),
+    max_header_block_size => pos_integer(),
     %% Shared service config, readable in handlers via livery_req:config/1.
     config => term(),
     stack := livery_middleware:stack(),
@@ -145,7 +201,7 @@ stop_accepting(Listener) ->
     livery_adapter:send_opts()
 ) ->
     livery_adapter:send_result().
-send_headers({Conn, StreamId}, Status, Headers, Opts) ->
+send_headers({Conn, StreamId, _Alpn}, Status, Headers, Opts) ->
     closed_guard(fun() ->
         case {maps:get(end_stream, Opts, false), drain_opts(Opts)} of
             {true, {ok, RespOpts}} ->
@@ -174,7 +230,7 @@ send_headers({Conn, StreamId}, Status, Headers, Opts) ->
 %% path which frames the body as chunked. livery:emit/3 picks this up
 %% because the callback is exported. A per-response early-response drain
 %% budget routes through respond/6 so h1 honors it on an early close.
-send_full({Conn, StreamId}, Status, Headers, IoData, Opts) ->
+send_full({Conn, StreamId, _Alpn}, Status, Headers, IoData, Opts) ->
     closed_guard(fun() ->
         case drain_opts(Opts) of
             {ok, RespOpts} -> h1:respond(Conn, StreamId, Status, Headers, IoData, RespOpts);
@@ -184,13 +240,13 @@ send_full({Conn, StreamId}, Status, Headers, IoData, Opts) ->
 
 -spec send_data(stream(), iodata(), livery_adapter:send_opts()) ->
     livery_adapter:send_result().
-send_data({Conn, StreamId}, IoData, Opts) ->
+send_data({Conn, StreamId, _Alpn}, IoData, Opts) ->
     EndStream = maps:get(end_stream, Opts, false),
     closed_guard(fun() -> h1:send_data(Conn, StreamId, IoData, EndStream) end).
 
 -spec send_trailers(stream(), [{binary(), binary()}]) ->
     livery_adapter:send_result().
-send_trailers({Conn, StreamId}, Trailers) ->
+send_trailers({Conn, StreamId, _Alpn}, Trailers) ->
     closed_guard(fun() -> h1:send_trailers(Conn, StreamId, Trailers) end).
 
 %% A send to a connection whose process has gone away (peer closed) exits
@@ -209,17 +265,17 @@ closed_guard(Fun) ->
 
 -spec send_informational(stream(), 100..199, [{binary(), binary()}]) ->
     livery_adapter:send_result().
-send_informational({Conn, StreamId}, Status, Headers) ->
+send_informational({Conn, StreamId, _Alpn}, Status, Headers) ->
     closed_guard(fun() -> h1:send_informational(Conn, StreamId, Status, Headers) end).
 
 -spec reset(stream(), term()) -> ok.
-reset({Conn, StreamId}, Reason) ->
+reset({Conn, StreamId, _Alpn}, Reason) ->
     _ = h1:cancel_stream(Conn, StreamId, Reason),
     ok.
 
 -spec peer_info(stream()) -> livery_adapter:peer_info().
-peer_info({Conn, _StreamId}) ->
-    #{peer => conn_peer(Conn), tls => undefined, alpn => <<"http/1.1">>}.
+peer_info({Conn, _StreamId, Alpn}) ->
+    #{peer => conn_peer(Conn), tls => undefined, alpn => Alpn}.
 
 %% The h1 connection records the peer at accept time (h1 >= 0.8.0).
 -spec conn_peer(h1:connection()) ->
@@ -283,7 +339,7 @@ handshake or socket transfer failure.
     term()
 ) ->
     {ok, pid()} | {error, term()}.
-accept_ws({Conn, StreamId}, Req, HandlerMod, Opts) ->
+accept_ws({Conn, StreamId, _Alpn}, Req, HandlerMod, Opts) ->
     {ValidateOpts, AcceptOpts0} = livery_ws:handshake_opts(Opts),
     Headers = livery_req:headers(Req),
     case ws_h1_upgrade:validate_request(Headers, ValidateOpts) of
@@ -356,10 +412,45 @@ ws_transport(Req) ->
     livery_middleware:handler()
 ) -> map().
 build_h1_opts(Opts, Stack, Handler) ->
-    MaxBody = maps:get(max_body, Opts, ?DEFAULT_MAX_BODY),
     Transport = maps:get(transport, Opts, tcp),
-    Base = #{
-        transport => Transport,
+    Base = conn_base(Opts, Stack, Handler, Transport, listener_alpn(Transport)),
+    copy_keys(?LISTEN_KEYS ++ ?CONN_KEYS, Opts, Base#{transport => Transport}).
+
+%% A dedicated TLS listener advertises `http/1.1' and nothing else, so
+%% that is what ALPN settles on; a cleartext listener negotiates nothing.
+%% The multiplexed listener knows the real value and passes it to
+%% `serve_opts/1' instead.
+-spec listener_alpn(tcp | ssl) -> binary() | undefined.
+listener_alpn(ssl) -> <<"http/1.1">>;
+listener_alpn(tcp) -> undefined.
+
+-doc """
+Build the `h1:serve_socket/2` option map for a socket the caller
+already accepted and handshaked.
+
+Used by `livery_h1h2` after ALPN settles on `http/1.1`. `Opts` is
+the listener's `listen_opts()`; `Alpn` is the protocol actually
+negotiated (`undefined` when the client offered none). Listen-time
+keys (`cert`, `acceptors`, ...) are dropped: the socket is already
+up, so only the per-connection options apply.
+""".
+-spec serve_opts(listen_opts(), binary() | undefined) -> map().
+serve_opts(Opts, Alpn) ->
+    Stack = maps:get(stack, Opts),
+    Handler = maps:get(handler, Opts),
+    Base = conn_base(Opts, Stack, Handler, ssl, Alpn),
+    copy_keys(?CONN_KEYS, Opts, Base).
+
+-spec conn_base(
+    listen_opts(),
+    livery_middleware:stack(),
+    livery_middleware:handler(),
+    tcp | ssl,
+    binary() | undefined
+) -> map().
+conn_base(Opts, Stack, Handler, Transport, Alpn) ->
+    MaxBody = maps:get(max_body, Opts, ?DEFAULT_MAX_BODY),
+    #{
         %% Disable h1's own parser-level body cap and enforce `max_body' in
         %% the translator instead. h1's parser runs upstream of the translate
         %% cap and, on exceed, tears the connection down, which would pre-empt
@@ -369,28 +460,9 @@ build_h1_opts(Opts, Stack, Handler) ->
         %% erlang_h1 >= 0.7.1, which forwards max_body_size from server opts.
         max_body_size => infinity,
         handler => make_handler_fun(
-            Stack, Handler, MaxBody, maps:get(config, Opts, undefined), Transport
+            Stack, Handler, MaxBody, maps:get(config, Opts, undefined), Transport, Alpn
         )
-    },
-    copy_keys(
-        [
-            ip,
-            inet6,
-            cert,
-            key,
-            cacerts,
-            ssl_opts,
-            acceptors,
-            handshake_timeout,
-            idle_timeout,
-            request_timeout,
-            early_response_drain,
-            lingering_timeout,
-            max_keepalive_requests
-        ],
-        Opts,
-        Base
-    ).
+    }.
 
 -spec copy_keys([atom()], map(), map()) -> map().
 copy_keys([], _Src, Dst) ->
@@ -406,7 +478,8 @@ copy_keys([K | Rest], Src, Dst) ->
     livery_middleware:handler(),
     non_neg_integer() | infinity,
     term(),
-    tcp | ssl
+    tcp | ssl,
+    binary() | undefined
 ) ->
     fun(
         (
@@ -417,7 +490,7 @@ copy_keys([K | Rest], Src, Dst) ->
             h1:headers()
         ) -> ok
     ).
-make_handler_fun(Stack, Handler, MaxBody, Config, Transport) ->
+make_handler_fun(Stack, Handler, MaxBody, Config, Transport, Alpn) ->
     fun(Conn, StreamId, Method, Path, Headers) ->
         dispatch_request(
             Conn,
@@ -429,7 +502,8 @@ make_handler_fun(Stack, Handler, MaxBody, Config, Transport) ->
             Handler,
             MaxBody,
             Config,
-            Transport
+            Transport,
+            Alpn
         )
     end.
 
@@ -443,10 +517,11 @@ make_handler_fun(Stack, Handler, MaxBody, Config, Transport) ->
     livery_middleware:handler(),
     non_neg_integer() | infinity,
     term(),
-    tcp | ssl
+    tcp | ssl,
+    binary() | undefined
 ) -> ok.
 dispatch_request(
-    Conn, StreamId, Method, Path, Headers, Stack, Handler, MaxBody, Config, Transport
+    Conn, StreamId, Method, Path, Headers, Stack, Handler, MaxBody, Config, Transport, Alpn
 ) ->
     %% This function runs in the per-request worker spawned by
     %% h1_server. Body and trailer events arrive as
@@ -456,7 +531,8 @@ dispatch_request(
     DiscRef = make_ref(),
     Reader = livery_body:new(BodyRef),
     {RawPath, RawQuery} = split_query(Path),
-    Req = build_req(Conn, StreamId, Method, RawPath, Headers, Reader, Transport),
+    Stream = {Conn, StreamId, Alpn},
+    Req = build_req(Stream, Method, RawPath, Headers, Reader, Transport),
     %% The dispatch process (this one) runs the translator loop, so it
     %% is the disconnect notifier the handler registers with.
     Req1 = Req#livery_req{
@@ -468,7 +544,7 @@ dispatch_request(
     case
         livery_req_sup:start_request(#{
             adapter => ?MODULE,
-            stream => {Conn, StreamId},
+            stream => Stream,
             req => Req1,
             stack => Stack,
             handler => Handler
@@ -484,7 +560,7 @@ dispatch_request(
                 StreamId, BodyRef, DiscRef, Conn, WorkerPid, WMRef, CMRef, [], false, MaxBody, 0
             );
         {error, _} ->
-            reject_overload({Conn, StreamId})
+            reject_overload(Stream)
     end.
 
 %% No worker slot available (concurrency cap reached): answer 503 and
@@ -500,15 +576,14 @@ reject_overload(Stream) ->
     ok.
 
 -spec build_req(
-    h1:connection(),
-    h1:stream_id(),
+    stream(),
     binary(),
     binary(),
     h1:headers(),
     livery_body:reader(),
     tcp | ssl
 ) -> livery_req:req().
-build_req(Conn, StreamId, Method, Path, Headers, Reader, Transport) ->
+build_req({Conn, _StreamId, _Alpn} = Stream, Method, Path, Headers, Reader, Transport) ->
     livery_req:new(#{
         protocol => h1,
         method => Method,
@@ -516,7 +591,7 @@ build_req(Conn, StreamId, Method, Path, Headers, Reader, Transport) ->
         headers => Headers,
         body => {stream, Reader},
         adapter => ?MODULE,
-        stream => {Conn, StreamId},
+        stream => Stream,
         engine_pid => Conn,
         peer => conn_peer(Conn),
         tls => tls_info(Transport)

--- a/src/livery_h1h2.erl
+++ b/src/livery_h1h2.erl
@@ -1,0 +1,424 @@
+-module(livery_h1h2).
+-moduledoc """
+One TLS listener serving HTTP/2 and HTTP/1.1, chosen per connection
+by ALPN.
+
+Livery owns the listen socket here rather than delegating it to `h1`
+or `h2`, because only the process that ran the handshake knows which
+protocol the client asked for. Per connection the listener:
+
+1. Accepts, then hands the socket to a fresh process, so a stalled
+   handshake never blocks the accept queue.
+2. Runs `ssl:handshake/2` and reads `ssl:negotiated_protocol/1`.
+3. Calls `h2:serve_socket/2` for `h2`, and `h1:serve_socket/2` for
+   `http/1.1` and for a client that offered no ALPN at all.
+4. Stays alive for the connection's lifetime: `serve_socket/2` links
+   the connection to its caller, so the process that dispatched is
+   the one the connection dies with.
+
+Requests dispatch through `livery_h1` and `livery_h2` exactly as on
+the dedicated listeners, so handlers, middleware, and
+`livery_req:protocol/1` see the real per-connection protocol. The
+negotiated ALPN travels on the stream and comes back out of
+`Adapter:peer_info/1`.
+
+The server prefers the protocols in the order `alpn` lists them, so
+the default `[h2, http1]` means h2 wins whenever a client offers
+both.
+""".
+
+-behaviour(gen_server).
+
+-export([start/1, start/3, stop/1, stop_accepting/1, server_port/1]).
+
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+-export_type([listen_opts/0, listener/0, protocol/0]).
+
+-define(DEFAULT_HANDSHAKE_TIMEOUT, 30000).
+-define(H2, <<"h2">>).
+-define(HTTP1, <<"http/1.1">>).
+
+-type listener() :: {pid(), inet:port_number()}.
+-type protocol() :: h2 | http1.
+
+-type listen_opts() :: #{
+    port => inet:port_number(),
+    %% Bind address. An IPv6 8-tuple selects the inet6 family.
+    ip => inet:ip_address(),
+    %% Bind the IPv6 wildcard (`::') when no explicit `ip' is given.
+    inet6 => boolean(),
+    %% Required in practice: without both, `start/1' returns
+    %% `{error, {missing_required_option, [cert, key]}}'.
+    cert => binary() | string(),
+    key => binary() | string(),
+    cacerts => [binary()],
+    verify => verify_none | verify_peer,
+    ssl_opts => [ssl:tls_server_option()],
+    %% Protocols to advertise, most preferred first. Defaults to
+    %% `[h2, http1]'.
+    alpn => [protocol()],
+    acceptors => pos_integer(),
+    handshake_timeout => timeout(),
+    stack := livery_middleware:stack(),
+    handler := livery_middleware:handler(),
+    %% The rest of the map is forwarded whole to the adapter that ends
+    %% up serving each connection, so `livery_h1:listen_opts()' and
+    %% `livery_h2:listen_opts()' are the full lists of what else is
+    %% understood here (`max_body', h1's parser size limits, h2's
+    %% `settings', ...).
+    atom() => term()
+}.
+
+-record(state, {
+    listen :: ssl:sslsocket() | undefined,
+    port :: inet:port_number(),
+    acceptors = [] :: [pid()],
+    conns = #{} :: #{pid() => true},
+    conn_args :: conn_args()
+}).
+
+-type state() :: #state{}.
+-type conn_args() :: #{
+    handshake_timeout := timeout(),
+    h2 := map(),
+    http1 := map(),
+    no_alpn := map()
+}.
+
+%%====================================================================
+%% Public API
+%%====================================================================
+
+-doc """
+Start a multiplexed TLS listener.
+
+`Opts` must include `cert`, `key`, `stack`, and `handler`. `port`
+defaults to 0 (random port). Returns a handle for `stop/1`,
+`stop_accepting/1`, and `server_port/1`.
+""".
+-spec start(listen_opts()) -> {ok, listener()} | {error, term()}.
+start(Opts) when is_map(Opts) ->
+    start(undefined, Opts, #{}).
+
+-spec start(atom() | undefined, listen_opts(), map()) ->
+    {ok, listener()} | {error, term()}.
+start(_Name, Opts, _StartOpts) ->
+    case gen_server:start(?MODULE, Opts, []) of
+        {ok, Pid} -> {ok, {Pid, gen_server:call(Pid, port)}};
+        {error, _} = Error -> Error
+    end.
+
+-doc """
+Stop the listener. Synchronous: closes the listen socket and every
+accepted connection before returning.
+""".
+-spec stop(listener()) -> ok.
+stop({Pid, _Port}) ->
+    try
+        gen_server:stop(Pid)
+    catch
+        exit:_ -> ok
+    end.
+
+-doc """
+Stop accepting new connections while continuing to serve the
+established ones. Call `stop/1` afterwards to close them.
+""".
+-spec stop_accepting(listener()) -> ok.
+stop_accepting({Pid, _Port}) ->
+    try
+        gen_server:call(Pid, stop_accepting)
+    catch
+        exit:_ -> ok
+    end.
+
+-doc "The port the listener bound to.".
+-spec server_port(listener()) -> inet:port_number().
+server_port({_Pid, Port}) -> Port.
+
+%%====================================================================
+%% gen_server callbacks
+%%====================================================================
+
+-spec init(listen_opts()) -> {ok, state()} | {stop, term()}.
+init(Opts) ->
+    process_flag(trap_exit, true),
+    case ssl_listen_opts(Opts) of
+        {ok, SslOpts} -> listen(Opts, SslOpts);
+        {error, Reason} -> {stop, Reason}
+    end.
+
+-spec handle_call(term(), {pid(), term()}, state()) ->
+    {reply, term(), state()}.
+handle_call(port, _From, State) ->
+    {reply, State#state.port, State};
+handle_call(new_connection, _From, #state{listen = undefined} = State) ->
+    {reply, {error, stopping}, State};
+handle_call(new_connection, _From, State) ->
+    Args = State#state.conn_args,
+    Pid = spawn_link(fun() -> connection_init(Args) end),
+    {reply, {ok, Pid}, State#state{conns = maps:put(Pid, true, State#state.conns)}};
+handle_call(stop_accepting, _From, State) ->
+    %% Closing the listen socket is what stops the accept loops; each
+    %% acceptor sees `{error, closed}' and exits. Connections already
+    %% established keep running.
+    _ = close_listen(State#state.listen),
+    {reply, ok, State#state{listen = undefined, acceptors = []}};
+handle_call(_, _, State) ->
+    {reply, {error, unknown_call}, State}.
+
+-spec handle_cast(term(), state()) -> {noreply, state()}.
+handle_cast(_, State) -> {noreply, State}.
+
+-spec handle_info(term(), state()) -> {noreply, state()}.
+handle_info({'EXIT', Pid, _Reason}, State) ->
+    {noreply, forget(Pid, State)};
+handle_info(_, State) ->
+    {noreply, State}.
+
+-spec terminate(term(), state()) -> ok.
+terminate(_Reason, State) ->
+    _ = close_listen(State#state.listen),
+    %% A `normal' gen_server exit does not reach linked processes that do
+    %% not trap exits, so the connections are killed explicitly. Each one
+    %% takes its `serve_socket/2' peer, and with it the socket, down.
+    _ = [exit(Pid, kill) || Pid <- maps:keys(State#state.conns)],
+    ok.
+
+-spec code_change(term(), state(), term()) -> {ok, state()}.
+code_change(_, State, _) -> {ok, State}.
+
+%%====================================================================
+%% Internals: listener
+%%====================================================================
+
+listen(Opts, SslOpts) ->
+    case ssl:listen(maps:get(port, Opts, 0), SslOpts) of
+        {ok, Listen} ->
+            {ok, {_Addr, Bound}} = ssl:sockname(Listen),
+            State = #state{
+                listen = Listen,
+                port = Bound,
+                conn_args = conn_args(Opts)
+            },
+            {ok, start_acceptors(State, acceptor_count(Opts))};
+        {error, Reason} ->
+            {stop, {listen_failed, Reason}}
+    end.
+
+acceptor_count(Opts) ->
+    maps:get(acceptors, Opts, erlang:system_info(schedulers)).
+
+%% Precompute the three per-connection option maps: one per protocol the
+%% dispatch can land on. Only the ALPN they record differs, and it is
+%% fixed per branch, so nothing has to be rebuilt per connection.
+conn_args(Opts) ->
+    #{
+        handshake_timeout => maps:get(handshake_timeout, Opts, ?DEFAULT_HANDSHAKE_TIMEOUT),
+        h2 => livery_h2:serve_opts(Opts, ?H2),
+        http1 => livery_h1:serve_opts(Opts, ?HTTP1),
+        no_alpn => livery_h1:serve_opts(Opts, undefined)
+    }.
+
+start_acceptors(State, Count) ->
+    Listen = State#state.listen,
+    Self = self(),
+    Pids = [spawn_link(fun() -> acceptor_loop(Self, Listen) end) || _ <- lists:seq(1, Count)],
+    State#state{acceptors = Pids}.
+
+%% Drop a dead child. An acceptor that died while we are still accepting
+%% is replaced so the pool keeps its width; one that died because the
+%% listen socket closed is simply forgotten.
+forget(Pid, #state{listen = undefined} = State) ->
+    State#state{
+        acceptors = State#state.acceptors -- [Pid],
+        conns = maps:remove(Pid, State#state.conns)
+    };
+forget(Pid, State) ->
+    case lists:member(Pid, State#state.acceptors) of
+        true ->
+            Self = self(),
+            Listen = State#state.listen,
+            New = spawn_link(fun() -> acceptor_loop(Self, Listen) end),
+            State#state{acceptors = [New | State#state.acceptors -- [Pid]]};
+        false ->
+            State#state{conns = maps:remove(Pid, State#state.conns)}
+    end.
+
+close_listen(undefined) -> ok;
+close_listen(Listen) -> ssl:close(Listen).
+
+%%====================================================================
+%% Internals: acceptor
+%%====================================================================
+
+acceptor_loop(Listener, Listen) ->
+    case ssl:transport_accept(Listen) of
+        {ok, Socket} ->
+            handoff(Listener, Socket),
+            acceptor_loop(Listener, Listen);
+        {error, Closed} when Closed =:= closed; Closed =:= einval ->
+            ok;
+        {error, _Transient} ->
+            acceptor_loop(Listener, Listen)
+    end.
+
+%% The handshake runs in the connection process, not here, so a client
+%% that opens a socket and then stalls costs one process instead of one
+%% acceptor slot. The socket is transferred before the process is told
+%% about it, so it never reads from a socket it does not own.
+handoff(Listener, Socket) ->
+    case gen_server:call(Listener, new_connection, infinity) of
+        {ok, Pid} ->
+            case ssl:controlling_process(Socket, Pid) of
+                ok ->
+                    Pid ! {socket, Socket};
+                {error, _} ->
+                    exit(Pid, kill),
+                    _ = ssl:close(Socket),
+                    ok
+            end;
+        {error, stopping} ->
+            _ = ssl:close(Socket),
+            ok
+    end.
+
+%%====================================================================
+%% Internals: per-connection dispatch
+%%====================================================================
+
+connection_init(Args) ->
+    Timeout = maps:get(handshake_timeout, Args),
+    receive
+        {socket, Socket} -> handshake(Socket, Timeout, Args)
+    after Timeout -> ok
+    end.
+
+handshake(Socket, Timeout, Args) ->
+    case ssl:handshake(Socket, Timeout) of
+        {ok, Tls} ->
+            dispatch(Tls, Args);
+        {error, _Reason} ->
+            _ = ssl:close(Socket),
+            ok
+    end.
+
+dispatch(Socket, Args) ->
+    case ssl:negotiated_protocol(Socket) of
+        {ok, ?H2} ->
+            serve(fun h2:serve_socket/2, Socket, maps:get(h2, Args));
+        {ok, ?HTTP1} ->
+            serve(fun h1:serve_socket/2, Socket, maps:get(http1, Args));
+        %% No ALPN is not a failure: a client that sent none is speaking
+        %% HTTP/1.1, since RFC 9113 requires ALPN to reach h2 over TLS.
+        {error, protocol_not_negotiated} ->
+            serve(fun h1:serve_socket/2, Socket, maps:get(no_alpn, Args));
+        _Unadvertised ->
+            _ = ssl:close(Socket),
+            ok
+    end.
+
+%% `serve_socket/2' hands the socket to a process linked to this one, so
+%% this process has to outlive the connection: it waits for the peer to
+%% go down, and its own death tears the connection down in turn.
+serve(Serve, Socket, Opts) ->
+    case Serve(Socket, Opts) of
+        {ok, Pid} ->
+            MRef = erlang:monitor(process, Pid),
+            receive
+                {'DOWN', MRef, process, Pid, _Reason} -> ok
+            end;
+        {error, _Reason} ->
+            _ = ssl:close(Socket),
+            ok
+    end.
+
+%%====================================================================
+%% Internals: TLS options
+%%====================================================================
+
+%% Mirrors the option contract h1 and h2 apply to their own listeners:
+%% `verify_peer' requires `cacerts' (so a server asking for client
+%% authentication without a trust anchor fails closed instead of
+%% listening with it silently disabled) and implies a mandatory client
+%% certificate, and user `ssl_opts' merge last so an override still wins.
+ssl_listen_opts(Opts) ->
+    case {maps:find(cert, Opts), maps:find(key, Opts)} of
+        {{ok, Cert}, {ok, Key}} -> ssl_listen_opts(Cert, Key, Opts);
+        _ -> {error, {missing_required_option, [cert, key]}}
+    end.
+
+ssl_listen_opts(Cert, Key, Opts) ->
+    Verify = maps:get(verify, Opts, verify_none),
+    CACerts = maps:get(cacerts, Opts, []),
+    case {Verify, CACerts, alpn_protocols(Opts)} of
+        {verify_peer, [], _} ->
+            {error, verify_peer_requires_cacerts};
+        {_, _, {error, _} = Error} ->
+            Error;
+        {_, _, {ok, Protocols}} ->
+            Base =
+                [
+                    binary,
+                    {active, false},
+                    {packet, raw},
+                    {reuseaddr, true},
+                    {backlog, 1024},
+                    {nodelay, true},
+                    {certfile, to_list(Cert)},
+                    {keyfile, to_list(Key)},
+                    {alpn_preferred_protocols, Protocols},
+                    %% h2 over TLS requires 1.2 or better (RFC 9113 s9.2).
+                    {versions, ['tlsv1.2', 'tlsv1.3']},
+                    {verify, Verify}
+                ] ++ auth_opts(Verify, CACerts) ++ addr_opts(Opts),
+            {ok, merge(Base, maps:get(ssl_opts, Opts, []))}
+    end.
+
+auth_opts(_Verify, []) -> [];
+auth_opts(verify_peer, CACerts) -> [{cacerts, CACerts}, {fail_if_no_peer_cert, true}];
+auth_opts(_Verify, CACerts) -> [{cacerts, CACerts}].
+
+%% Server preference order: ssl picks the first entry the client also
+%% offered, so `[h2, http1]' means h2 wins when both are on the table.
+alpn_protocols(Opts) ->
+    fold_protocols(maps:get(alpn, Opts, [h2, http1]), []).
+
+fold_protocols([], Acc) -> {ok, lists:reverse(Acc)};
+fold_protocols([h2 | Rest], Acc) -> fold_protocols(Rest, [?H2 | Acc]);
+fold_protocols([http1 | Rest], Acc) -> fold_protocols(Rest, [?HTTP1 | Acc]);
+fold_protocols([Other | _], _Acc) -> {error, {unknown_alpn_protocol, Other}}.
+
+%% An IPv6 `ip' tuple selects the inet6 family, as it does on the
+%% dedicated listeners.
+addr_opts(Opts) ->
+    case maps:find(ip, Opts) of
+        {ok, IP} when tuple_size(IP) =:= 8 -> [inet6, {ip, IP}];
+        {ok, IP} -> [{ip, IP}];
+        error -> inet6_opt(maps:get(inet6, Opts, false))
+    end.
+
+inet6_opt(true) -> [inet6];
+inet6_opt(false) -> [].
+
+merge(Base, User) ->
+    lists:foldl(fun replace/2, Base, User).
+
+replace(Opt, Acc) when is_tuple(Opt) ->
+    lists:keystore(element(1, Opt), 1, Acc, Opt);
+replace(Opt, Acc) ->
+    case lists:member(Opt, Acc) of
+        true -> Acc;
+        false -> Acc ++ [Opt]
+    end.
+
+to_list(V) when is_binary(V) -> binary_to_list(V);
+to_list(V) -> V.

--- a/src/livery_h2.erl
+++ b/src/livery_h2.erl
@@ -29,13 +29,18 @@ in `capabilities/1`.
 %% (`infinity' disables it). See livery_h1 for the rationale.
 -define(DEFAULT_MAX_BODY, 16 * 1024 * 1024).
 
+%% Per-connection options: exactly the set h2 selects into its connection
+%% opts, so the listener and the serve-an-accepted-socket path forward the
+%% same ones.
+-define(CONN_KEYS, [settings, enable_connect_protocol]).
+
 %% h2:server_opts() declares `cert' and `key' as required map keys,
 %% which is wrong for h2c (tcp transport). Suppress the cascading
 %% contract-mismatch warning on our entry points until h2's spec
 %% relaxes those keys to optional.
 -dialyzer({nowarn_function, [start/1, start/3]}).
 
--export([start/1, accept_ws/4, accept_wt/4]).
+-export([start/1, accept_ws/4, accept_wt/4, serve_opts/2]).
 
 -export([
     start/3,
@@ -53,7 +58,10 @@ in `capabilities/1`.
 -export_type([listen_opts/0, listener/0, stream/0]).
 
 -type listener() :: h2:server_ref().
--type stream() :: {h2:connection(), h2:stream_id()}.
+%% The third element is the protocol ALPN settled on for this connection
+%% (`undefined` for cleartext h2c). Only the process that handshaked the
+%% socket ever knows it, so it rides along rather than being looked up.
+-type stream() :: {h2:connection(), h2:stream_id(), binary() | undefined}.
 
 -type listen_opts() :: #{
     port => inet:port_number(),
@@ -65,6 +73,10 @@ in `capabilities/1`.
     cert => binary() | string(),
     key => binary() | string(),
     cacerts => [binary()],
+    %% Client-certificate policy. `verify_peer' asks for (and requires) a
+    %% client certificate and needs `cacerts'; h2 rejects the pair otherwise
+    %% rather than listening with authentication silently off.
+    verify => verify_none | verify_peer,
     ssl_opts => [ssl:tls_server_option()],
     acceptors => pos_integer(),
     enable_connect_protocol => boolean(),
@@ -115,7 +127,7 @@ stop(Listener) ->
     livery_adapter:send_opts()
 ) ->
     livery_adapter:send_result().
-send_headers({Conn, StreamId}, Status, Headers, Opts) ->
+send_headers({Conn, StreamId, _Alpn}, Status, Headers, Opts) ->
     closed_guard(fun() ->
         case h2:send_response(Conn, StreamId, Status, Headers) of
             ok ->
@@ -130,7 +142,7 @@ send_headers({Conn, StreamId}, Status, Headers, Opts) ->
 
 -spec send_data(stream(), iodata(), livery_adapter:send_opts()) ->
     livery_adapter:send_result().
-send_data({Conn, StreamId}, IoData, Opts) ->
+send_data({Conn, StreamId, _Alpn}, IoData, Opts) ->
     EndStream = maps:get(end_stream, Opts, false),
     closed_guard(fun() -> h2:send_data(Conn, StreamId, iolist_to_binary(IoData), EndStream) end).
 
@@ -145,14 +157,14 @@ send_data({Conn, StreamId}, IoData, Opts) ->
     livery_adapter:send_opts()
 ) ->
     livery_adapter:send_result().
-send_full({Conn, StreamId}, Status, Headers, IoData, _Opts) ->
+send_full({Conn, StreamId, _Alpn}, Status, Headers, IoData, _Opts) ->
     closed_guard(fun() ->
         h2:respond(Conn, StreamId, Status, Headers, iolist_to_binary(IoData))
     end).
 
 -spec send_trailers(stream(), [{binary(), binary()}]) ->
     livery_adapter:send_result().
-send_trailers({Conn, StreamId}, Trailers) ->
+send_trailers({Conn, StreamId, _Alpn}, Trailers) ->
     closed_guard(fun() -> h2:send_trailers(Conn, StreamId, Trailers) end).
 
 %% Interim responses ride the normal HEADERS path: a 1xx block carries
@@ -160,7 +172,7 @@ send_trailers({Conn, StreamId}, Trailers) ->
 %% follows on the same stream. h2 itself rejects 101 (RFC 9113 §8.6).
 -spec send_informational(stream(), 100..199, [{binary(), binary()}]) ->
     livery_adapter:send_result().
-send_informational({Conn, StreamId}, Status, Headers) ->
+send_informational({Conn, StreamId, _Alpn}, Status, Headers) ->
     closed_guard(fun() -> h2:send_response(Conn, StreamId, Status, Headers) end).
 
 %% A send to a connection whose client has gone away exits the underlying
@@ -181,14 +193,13 @@ closed_guard(Fun) ->
     end.
 
 -spec reset(stream(), term()) -> ok.
-reset({Conn, StreamId}, _Reason) ->
+reset({Conn, StreamId, _Alpn}, _Reason) ->
     _ = h2:cancel(Conn, StreamId),
     ok.
 
 -spec peer_info(stream()) -> livery_adapter:peer_info().
-peer_info({Conn, _StreamId}) ->
-    %% Future: surface ALPN, peer cert, etc. via h2's connection state.
-    #{peer => h2_peer(Conn), tls => undefined, alpn => <<"h2">>}.
+peer_info({Conn, _StreamId, Alpn}) ->
+    #{peer => h2_peer(Conn), tls => undefined, alpn => Alpn}.
 
 -spec capabilities(listener()) -> livery_adapter:capabilities().
 capabilities(_Listener) ->
@@ -213,7 +224,7 @@ driven by the `livery_ws_h2` transport.
 """.
 -spec accept_ws(stream(), livery_req:req(), module(), term()) ->
     {ok, pid()} | {error, term()}.
-accept_ws({Conn, StreamId}, Req, HandlerMod, Opts) ->
+accept_ws({Conn, StreamId, _Alpn}, Req, HandlerMod, Opts) ->
     {ValidateOpts, AcceptOpts0} = livery_ws:handshake_opts(Opts),
     Pseudo = connect_pseudo_headers(Req, <<"websocket">>),
     case ws_h2_upgrade:validate_request(Pseudo, ValidateOpts) of
@@ -275,7 +286,7 @@ Reconstructs the CONNECT pseudo-headers from the request value
 -spec accept_wt(h2, livery_req:req(), module(), term()) ->
     {ok, pid()} | {error, term()}.
 accept_wt(h2, Req, HandlerMod, Opts) ->
-    {Conn, StreamId} = livery_req:stream(Req),
+    {Conn, StreamId, _Alpn} = livery_req:stream(Req),
     Headers = connect_pseudo_headers(Req, <<"webtransport">>),
     webtransport:accept(Conn, StreamId, Headers, Opts#{
         transport => h2,
@@ -294,26 +305,50 @@ accept_wt(h2, Req, HandlerMod, Opts) ->
 ) -> map().
 build_h2_opts(Opts, Stack, Handler) ->
     Transport = maps:get(transport, Opts, tcp),
-    MaxBody = maps:get(max_body, Opts, ?DEFAULT_MAX_BODY),
-    Base = #{
-        transport => Transport,
-        handler => make_handler_fun(Stack, Handler, MaxBody, maps:get(config, Opts, undefined))
-    },
+    Base = conn_base(Opts, Stack, Handler, Transport, listener_alpn(Transport)),
     copy_keys(
-        [
-            ip,
-            inet6,
-            cert,
-            key,
-            cacerts,
-            ssl_opts,
-            acceptors,
-            settings,
-            enable_connect_protocol
-        ],
+        [ip, inet6, cert, key, cacerts, verify, ssl_opts, acceptors] ++ ?CONN_KEYS,
         Opts,
-        Base
+        Base#{transport => Transport}
     ).
+
+%% A dedicated TLS listener advertises `h2' and nothing else, so that is
+%% what ALPN settles on; cleartext h2c negotiates nothing. The multiplexed
+%% listener knows the real value and passes it to `serve_opts/2' instead.
+-spec listener_alpn(tcp | ssl) -> binary() | undefined.
+listener_alpn(ssl) -> <<"h2">>;
+listener_alpn(tcp) -> undefined.
+
+-doc """
+Build the `h2:serve_socket/2` option map for a socket the caller
+already accepted and handshaked.
+
+Used by `livery_h1h2` after ALPN settles on `h2`. `Opts` is the
+listener's `listen_opts()`; `Alpn` is the protocol actually
+negotiated. Listen-time keys (`cert`, `acceptors`, ...) are
+dropped: the socket is already up, so only the per-connection
+options apply.
+""".
+-spec serve_opts(listen_opts(), binary() | undefined) -> map().
+serve_opts(Opts, Alpn) ->
+    Stack = maps:get(stack, Opts),
+    Handler = maps:get(handler, Opts),
+    copy_keys(?CONN_KEYS, Opts, conn_base(Opts, Stack, Handler, ssl, Alpn)).
+
+-spec conn_base(
+    listen_opts(),
+    livery_middleware:stack(),
+    livery_middleware:handler(),
+    tcp | ssl,
+    binary() | undefined
+) -> map().
+conn_base(Opts, Stack, Handler, Transport, Alpn) ->
+    MaxBody = maps:get(max_body, Opts, ?DEFAULT_MAX_BODY),
+    #{
+        handler => make_handler_fun(
+            Stack, Handler, MaxBody, maps:get(config, Opts, undefined), Transport, Alpn
+        )
+    }.
 
 -spec copy_keys([atom()], map(), map()) -> map().
 copy_keys([], _Src, Dst) ->
@@ -328,7 +363,9 @@ copy_keys([K | Rest], Src, Dst) ->
     livery_middleware:stack(),
     livery_middleware:handler(),
     non_neg_integer() | infinity,
-    term()
+    term(),
+    tcp | ssl,
+    binary() | undefined
 ) ->
     fun(
         (
@@ -339,7 +376,7 @@ copy_keys([K | Rest], Src, Dst) ->
             h2:headers()
         ) -> ok
     ).
-make_handler_fun(Stack, Handler, MaxBody, Config) ->
+make_handler_fun(Stack, Handler, MaxBody, Config, Transport, Alpn) ->
     fun(Conn, StreamId, Method, Path, Headers) ->
         dispatch_request(
             Conn,
@@ -350,7 +387,9 @@ make_handler_fun(Stack, Handler, MaxBody, Config) ->
             Stack,
             Handler,
             MaxBody,
-            Config
+            Config,
+            Transport,
+            Alpn
         )
     end.
 
@@ -363,14 +402,19 @@ make_handler_fun(Stack, Handler, MaxBody, Config) ->
     livery_middleware:stack(),
     livery_middleware:handler(),
     non_neg_integer() | infinity,
-    term()
+    term(),
+    tcp | ssl,
+    binary() | undefined
 ) -> ok.
-dispatch_request(Conn, StreamId, Method, Path, Headers, Stack, Handler, MaxBody, Config) ->
+dispatch_request(
+    Conn, StreamId, Method, Path, Headers, Stack, Handler, MaxBody, Config, Transport, Alpn
+) ->
     BodyRef = make_ref(),
     DiscRef = make_ref(),
     Reader = livery_body:new(BodyRef),
     {RawPath, RawQuery} = split_query(Path),
-    Req = build_req(Conn, StreamId, Method, RawPath, Headers, Reader),
+    Stream = {Conn, StreamId, Alpn},
+    Req = build_req(Stream, Method, RawPath, Headers, Reader, Transport),
     %% The translator is the disconnect notifier. It is spawned before
     %% the worker (so the req can carry its pid) and given the worker
     %% pid afterwards via {worker, _}, breaking the dependency cycle.
@@ -386,7 +430,7 @@ dispatch_request(Conn, StreamId, Method, Path, Headers, Stack, Handler, MaxBody,
     case
         livery_req_sup:start_request(#{
             adapter => ?MODULE,
-            stream => {Conn, StreamId},
+            stream => Stream,
             req => Req1,
             stack => Stack,
             handler => Handler
@@ -410,7 +454,7 @@ dispatch_request(Conn, StreamId, Method, Path, Headers, Stack, Handler, MaxBody,
             end;
         {error, _} ->
             exit(Translator, kill),
-            reject_overload({Conn, StreamId})
+            reject_overload(Stream)
     end,
     ok.
 
@@ -435,14 +479,14 @@ reject_overload(Stream) ->
     ok.
 
 -spec build_req(
-    h2:connection(),
-    h2:stream_id(),
+    stream(),
     binary(),
     binary(),
     h2:headers(),
-    livery_body:reader()
+    livery_body:reader(),
+    tcp | ssl
 ) -> livery_req:req().
-build_req(Conn, StreamId, Method, Path, Headers, Reader) ->
+build_req({Conn, _StreamId, _Alpn} = Stream, Method, Path, Headers, Reader, Transport) ->
     Authority = proplists:get_value(<<":authority">>, Headers, <<>>),
     Scheme = proplists:get_value(<<":scheme">>, Headers, <<"http">>),
     livery_req:new(#{
@@ -454,10 +498,18 @@ build_req(Conn, StreamId, Method, Path, Headers, Reader) ->
         headers => app_headers(Authority, Headers),
         body => {stream, Reader},
         adapter => ?MODULE,
-        stream => {Conn, StreamId},
+        stream => Stream,
         engine_pid => Conn,
-        peer => h2_peer(Conn)
+        peer => h2_peer(Conn),
+        tls => tls_info(Transport)
     }).
+
+%% Mark TLS connections so handlers can tell a secure listener from an
+%% h2c one, as the H1 adapter already does. h2 does not surface
+%% certificate details, so this is an empty map rather than undefined.
+-spec tls_info(tcp | ssl) -> undefined | map().
+tls_info(ssl) -> #{};
+tls_info(_) -> undefined.
 
 %% h2 (>= 0.10.2) keeps `:authority' and `:scheme' in the handler header
 %% list. Drop them from the application-visible headers (they are exposed
@@ -559,7 +611,7 @@ translate_loop(Conn, StreamId, BodyRef, DiscRef, WorkerPid, WMRef, CMRef, Cbs, F
                     WorkerPid ! {livery_body, BodyRef, eof},
                     Loop(Cbs, Fired, Bytes1);
                 _ ->
-                    abort_body({Conn, StreamId}, WorkerPid, BodyRef),
+                    abort_body(Conn, StreamId, WorkerPid, BodyRef),
                     Loop(Cbs, Fired, aborted)
             end;
         {h2, Conn, {data, StreamId, Chunk, false}} ->
@@ -570,7 +622,7 @@ translate_loop(Conn, StreamId, BodyRef, DiscRef, WorkerPid, WMRef, CMRef, Cbs, F
                 aborted ->
                     Loop(Cbs, Fired, aborted);
                 over ->
-                    abort_body({Conn, StreamId}, WorkerPid, BodyRef),
+                    abort_body(Conn, StreamId, WorkerPid, BodyRef),
                     Loop(Cbs, Fired, aborted)
             end;
         {h2, Conn, {trailers, StreamId, Trailers}} ->
@@ -601,8 +653,8 @@ translate_loop(Conn, StreamId, BodyRef, DiscRef, WorkerPid, WMRef, CMRef, Cbs, F
 
 %% Signal the worker that the body exceeded `max_body' and reset the
 %% stream so the client stops sending.
--spec abort_body(stream(), pid(), reference()) -> ok.
-abort_body(Stream, WorkerPid, BodyRef) ->
+-spec abort_body(h2:connection(), h2:stream_id(), pid(), reference()) -> ok.
+abort_body(Conn, StreamId, WorkerPid, BodyRef) ->
     WorkerPid ! {livery_body, BodyRef, {error, body_too_large}},
-    _ = reset(Stream, body_too_large),
+    _ = h2:cancel(Conn, StreamId),
     ok.

--- a/src/livery_h3.erl
+++ b/src/livery_h3.erl
@@ -67,6 +67,8 @@ adapter callbacks, which call into `quic_h3:send_response/4`,
     ),
     settings => map(),
     quic_opts => map(),
+    %% Size of the `quic' connection worker pool, forwarded to `quic_h3'.
+    pool_size => pos_integer(),
     max_body => non_neg_integer() | infinity,
     %% Shared service config, readable in handlers via livery_req:config/1.
     config => term(),

--- a/src/livery_service.erl
+++ b/src/livery_service.erl
@@ -7,13 +7,18 @@ supervisor, sharing one router/middleware/handler. Optionally
 advertises Alt-Svc on H1 and H2 responses so clients race up to
 H3.
 
+The `https` listener is h2-only by default; `alpn => [h2, http1]`
+makes it serve HTTP/2 and HTTP/1.1 from the same port, chosen per
+connection.
+
 Configuration map:
 
 ```
 livery:start_service(#{
     host       => <<"example.com">>,
     http3      => #{port => 443, cert => Cert, key => Key},
-    https      => #{port => 443, cert => Cert, key => Key},
+    https      => #{port => 443, cert => Cert, key => Key,
+                    alpn => [h2, http1]},
     http       => #{port => 80},
     handler    => fun handler/1,
     middleware => Stack,
@@ -68,6 +73,12 @@ in-flight requests finish, use `livery:drain/1,2`.
     alt_svc => advertise | none
 }.
 
+%% Per-listener options. The keys below are the ones that mean something
+%% on more than one listener; anything else in the map is forwarded
+%% verbatim to the adapter that ends up serving the key, so
+%% `livery_h1:listen_opts()', `livery_h2:listen_opts()',
+%% `livery_h1h2:listen_opts()', and `livery_h3:listen_opts()' are the
+%% full lists (h1's parser size limits, h3's `quic_opts', and so on).
 -type listener_opts() :: #{
     %% HTTP/3 listener name (atom); auto-derived from the port if absent.
     name => atom(),
@@ -76,10 +87,29 @@ in-flight requests finish, use `livery:drain/1,2`.
     ip => inet:ip_address(),
     %% Bind the IPv6 wildcard (`::') when no explicit `ip' is given.
     inet6 => boolean(),
+    %% Override the default transport for the key: `http' defaults to
+    %% `tcp' and `https' to `ssl'. The useful one is h2c, which is
+    %% `https' with `transport => tcp' and no certificates.
+    transport => tcp | ssl,
     cert => binary() | string(),
     key => binary() | string() | term(),
     cacerts => [binary()],
+    %% Client-certificate policy on the H1/H2 listeners. `verify_peer'
+    %% requires `cacerts' and makes the certificate mandatory.
+    verify => verify_none | verify_peer,
+    ssl_opts => [ssl:tls_server_option()],
+    %% `https' only: the protocols to advertise over ALPN, most preferred
+    %% first. Defaults to `[h2]', an h2-only listener. `[h2, http1]' puts
+    %% HTTP/2 and HTTP/1.1 on the same TLS port, chosen per connection.
+    alpn => [livery_h1h2:protocol()],
     acceptors => pos_integer(),
+    handshake_timeout => timeout(),
+    %% Slow-client guards on the H1 listener; see `livery_h1:listen_opts()'.
+    idle_timeout => timeout(),
+    request_timeout => timeout(),
+    max_keepalive_requests => pos_integer() | infinity,
+    %% RFC 8441 extended CONNECT on the H2 listener.
+    enable_connect_protocol => boolean(),
     %% Request-body ceiling. A body past this yields a graceful 413;
     %% `infinity' disables it, default 16 MiB. Honored by all three adapters;
     %% the H1 adapter enforces it in place of h1's own parser cap, so a value
@@ -91,6 +121,7 @@ in-flight requests finish, use `livery:drain/1,2`.
             {ok, #{cert := binary(), key := term(), cert_chain => [binary()]}}
             | {error, term()}
     ),
+    %% H2/H3 SETTINGS overrides.
     settings => map(),
     quic_opts => map(),
     %% HTTP/1.1 early-response inbound-drain budget (lingering close).
@@ -102,10 +133,17 @@ in-flight requests finish, use `livery:drain/1,2`.
     config => term()
 }.
 
+%% One entry per listen socket, not per protocol: an ALPN listener serves
+%% both `h1' and `h2' from a single port, so `protocols' is a list.
+-record(listener, {
+    mod :: livery_h1 | livery_h2 | livery_h3 | livery_h1h2,
+    ref :: term(),
+    port :: inet:port_number(),
+    protocols :: [h1 | h2 | h3]
+}).
+
 -record(state, {
-    h1 :: {livery_h1:listener(), inet:port_number()} | undefined,
-    h2 :: {livery_h2:listener(), inet:port_number()} | undefined,
-    h3 :: {livery_h3:listener(), inet:port_number()} | undefined
+    listeners = [] :: [#listener{}]
 }).
 
 -define(SERVER, ?MODULE).
@@ -135,9 +173,12 @@ stop_accepting(Pid) when is_pid(Pid) ->
 
 -doc """
 Return the ports the service is bound to, by protocol. Keys are
-present only for protocols that were configured.
+present only for protocols that were configured, and each maps to
+every port serving that protocol: an ALPN listener puts one port
+under both `h1` and `h2`, and a cleartext `http` listener alongside
+it gives `h1` two.
 """.
--spec which_listeners(pid()) -> #{h1 | h2 | h3 => inet:port_number()}.
+-spec which_listeners(pid()) -> #{h1 | h2 | h3 => [inet:port_number()]}.
 which_listeners(Pid) ->
     gen_server:call(Pid, which_listeners).
 
@@ -154,9 +195,11 @@ init(Opts) ->
         %% building the Alt-Svc value used by H1 and H2.
         H3 = maybe_start_h3(Opts, base_stack(Opts), Handler),
         Stack = build_stack(Opts, H3),
-        H1 = maybe_start_h1(Opts, Stack, Handler),
-        H2 = maybe_start_h2(Opts, Stack, Handler),
-        {ok, #state{h1 = H1, h2 = H2, h3 = H3}}
+        Listeners =
+            H3 ++
+                maybe_start_http(Opts, Stack, Handler) ++
+                maybe_start_https(Opts, Stack, Handler),
+        {ok, #state{listeners = Listeners}}
     catch
         throw:Reason ->
             {stop, Reason};
@@ -167,14 +210,21 @@ init(Opts) ->
 -spec handle_call(term(), {pid(), term()}, #state{}) ->
     {reply, term(), #state{}}.
 handle_call(stop_accepting, _From, State) ->
-    %% H2/H3 listeners stop entirely; the H1 listener only stops
-    %% accepting, so established (in-flight and kept-alive) connections
-    %% keep being served through the drain window. The kept ref lets
-    %% terminate/2 close them once the drain ends.
-    _ = stop_h3(State#state.h3),
-    _ = stop_h2(State#state.h2),
-    _ = stop_accepting_h1(State#state.h1),
-    {reply, ok, State#state{h2 = undefined, h3 = undefined}};
+    %% Listeners that can keep serving what they already accepted do so,
+    %% and stay in the state so terminate/2 closes them once the drain
+    %% ends. The H2 and H3 libraries have no stop-accepting, so those
+    %% stop outright and drop out.
+    Kept = lists:foldr(
+        fun(L, Acc) ->
+            case drain_listener(L) of
+                keep -> [L | Acc];
+                drop -> Acc
+            end
+        end,
+        [],
+        State#state.listeners
+    ),
+    {reply, ok, State#state{listeners = Kept}};
 handle_call(which_listeners, _From, State) ->
     {reply, listeners_map(State), State};
 handle_call(_, _, State) ->
@@ -188,9 +238,7 @@ handle_info(_, State) -> {noreply, State}.
 
 -spec terminate(term(), #state{}) -> ok.
 terminate(_Reason, State) ->
-    _ = stop_h3(State#state.h3),
-    _ = stop_h2(State#state.h2),
-    _ = stop_h1(State#state.h1),
+    _ = [stop_listener(L) || L <- State#state.listeners],
     ok.
 
 -spec code_change(term(), #state{}, term()) -> {ok, #state{}}.
@@ -216,82 +264,111 @@ resolve_handler(Opts) ->
 base_stack(Opts) ->
     maps:get(middleware, Opts, []).
 
--spec build_stack(
-    service_opts(),
-    {atom(), inet:port_number()} | undefined
-) ->
+-spec build_stack(service_opts(), [#listener{}]) ->
     livery_middleware:stack().
 build_stack(Opts, H3) ->
     User = base_stack(Opts),
     case {maps:get(alt_svc, Opts, none), H3} of
-        {advertise, {_Name, Port}} ->
-            [{livery_alt_svc, #{value => alt_svc_header(Port)}} | User];
+        {advertise, [#listener{port = Port} | _]} ->
+            Value = alt_svc_header(maps:get(host, Opts, undefined), Port),
+            [{livery_alt_svc, #{value => Value}} | User];
         _ ->
             User
     end.
 
--spec alt_svc_header(inet:port_number()) -> binary().
-alt_svc_header(Port) ->
+%% RFC 7838 alt-authority is `[uri-host] ":" port', so the service `host'
+%% (when given) qualifies the advertised authority instead of leaving the
+%% client to reuse the origin's.
+-spec alt_svc_header(binary() | undefined, inet:port_number()) -> binary().
+alt_svc_header(Host, Port) ->
+    Authority =
+        case Host of
+            undefined -> <<>>;
+            _ -> Host
+        end,
     iolist_to_binary([
-        <<"h3=\":">>,
+        <<"h3=\"">>,
+        Authority,
+        <<":">>,
         integer_to_binary(Port),
         <<"\"; ma=86400">>
     ]).
 
-maybe_start_h1(Opts, Stack, Handler) ->
+maybe_start_http(Opts, Stack, Handler) ->
     case maps:find(http, Opts) of
         {ok, ListenOpts} ->
-            ListenOpts1 = maps:merge(
-                ListenOpts,
-                #{stack => Stack, handler => Handler, config => listener_config(Opts, ListenOpts)}
-            ),
-            {ok, Ref} = livery_h1:start(ListenOpts1),
-            {Ref, h1:server_port(Ref)};
+            {ok, Ref} = livery_h1:start(listener_opts(Opts, ListenOpts, Stack, Handler)),
+            [
+                #listener{
+                    mod = livery_h1,
+                    ref = Ref,
+                    port = h1:server_port(Ref),
+                    protocols = [h1]
+                }
+            ];
         error ->
-            undefined
+            []
     end.
 
-maybe_start_h2(Opts, Stack, Handler) ->
+%% `alpn' decides which library owns the TLS port. The default `[h2]' is
+%% the historical behaviour, an h2-only listener; anything naming more
+%% than one protocol goes to the multiplexing listener, which resolves
+%% ALPN itself and hands each connection to h1 or h2.
+maybe_start_https(Opts, Stack, Handler) ->
     case maps:find(https, Opts) of
         {ok, ListenOpts} ->
-            ListenOpts1 = maps:merge(
-                ListenOpts,
-                #{
-                    stack => Stack,
-                    handler => Handler,
-                    config => listener_config(Opts, ListenOpts),
-                    transport => maps:get(
-                        transport,
-                        ListenOpts,
-                        ssl
-                    )
-                }
-            ),
-            {ok, Ref} = livery_h2:start(ListenOpts1),
-            {Ref, h2:server_port(Ref)};
+            Merged = listener_opts(Opts, ListenOpts, Stack, Handler),
+            start_https(maps:get(alpn, ListenOpts, [h2]), Merged);
         error ->
-            undefined
+            []
     end.
+
+start_https([h2], Opts) ->
+    {ok, Ref} = livery_h2:start(with_transport(Opts)),
+    [#listener{mod = livery_h2, ref = Ref, port = h2:server_port(Ref), protocols = [h2]}];
+start_https([http1], Opts) ->
+    {ok, Ref} = livery_h1:start(with_transport(Opts)),
+    [#listener{mod = livery_h1, ref = Ref, port = h1:server_port(Ref), protocols = [h1]}];
+start_https(Alpn, Opts) ->
+    {ok, Ref} = livery_h1h2:start(Opts#{alpn => Alpn}),
+    [
+        #listener{
+            mod = livery_h1h2,
+            ref = Ref,
+            port = livery_h1h2:server_port(Ref),
+            protocols = protocols(Alpn)
+        }
+    ].
+
+protocols(Alpn) ->
+    lists:usort([protocol(P) || P <- Alpn]).
+
+protocol(h2) -> h2;
+protocol(http1) -> h1.
+
+with_transport(Opts) ->
+    Opts#{transport => maps:get(transport, Opts, ssl)}.
 
 maybe_start_h3(Opts, Stack, Handler) ->
     case maps:find(http3, Opts) of
         {ok, ListenOpts} ->
-            ListenOpts1 = ensure_h3_name(
-                maps:merge(
-                    ListenOpts,
-                    #{
-                        stack => Stack,
-                        handler => Handler,
-                        config => listener_config(Opts, ListenOpts)
-                    }
-                )
-            ),
-            {ok, Name} = livery_h3:start(ListenOpts1),
+            Merged = ensure_h3_name(listener_opts(Opts, ListenOpts, Stack, Handler)),
+            {ok, Name} = livery_h3:start(Merged),
             {ok, Port} = quic:get_server_port(Name),
-            {Name, Port};
+            [#listener{mod = livery_h3, ref = Name, port = Port, protocols = [h3]}];
         error ->
-            undefined
+            []
     end.
+
+listener_opts(Opts, ListenOpts, Stack, Handler) ->
+    maps:merge(
+        ListenOpts,
+        #{
+            stack => Stack,
+            handler => Handler,
+            config => listener_config(Opts, ListenOpts)
+        }
+    ).
 
 %% A per-listener `config' overrides the service-wide one.
 -spec listener_config(service_opts(), listener_opts()) -> term().
@@ -310,31 +387,34 @@ ensure_h3_name(#{port := Port} = Opts) when is_integer(Port), Port > 0 ->
 ensure_h3_name(Opts) ->
     Opts.
 
-stop_h1(undefined) -> ok;
-stop_h1({Ref, _Port}) -> livery_h1:stop(Ref).
+stop_listener(#listener{mod = livery_h1, ref = Ref}) -> livery_h1:stop(Ref);
+stop_listener(#listener{mod = livery_h2, ref = Ref}) -> livery_h2:stop(Ref);
+stop_listener(#listener{mod = livery_h3, ref = Ref}) -> livery_h3:stop(Ref);
+stop_listener(#listener{mod = livery_h1h2, ref = Ref}) -> livery_h1h2:stop(Ref).
 
-stop_accepting_h1(undefined) -> ok;
-stop_accepting_h1({Ref, _Port}) -> livery_h1:stop_accepting(Ref).
+%% `keep' means the listener stopped accepting but is still serving what
+%% it accepted, so it stays in the state for terminate/2 to close.
+drain_listener(#listener{mod = livery_h1, ref = Ref}) ->
+    livery_h1:stop_accepting(Ref),
+    keep;
+drain_listener(#listener{mod = livery_h1h2, ref = Ref}) ->
+    livery_h1h2:stop_accepting(Ref),
+    keep;
+drain_listener(#listener{mod = livery_h2, ref = Ref}) ->
+    livery_h2:stop(Ref),
+    drop;
+drain_listener(#listener{mod = livery_h3, ref = Ref}) ->
+    livery_h3:stop(Ref),
+    drop.
 
-stop_h2(undefined) -> ok;
-stop_h2({Ref, _Port}) -> livery_h2:stop(Ref).
+listeners_map(#state{listeners = Listeners}) ->
+    lists:foldl(fun add_ports/2, #{}, Listeners).
 
-stop_h3(undefined) -> ok;
-stop_h3({Name, _Port}) -> livery_h3:stop(Name).
-
-listeners_map(State) ->
-    Acc0 = #{},
-    Acc1 =
-        case State#state.h1 of
-            undefined -> Acc0;
-            {_, P1} -> Acc0#{h1 => P1}
+add_ports(#listener{port = Port, protocols = Protocols}, Acc) ->
+    lists:foldl(
+        fun(Protocol, A) ->
+            A#{Protocol => maps:get(Protocol, A, []) ++ [Port]}
         end,
-    Acc2 =
-        case State#state.h2 of
-            undefined -> Acc1;
-            {_, P2} -> Acc1#{h2 => P2}
-        end,
-    case State#state.h3 of
-        undefined -> Acc2;
-        {_, P3} -> Acc2#{h3 => P3}
-    end.
+        Acc,
+        Protocols
+    ).

--- a/test/livery_alpn_SUITE.erl
+++ b/test/livery_alpn_SUITE.erl
@@ -1,0 +1,298 @@
+%% @doc One TLS port serving HTTP/2 and HTTP/1.1, chosen by ALPN.
+%%
+%% Brings up a service whose `https' listener advertises
+%% `[h2, http1]', then dials it three ways: offering both protocols
+%% (h2 must win), offering only `http/1.1', and offering no ALPN at
+%% all. Each connection must reach the same handler over the
+%% protocol ALPN settled on, and `which_listeners/1' must report the
+%% one port under both `h1' and `h2'.
+-module(livery_alpn_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([
+    all/0,
+    init_per_suite/1,
+    end_per_suite/1,
+    init_per_testcase/2,
+    end_per_testcase/2
+]).
+
+-export([
+    both_offered_negotiates_h2/1,
+    http1_only_client_is_served_by_h1/1,
+    client_without_alpn_is_served_by_h1/1,
+    which_listeners_reports_h1_and_h2_on_one_port/1,
+    h2_only_default_leaves_http1_unserved/1,
+    cleartext_http_keeps_its_own_h1_port/1,
+    stop_accepting_refuses_new_connections/1
+]).
+
+-define(H2, <<"h2">>).
+-define(HTTP1, <<"http/1.1">>).
+
+%%====================================================================
+%% Suite plumbing
+%%====================================================================
+
+all() ->
+    [
+        both_offered_negotiates_h2,
+        http1_only_client_is_served_by_h1,
+        client_without_alpn_is_served_by_h1,
+        which_listeners_reports_h1_and_h2_on_one_port,
+        h2_only_default_leaves_http1_unserved,
+        cleartext_http_keeps_its_own_h1_port,
+        stop_accepting_refuses_new_connections
+    ].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(livery),
+    {ok, _} = application:ensure_all_started(h1),
+    {ok, _} = application:ensure_all_started(h2),
+    {CertFile, KeyFile} = livery_test_certs:paths(),
+    [{cert_file, CertFile}, {key_file, KeyFile} | Config].
+
+end_per_suite(_Config) ->
+    _ = application:stop(h2),
+    _ = application:stop(h1),
+    _ = application:stop(livery),
+    ok.
+
+init_per_testcase(_Case, Config) ->
+    Config.
+
+end_per_testcase(_Case, _Config) ->
+    ok.
+
+%%====================================================================
+%% Cases
+%%====================================================================
+
+%% The server lists h2 first, so a client offering both gets h2 and the
+%% request runs through the H2 adapter.
+both_offered_negotiates_h2(Config) ->
+    with_service(Config, [h2, http1], fun(_Pid, Ports) ->
+        Port = alpn_port(Ports),
+        ?assertEqual({ok, ?H2}, negotiated(Port, [?H2, ?HTTP1])),
+        ?assertEqual(<<"h2 h2">>, body_via_h2(Port))
+    end).
+
+http1_only_client_is_served_by_h1(Config) ->
+    with_service(Config, [h2, http1], fun(_Pid, Ports) ->
+        Port = alpn_port(Ports),
+        ?assertEqual({ok, ?HTTP1}, negotiated(Port, [?HTTP1])),
+        ?assertEqual({200, <<"h1 http/1.1">>}, body_via_h1(Port, [?HTTP1]))
+    end).
+
+%% RFC 9113 requires ALPN to reach h2 over TLS, so a client that offers
+%% none is HTTP/1.1 and must be served, not dropped.
+client_without_alpn_is_served_by_h1(Config) ->
+    with_service(Config, [h2, http1], fun(_Pid, Ports) ->
+        Port = alpn_port(Ports),
+        ?assertEqual({error, protocol_not_negotiated}, negotiated(Port, undefined)),
+        %% Nothing was negotiated, so the request reports no ALPN.
+        ?assertEqual({200, <<"h1 none">>}, body_via_h1(Port, undefined))
+    end).
+
+which_listeners_reports_h1_and_h2_on_one_port(Config) ->
+    with_service(Config, [h2, http1], fun(_Pid, Ports) ->
+        Port = alpn_port(Ports),
+        ?assertEqual(#{h1 => [Port], h2 => [Port]}, Ports)
+    end).
+
+%% The default is unchanged: `https' without `alpn' is an h2-only
+%% listener, and an http/1.1-only client cannot complete a handshake.
+h2_only_default_leaves_http1_unserved(Config) ->
+    with_service(Config, default, fun(_Pid, Ports) ->
+        Port = hd(maps:get(h2, Ports)),
+        ?assertEqual([h2], maps:keys(Ports)),
+        ?assertEqual({ok, ?H2}, negotiated(Port, [?H2])),
+        ?assertMatch({error, _}, negotiated(Port, [?HTTP1]))
+    end).
+
+%% An ALPN listener alongside a cleartext `http' listener puts HTTP/1.1
+%% on two ports, and both are reported.
+cleartext_http_keeps_its_own_h1_port(Config) ->
+    {ok, Pid} = livery:start_service(#{
+        http => #{port => 0},
+        https => https_opts(Config, [h2, http1]),
+        handler => fun handler/1
+    }),
+    try
+        #{h1 := H1Ports, h2 := [TlsPort]} = livery:which_listeners(Pid),
+        ?assertEqual(2, length(H1Ports)),
+        ?assert(lists:member(TlsPort, H1Ports)),
+        [Cleartext] = H1Ports -- [TlsPort],
+        ?assertEqual({200, <<"h1 none">>}, body_via_tcp(Cleartext))
+    after
+        livery:stop_service(Pid)
+    end.
+
+%% Draining closes the listen socket while the service stays up, so a
+%% fresh dial is refused on both protocols.
+stop_accepting_refuses_new_connections(Config) ->
+    with_service(Config, [h2, http1], fun(Pid, Ports) ->
+        Port = alpn_port(Ports),
+        ?assertEqual({ok, ?H2}, negotiated(Port, [?H2, ?HTTP1])),
+        ok = livery_service:stop_accepting(Pid),
+        ?assertMatch({error, _}, negotiated(Port, [?H2, ?HTTP1])),
+        ?assertMatch({error, _}, negotiated(Port, [?HTTP1]))
+    end).
+
+%%====================================================================
+%% Fixtures
+%%====================================================================
+
+%% The handler echoes the protocol the adapter reports and the ALPN the
+%% connection actually negotiated, so a case can tell which library
+%% served it without inspecting the wire.
+handler(Req) ->
+    Adapter = livery_req:adapter(Req),
+    #{alpn := Alpn} = Adapter:peer_info(livery_req:stream(Req)),
+    Body = iolist_to_binary([
+        atom_to_binary(livery_req:protocol(Req)),
+        <<" ">>,
+        case Alpn of
+            undefined -> <<"none">>;
+            _ -> Alpn
+        end
+    ]),
+    livery_resp:text(200, Body).
+
+https_opts(Config, default) ->
+    #{
+        port => 0,
+        cert => ?config(cert_file, Config),
+        key => ?config(key_file, Config)
+    };
+https_opts(Config, Alpn) ->
+    (https_opts(Config, default))#{alpn => Alpn}.
+
+%% The callback gets the service pid and its listener map; the service
+%% is stopped afterwards either way.
+with_service(Config, Alpn, Fun) ->
+    {ok, Pid} = livery:start_service(#{
+        https => https_opts(Config, Alpn),
+        handler => fun handler/1
+    }),
+    try
+        Fun(Pid, livery:which_listeners(Pid))
+    after
+        livery:stop_service(Pid)
+    end.
+
+alpn_port(#{h1 := [Port], h2 := [Port]}) -> Port.
+
+%%====================================================================
+%% Clients
+%%====================================================================
+
+%% Dial and report only what ALPN settled on. `undefined' advertises
+%% nothing, which is how a pre-ALPN client looks on the wire.
+negotiated(Port, Advertised) ->
+    case ssl:connect("127.0.0.1", Port, client_opts(Advertised), 5000) of
+        {ok, Socket} ->
+            Result = ssl:negotiated_protocol(Socket),
+            _ = ssl:close(Socket),
+            Result;
+        {error, _} = Error ->
+            Error
+    end.
+
+client_opts(undefined) ->
+    [
+        binary,
+        {active, false},
+        {verify, verify_none},
+        {server_name_indication, "localhost"}
+    ];
+client_opts(Advertised) ->
+    [{alpn_advertised_protocols, Advertised} | client_opts(undefined)].
+
+%% Speak HTTP/1.1 by hand rather than through a client library, so the
+%% test controls exactly what ALPN the ClientHello carries.
+body_via_h1(Port, Advertised) ->
+    {ok, Socket} = ssl:connect("127.0.0.1", Port, client_opts(Advertised), 5000),
+    try
+        ok = ssl:send(Socket, <<
+            "GET / HTTP/1.1\r\n"
+            "Host: localhost\r\n"
+            "Connection: close\r\n\r\n"
+        >>),
+        parse_http1(recv_all(Socket, <<>>))
+    after
+        _ = ssl:close(Socket)
+    end.
+
+body_via_tcp(Port) ->
+    {ok, Socket} = gen_tcp:connect("127.0.0.1", Port, [binary, {active, false}], 5000),
+    try
+        ok = gen_tcp:send(Socket, <<
+            "GET / HTTP/1.1\r\n"
+            "Host: localhost\r\n"
+            "Connection: close\r\n\r\n"
+        >>),
+        parse_http1(recv_all_tcp(Socket, <<>>))
+    after
+        _ = gen_tcp:close(Socket)
+    end.
+
+recv_all(Socket, Acc) ->
+    case ssl:recv(Socket, 0, 5000) of
+        {ok, Data} -> recv_all(Socket, <<Acc/binary, Data/binary>>);
+        {error, closed} -> Acc;
+        {error, Reason} -> error({recv_failed, Reason})
+    end.
+
+recv_all_tcp(Socket, Acc) ->
+    case gen_tcp:recv(Socket, 0, 5000) of
+        {ok, Data} -> recv_all_tcp(Socket, <<Acc/binary, Data/binary>>);
+        {error, closed} -> Acc;
+        {error, Reason} -> error({recv_failed, Reason})
+    end.
+
+%% `Connection: close' means the body runs to EOF, so everything after
+%% the header block is the body.
+parse_http1(Response) ->
+    [Head, Body] = binary:split(Response, <<"\r\n\r\n">>),
+    [StatusLine | _] = binary:split(Head, <<"\r\n">>),
+    [_Version, Status | _] = binary:split(StatusLine, <<" ">>, [global]),
+    {binary_to_integer(Status), Body}.
+
+body_via_h2(Port) ->
+    {ok, Conn} = h2:connect(
+        "127.0.0.1",
+        Port,
+        #{
+            transport => ssl,
+            ssl_opts => [
+                {verify, verify_none},
+                {server_name_indication, "localhost"}
+            ]
+        }
+    ),
+    try
+        {ok, StreamId} = h2:request(
+            Conn,
+            <<"GET">>,
+            <<"/">>,
+            [{<<"host">>, <<"localhost">>}]
+        ),
+        collect_h2(Conn, StreamId, [])
+    after
+        h2:close(Conn)
+    end.
+
+collect_h2(Conn, StreamId, Acc) ->
+    receive
+        {h2, Conn, {data, StreamId, Chunk, true}} ->
+            iolist_to_binary(lists:reverse([Chunk | Acc]));
+        {h2, Conn, {data, StreamId, Chunk, false}} ->
+            collect_h2(Conn, StreamId, [Chunk | Acc]);
+        {h2, Conn, _Other} ->
+            collect_h2(Conn, StreamId, Acc)
+    after 5000 ->
+        error(h2_timeout)
+    end.

--- a/test/livery_client_SUITE.erl
+++ b/test/livery_client_SUITE.erl
@@ -79,7 +79,7 @@ init_per_suite(Config) ->
     %% start_service links to us; unlink so the service survives the
     %% init_per_suite process and lives for the whole suite.
     true = unlink(Pid),
-    Port = maps:get(h1, livery:which_listeners(Pid)),
+    Port = hd(maps:get(h1, livery:which_listeners(Pid))),
     Base = iolist_to_binary([<<"http://127.0.0.1:">>, integer_to_binary(Port)]),
     [{service, Pid}, {counter, Counter}, {base, Base} | Config].
 

--- a/test/livery_client_balance_SUITE.erl
+++ b/test/livery_client_balance_SUITE.erl
@@ -61,7 +61,7 @@ start_replica(Id) ->
         router => Router
     }),
     true = unlink(Pid),
-    Port = maps:get(h1, livery:which_listeners(Pid)),
+    Port = hd(maps:get(h1, livery:which_listeners(Pid))),
     Base = iolist_to_binary([<<"http://127.0.0.1:">>, integer_to_binary(Port)]),
     #{pid => Pid, base => Base, counter => Counter}.
 

--- a/test/livery_client_cookie_SUITE.erl
+++ b/test/livery_client_cookie_SUITE.erl
@@ -40,7 +40,7 @@ init_per_suite(Config) ->
     ]),
     {ok, Pid} = livery:start_service(#{http => #{port => 0}, router => Router}),
     true = unlink(Pid),
-    Port = maps:get(h1, livery:which_listeners(Pid)),
+    Port = hd(maps:get(h1, livery:which_listeners(Pid))),
     Base = iolist_to_binary([<<"http://127.0.0.1:">>, integer_to_binary(Port)]),
     [{service, Pid}, {port, Port}, {base, Base} | Config].
 

--- a/test/livery_e2e_SUITE.erl
+++ b/test/livery_e2e_SUITE.erl
@@ -345,7 +345,7 @@ recv_ws_frame(Proto, Conn, StreamId, Parser) ->
 proto_msgs(h2) -> {h2, ignore};
 proto_msgs(h3) -> {quic_h3, stream_end}.
 
-port(Config, Proto) -> maps:get(Proto, ?config(listeners, Config)).
+port(Config, Proto) -> hd(maps:get(Proto, ?config(listeners, Config))).
 
 body_headers(<<>>) -> [];
 body_headers(_Body) -> [{<<"content-type">>, <<"application/json">>}].

--- a/test/livery_example_api_tests.erl
+++ b/test/livery_example_api_tests.erl
@@ -21,7 +21,7 @@ setup() ->
     {ok, _} = application:ensure_all_started(livery),
     {ok, _} = application:ensure_all_started(hackney),
     {ok, Pid} = livery_example_api:start(0),
-    #{h1 := Port} = livery:which_listeners(Pid),
+    #{h1 := [Port]} = livery:which_listeners(Pid),
     put(service_pid, Pid),
     Port.
 

--- a/test/livery_example_ws_tests.erl
+++ b/test/livery_example_ws_tests.erl
@@ -14,7 +14,7 @@ ws_echo_test_() ->
 setup() ->
     {ok, _} = application:ensure_all_started(livery),
     {ok, Pid} = livery_example_ws:start(0),
-    #{h1 := Port} = livery:which_listeners(Pid),
+    #{h1 := [Port]} = livery:which_listeners(Pid),
     put(service_pid, Pid),
     Port.
 

--- a/test/livery_h1_SUITE.erl
+++ b/test/livery_h1_SUITE.erl
@@ -222,7 +222,7 @@ send_to_gone_client_is_closed(_Config) ->
         {'DOWN', Ref, process, Dead, _} -> ok
     after 5000 -> ct:fail(proc_not_dead)
     end,
-    Stream = {Dead, 1},
+    Stream = {Dead, 1, <<"http/1.1">>},
     ?assertEqual({error, closed}, livery_h1:send_full(Stream, 200, [], <<"body">>, #{})),
     ?assertEqual(
         {error, closed}, livery_h1:send_data(Stream, <<"body">>, #{end_stream => true})

--- a/test/livery_h2_SUITE.erl
+++ b/test/livery_h2_SUITE.erl
@@ -256,7 +256,7 @@ send_to_gone_client_is_closed(_Config) ->
         {'DOWN', Ref, process, Dead, _} -> ok
     after 5000 -> ct:fail(proc_not_dead)
     end,
-    Stream = {Dead, 1},
+    Stream = {Dead, 1, <<"h2">>},
     ?assertEqual({error, closed}, livery_h2:send_full(Stream, 200, [], <<"body">>, #{})),
     ?assertEqual(
         {error, closed}, livery_h2:send_data(Stream, <<"body">>, #{end_stream => true})

--- a/test/livery_service_SUITE.erl
+++ b/test/livery_service_SUITE.erl
@@ -90,9 +90,9 @@ one_call_serves_all_three(Config) ->
     try
         Ports = livery:which_listeners(Pid),
         ?assertMatch(#{h1 := _, h2 := _, h3 := _}, Ports),
-        ?assertEqual(<<"hello">>, body_via_h1(maps:get(h1, Ports))),
-        ?assertEqual(<<"hello">>, body_via_h2(maps:get(h2, Ports))),
-        ?assertEqual(<<"hello">>, body_via_h3(maps:get(h3, Ports), Config))
+        ?assertEqual(<<"hello">>, body_via_h1(hd(maps:get(h1, Ports)))),
+        ?assertEqual(<<"hello">>, body_via_h2(hd(maps:get(h2, Ports)))),
+        ?assertEqual(<<"hello">>, body_via_h3(hd(maps:get(h3, Ports)), Config))
     after
         livery:stop_service(Pid)
     end.
@@ -101,17 +101,19 @@ alt_svc_advertised_on_h1_and_h2_only(Config) ->
     {ok, Pid} = start_full_service(Config),
     try
         Ports = livery:which_listeners(Pid),
-        H3Port = maps:get(h3, Ports),
+        H3Port = hd(maps:get(h3, Ports)),
+        %% The service sets `host', so the advertised authority is
+        %% qualified rather than port-only.
         Expected = iolist_to_binary([
-            <<"h3=\":">>,
+            <<"h3=\"localhost:">>,
             integer_to_binary(H3Port),
             <<"\"; ma=86400">>
         ]),
-        ?assertEqual(Expected, h1_header(maps:get(h1, Ports), <<"alt-svc">>)),
-        ?assertEqual(Expected, h2_header(maps:get(h2, Ports), <<"alt-svc">>)),
+        ?assertEqual(Expected, h1_header(hd(maps:get(h1, Ports)), <<"alt-svc">>)),
+        ?assertEqual(Expected, h2_header(hd(maps:get(h2, Ports)), <<"alt-svc">>)),
         ?assertEqual(
             undefined,
-            h3_header(maps:get(h3, Ports), Config, <<"alt-svc">>)
+            h3_header(H3Port, Config, <<"alt-svc">>)
         )
     after
         livery:stop_service(Pid)
@@ -124,7 +126,7 @@ which_listeners_reports_all_three(Config) ->
         ?assertEqual(3, map_size(Ports)),
         lists:foreach(
             fun(K) ->
-                ?assert(is_integer(maps:get(K, Ports)))
+                ?assertMatch([P] when is_integer(P), maps:get(K, Ports))
             end,
             [h1, h2, h3]
         )
@@ -142,7 +144,7 @@ router_service_dispatches_routes(_Config) ->
     ]),
     {ok, Pid} = livery:start_service(#{http => #{port => 0}, router => Router}),
     try
-        Port = maps:get(h1, livery:which_listeners(Pid)),
+        Port = hd(maps:get(h1, livery:which_listeners(Pid))),
         ?assertEqual({200, <<"root">>}, http_get(Port, <<"/">>)),
         ?assertEqual({200, <<"ada">>}, http_get(Port, <<"/hi/ada">>)),
         %% unknown path -> 404
@@ -166,7 +168,7 @@ config_is_readable_in_handler(_Config) ->
     try
         ?assertEqual(
             {200, <<"service_db">>},
-            http_get(maps:get(h1, livery:which_listeners(P1)), <<"/">>)
+            http_get(hd(maps:get(h1, livery:which_listeners(P1))), <<"/">>)
         )
     after
         livery:stop_service(P1)
@@ -180,7 +182,7 @@ config_is_readable_in_handler(_Config) ->
     try
         ?assertEqual(
             {200, <<"listener_db">>},
-            http_get(maps:get(h1, livery:which_listeners(P2)), <<"/">>)
+            http_get(hd(maps:get(h1, livery:which_listeners(P2))), <<"/">>)
         )
     after
         livery:stop_service(P2)
@@ -206,7 +208,7 @@ https_listener_forwards_ssl_opts(Config) ->
     try
         ?assertEqual(
             <<"ok">>,
-            body_via_h2(maps:get(h2, livery:which_listeners(Pid)))
+            body_via_h2(hd(maps:get(h2, livery:which_listeners(Pid))))
         ),
         receive
             {sni_seen, "localhost"} -> ok
@@ -237,7 +239,7 @@ http3_listener_forwards_sni_callback(Config) ->
     try
         ?assertEqual(
             <<"ok">>,
-            body_via_h3(maps:get(h3, livery:which_listeners(Pid)), Config)
+            body_via_h3(hd(maps:get(h3, livery:which_listeners(Pid))), Config)
         ),
         receive
             {sni_seen, <<"localhost">>} -> ok
@@ -258,7 +260,7 @@ stop_accepting_refuses_new_connections(_Config) ->
         http => #{port => 0},
         handler => fun(_R) -> livery_resp:text(200, <<"ok">>) end
     }),
-    Port = maps:get(h1, livery:which_listeners(Pid)),
+    Port = hd(maps:get(h1, livery:which_listeners(Pid))),
     ?assertMatch({ok, 200, _, <<"ok">>}, http_try(Port, <<"/">>)),
     ok = livery_service:stop_accepting(Pid),
     ?assertMatch({error, _}, http_try(Port, <<"/">>)),
@@ -275,7 +277,7 @@ max_body_raises_h1_parser_cap(_Config) ->
         handler => count_body_handler()
     }),
     try
-        Port = maps:get(h1, livery:which_listeners(Pid)),
+        Port = hd(maps:get(h1, livery:which_listeners(Pid))),
         Body = binary:copy(<<"x">>, Size),
         ?assertEqual({200, integer_to_binary(Size)}, http_put(Port, <<"/">>, Body))
     after
@@ -290,7 +292,7 @@ default_max_body_authoritative(_Config) ->
         http => #{port => 0}, handler => count_body_handler()
     }),
     try
-        Port = maps:get(h1, livery:which_listeners(Pid)),
+        Port = hd(maps:get(h1, livery:which_listeners(Pid))),
         Under = 12 * 1024 * 1024,
         ?assertEqual(
             {200, integer_to_binary(Under)},
@@ -313,7 +315,7 @@ drain_lets_inflight_finish(_Config) ->
         livery_resp:text(200, <<"done">>)
     end,
     {ok, Pid} = livery:start_service(#{http => #{port => 0}, handler => Handler}),
-    Port = maps:get(h1, livery:which_listeners(Pid)),
+    Port = hd(maps:get(h1, livery:which_listeners(Pid))),
     spawn(fun() -> Self ! {client_done, http_get(Port, <<"/">>)} end),
     WPid =
         receive
@@ -349,7 +351,7 @@ stop_service_closes_keepalive_connections(_Config) ->
         http => #{port => 0},
         handler => fun(_R) -> livery_resp:text(200, <<"ok">>) end
     }),
-    Port = maps:get(h1, livery:which_listeners(Pid)),
+    Port = hd(maps:get(h1, livery:which_listeners(Pid))),
     {ok, Sock} = gen_tcp:connect(
         "127.0.0.1", Port, [binary, {active, false}, {packet, raw}]
     ),
@@ -371,7 +373,7 @@ drain_closes_idle_keepalive_at_end(_Config) ->
         http => #{port => 0},
         handler => fun(_R) -> livery_resp:text(200, <<"ok">>) end
     }),
-    Port = maps:get(h1, livery:which_listeners(Pid)),
+    Port = hd(maps:get(h1, livery:which_listeners(Pid))),
     {ok, Sock} = gen_tcp:connect(
         "127.0.0.1", Port, [binary, {active, false}, {packet, raw}]
     ),
@@ -407,7 +409,7 @@ drain_times_out_on_stuck_request(_Config) ->
         end
     end,
     {ok, Pid} = livery:start_service(#{http => #{port => 0}, handler => Handler}),
-    Port = maps:get(h1, livery:which_listeners(Pid)),
+    Port = hd(maps:get(h1, livery:which_listeners(Pid))),
     spawn(fun() -> catch http_get(Port, <<"/">>) end),
     WPid =
         receive


### PR DESCRIPTION
Adds `https => #{..., alpn => [h2, http1]}`, one TLS port serving both protocols, picked per connection. Livery owns the listen socket (`livery_h1h2`), handshakes off the accept path so a stalled client costs a process rather than an acceptor slot, reads the negotiated protocol, and hands the socket to `h2:serve_socket/2` or `h1:serve_socket/2`. A client that offered no ALPN goes to HTTP/1.1 rather than being dropped. The list is server preference order, so `[h2, http1]` means h2 wins when a client offers both. It defaults to `[h2]`, which is the current h2-only behaviour, so existing users see no change.

Two breaking changes come with it. `which_listeners/1` now maps each protocol to a list of ports, because one port can serve two protocols and one protocol can sit on two ports; `maps:get(h1, L)` becomes `hd(maps:get(h1, L))`. And the H1/H2 stream handle is `{Conn, StreamId, Alpn}`, so `peer_info/1` can report what ALPN actually settled on instead of a constant, `undefined` on a cleartext listener or for a TLS client that offered none. H2 requests also carry `tls => #{}` on a TLS listener, as H1 requests already did.

Separately, the H1 listener now forwards h1's parser size limits (`max_line_length`, `max_request_line_size`, `max_empty_lines`, the header caps, `pipeline`), which h1 accepted all along but livery never passed on, and `verify` for mutual TLS now that h1 0.9.0 honours it. The service `host` is finally read: with it set, `alt_svc => advertise` emits an authority-qualified `Alt-Svc`. `livery_service:listener_opts()` declares the options that worked but went undeclared, and says the rest of the map is forwarded to the adapter's own `listen_opts()`.

Deps: h1 0.9.0 and h2 0.12.0 for `serve_socket/2`, webtransport 0.4.5 so it agrees with us on h2, hackney 4.7.4 for the pool fixes under `livery_client`.

Ships as 0.8.0.